### PR TITLE
Feature: Source Delete Job Cleanup

### DIFF
--- a/app/domain/job_visibility.py
+++ b/app/domain/job_visibility.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from sqlalchemy import Select, exists, or_, select
+from sqlalchemy.orm import aliased
+
+from app.persistence.models import JobPosting, JobSourceLink, Source
+
+
+def retained_deleted_source_job_predicate():
+    return (JobPosting.latest_bucket == "matched") & (JobPosting.current_state == "active")
+
+
+def associated_deleted_source_exists_predicate():
+    primary_source = aliased(Source)
+    linked_source = aliased(Source)
+    primary_deleted = exists(
+        select(primary_source.id).where(
+            primary_source.id == JobPosting.primary_source_id,
+            primary_source.deleted_at.is_not(None),
+        )
+    )
+    linked_deleted = exists(
+        select(JobSourceLink.id)
+        .join(linked_source, linked_source.id == JobSourceLink.source_id)
+        .where(
+            JobSourceLink.job_posting_id == JobPosting.id,
+            linked_source.deleted_at.is_not(None),
+        )
+    )
+    return primary_deleted | linked_deleted
+
+
+def visible_job_predicate():
+    """Normal user-facing visibility for jobs during source-delete cleanup.
+
+    Jobs are visible when they have no association with a deleted source, or when
+    they are the one retained class from a deleted source: matched and active.
+    """
+
+    return or_(~associated_deleted_source_exists_predicate(), retained_deleted_source_job_predicate())
+
+
+def apply_visible_jobs(query: Select) -> Select:
+    return query.where(visible_job_predicate())

--- a/app/domain/notifications.py
+++ b/app/domain/notifications.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.config.settings import get_settings
 from app.domain.common import utcnow
+from app.domain.job_visibility import apply_visible_jobs, visible_job_predicate
 from app.persistence.models import Digest, DigestItem, JobDecision, JobPosting, JobTrackingEvent, Reminder
 
 
@@ -36,11 +37,14 @@ class NotificationService:
         window_start = prior.generated_at if prior else now - timedelta(days=1)
         decisions = list(
             self.session.scalars(
-                select(JobDecision).where(
+                select(JobDecision)
+                .join(JobPosting, JobPosting.id == JobDecision.job_posting_id)
+                .where(
                     JobDecision.is_current.is_(True),
                     JobDecision.bucket.in_(["matched", "review"]),
                     JobDecision.created_at >= window_start,
                     JobDecision.created_at <= now,
+                    visible_job_predicate(),
                 )
             )
         )
@@ -64,7 +68,7 @@ class NotificationService:
         now = utcnow()
         jobs = list(
             self.session.scalars(
-                select(JobPosting).where(JobPosting.tracking_status.in_(["saved", "applied"]))
+                apply_visible_jobs(select(JobPosting)).where(JobPosting.tracking_status.in_(["saved", "applied"]))
             )
         )
         reminders: list[Reminder] = []

--- a/app/domain/source_cleanup.py
+++ b/app/domain/source_cleanup.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import delete, distinct, or_, select
+from sqlalchemy.orm import Session
+
+from app.persistence.models import (
+    DigestItem,
+    JobDecision,
+    JobDecisionRule,
+    JobPosting,
+    JobSourceLink,
+    JobTrackingEvent,
+    Reminder,
+    Source,
+    SourceRun,
+    utcnow,
+)
+
+logger = logging.getLogger(__name__)
+
+SOURCE_DELETE_CLEANUP_TRIGGER = "source_delete_cleanup"
+
+
+@dataclass(frozen=True)
+class SourceDeleteCleanupResult:
+    source_id: int
+    status: str
+    associated_count: int = 0
+    retained_count: int = 0
+    deleted_count: int = 0
+    run_id: int | None = None
+
+
+class SourceDeleteCleanupService:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def cleanup_source(self, source_id: int) -> SourceDeleteCleanupResult:
+        source = self.session.get(Source, source_id)
+        if source is None:
+            logger.info("source delete cleanup skipped; source not found", extra={"source_id": source_id})
+            return SourceDeleteCleanupResult(source_id=source_id, status="skipped_source_not_found")
+        if source.deleted_at is None:
+            logger.info("source delete cleanup skipped; source is not deleted", extra={"source_id": source_id})
+            return SourceDeleteCleanupResult(source_id=source_id, status="skipped_source_not_deleted")
+
+        run = SourceRun(source_id=source_id, trigger_type=SOURCE_DELETE_CLEANUP_TRIGGER, status="running")
+        self.session.add(run)
+        self.session.flush()
+        run_id = run.id
+        self.session.commit()
+
+        try:
+            associated_ids = self._associated_job_ids(source_id)
+            retained_ids = self._retained_job_ids(associated_ids)
+            delete_ids = [job_id for job_id in associated_ids if job_id not in retained_ids]
+
+            deleted_count = self._delete_jobs(delete_ids)
+
+            run.status = "success"
+            run.finished_at = utcnow()
+            run.jobs_fetched_count = len(associated_ids)
+            run.empty_result_flag = len(associated_ids) == 0
+            run.log_summary = (
+                f"Source delete cleanup evaluated {len(associated_ids)} job(s), "
+                f"retained {len(retained_ids)}, deleted {deleted_count}."
+            )
+            run.error_details_json = {
+                "source_id": source_id,
+                "associated_count": len(associated_ids),
+                "retained_count": len(retained_ids),
+                "deleted_count": deleted_count,
+            }
+            self.session.add(run)
+            self.session.commit()
+            logger.info(
+                "source delete cleanup completed",
+                extra={
+                    "source_id": source_id,
+                    "cleanup_run_id": run_id,
+                    "associated_count": len(associated_ids),
+                    "retained_count": len(retained_ids),
+                    "deleted_count": deleted_count,
+                    "status": "success",
+                },
+            )
+            return SourceDeleteCleanupResult(
+                source_id=source_id,
+                status="success",
+                associated_count=len(associated_ids),
+                retained_count=len(retained_ids),
+                deleted_count=deleted_count,
+                run_id=run_id,
+            )
+        except Exception as exc:
+            self.session.rollback()
+            failed_run = self.session.get(SourceRun, run_id)
+            if failed_run is not None:
+                failed_run.status = "failed"
+                failed_run.finished_at = utcnow()
+                failed_run.error_count = 1
+                failed_run.log_summary = "Source delete cleanup failed."
+                failed_run.error_details_json = {"source_id": source_id, "error": str(exc), "error_type": type(exc).__name__}
+                self.session.add(failed_run)
+                self.session.commit()
+            logger.exception("source delete cleanup failed", extra={"source_id": source_id, "cleanup_run_id": run_id})
+            raise
+
+    def _associated_job_ids(self, source_id: int) -> list[int]:
+        query = (
+            select(distinct(JobPosting.id))
+            .outerjoin(JobSourceLink, JobSourceLink.job_posting_id == JobPosting.id)
+            .where(or_(JobPosting.primary_source_id == source_id, JobSourceLink.source_id == source_id))
+        )
+        return list(self.session.scalars(query))
+
+    def _retained_job_ids(self, job_ids: list[int]) -> set[int]:
+        if not job_ids:
+            return set()
+        query = select(JobPosting.id).where(
+            JobPosting.id.in_(job_ids),
+            JobPosting.latest_bucket == "matched",
+            JobPosting.current_state == "active",
+        )
+        return set(self.session.scalars(query))
+
+    def _delete_jobs(self, job_ids: list[int]) -> int:
+        if not job_ids:
+            return 0
+
+        decision_ids = list(self.session.scalars(select(JobDecision.id).where(JobDecision.job_posting_id.in_(job_ids))))
+        if decision_ids:
+            self.session.execute(delete(JobDecisionRule).where(JobDecisionRule.job_decision_id.in_(decision_ids)))
+        self.session.execute(delete(JobDecision).where(JobDecision.job_posting_id.in_(job_ids)))
+        self.session.execute(delete(JobTrackingEvent).where(JobTrackingEvent.job_posting_id.in_(job_ids)))
+        self.session.execute(delete(Reminder).where(Reminder.job_posting_id.in_(job_ids)))
+        self.session.execute(delete(DigestItem).where(DigestItem.job_posting_id.in_(job_ids)))
+        self.session.execute(delete(JobSourceLink).where(JobSourceLink.job_posting_id.in_(job_ids)))
+        result = self.session.execute(
+            delete(JobPosting).where(
+                JobPosting.id.in_(job_ids),
+                or_(
+                    JobPosting.latest_bucket.is_(None),
+                    JobPosting.latest_bucket != "matched",
+                    JobPosting.current_state.is_(None),
+                    JobPosting.current_state != "active",
+                ),
+            )
+        )
+        return int(result.rowcount or 0)
+
+
+def run_source_delete_cleanup(source_id: int) -> None:
+    from app.persistence.db import SessionLocal
+
+    with SessionLocal() as session:
+        SourceDeleteCleanupService(session).cleanup_source(source_id)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -77,6 +77,8 @@ class SourceDeleteResponse(BaseModel):
     deleted: bool
     source_id: int
     deleted_at: datetime
+    cleanup_queued: bool = False
+    cleanup_status: str | None = None
 
 
 class SourceRunResponse(BaseModel):

--- a/app/templates/jobs/detail.html
+++ b/app/templates/jobs/detail.html
@@ -72,20 +72,21 @@
 
 <section class="content-grid content-grid--2">
   <article class="surface">
-    <div class="section-heading"><h3>Source links</h3></div>
+    <div class="section-heading"><h3>Source evidence</h3></div>
     {% if source_links %}
       <div class="stack-list">
         {% for link in source_links %}
           {% set source = sources.get(link.source_id|string) or sources.get(link.source_id) %}
           <div class="list-item list-item--stacked">
             <strong>{{ source.name if source else 'Historical source' }}</strong>
-            <div class="muted">{{ link.source_job_url }}</div>
-            {% if source and not source.is_active %}<div>{{ ui.badge('Inactive source', 'warning') }}</div>{% endif %}
+            {% if source and source.deleted_at %}{{ ui.badge('Deleted source', 'neutral') }}{% endif %}
+            <div class="muted">External job id: {{ link.external_job_id or '—' }} · Last seen {{ format_dt(link.last_seen_at) }}</div>
+            {% if link.source_job_url %}<a href="{{ link.source_job_url }}" target="_blank" rel="noreferrer">Open posting</a>{% endif %}
           </div>
         {% endfor %}
       </div>
     {% else %}
-      {{ ui.empty_state('No source links', 'This job does not have attached source provenance.') }}
+      {{ ui.empty_state('No source provenance records available', 'This job does not have attached source provenance.') }}
     {% endif %}
   </article>
   <article class="surface">

--- a/app/templates/jobs/list.html
+++ b/app/templates/jobs/list.html
@@ -17,26 +17,31 @@
 
 <section class="surface">
   <form method="get" class="toolbar" data-clean-empty-query="true">
-    <input type="search" name="search" value="{{ filters.search }}" placeholder="Search title, company, or description">
-    <select name="bucket">
+    <label class="sr-only" for="jobs-search">Search jobs</label>
+    <input id="jobs-search" type="search" name="search" value="{{ filters.search }}" placeholder="Search title, company, or description">
+    <label class="sr-only" for="jobs-bucket">Bucket</label>
+    <select id="jobs-bucket" name="bucket">
       <option value="">All buckets</option>
       {% for value in ['matched', 'review', 'rejected'] %}
         <option value="{{ value }}" {% if filters.bucket == value %}selected{% endif %}>{{ value|title }}</option>
       {% endfor %}
     </select>
-    <select name="tracking_status">
+    <label class="sr-only" for="jobs-tracking-status">Tracking status</label>
+    <select id="jobs-tracking-status" name="tracking_status">
       <option value="">All tracking states</option>
       {% for value in tracking_statuses|default([]) %}
         <option value="{{ value }}" {% if filters.tracking_status == value %}selected{% endif %}>{{ value|replace('_', ' ')|title }}</option>
       {% endfor %}
     </select>
-    <select name="source_id">
+    <label class="sr-only" for="jobs-source-id">Source</label>
+    <select id="jobs-source-id" name="source_id">
       <option value="">All sources</option>
       {% for source in available_sources %}
         <option value="{{ source.id }}" {% if filters.source_id|string == source.id|string %}selected{% endif %}>{{ source.name }}</option>
       {% endfor %}
     </select>
-    <select name="sort">
+    <label class="sr-only" for="jobs-sort">Sort</label>
+    <select id="jobs-sort" name="sort">
       <option value="newest" {% if filters.sort == 'newest' %}selected{% endif %}>Newest</option>
       <option value="score" {% if filters.sort == 'score' %}selected{% endif %}>Highest score</option>
       <option value="title" {% if filters.sort == 'title' %}selected{% endif %}>Title</option>
@@ -58,7 +63,10 @@
                 <a class="table-link" href="/jobs/{{ job.id }}">{{ job.title }}</a>
                 <div class="muted">{{ job.company_name }} · {{ job.location_text or 'Location not specified' }}</div>
               </td>
-              <td>{{ job.source_name or 'Unknown source' }}</td>
+              <td>
+                {{ job.source_name or 'Unknown source' }}
+                {% if job.source_deleted %}{{ ui.badge('Deleted source', 'neutral') }}{% endif %}
+              </td>
               <td>{{ ui.badge(job.bucket|title, ui.tone_from_status(job.bucket)) }}</td>
               <td>{{ ui.badge((job.tracking_status or 'untracked')|replace('_', ' ')|title, ui.tone_from_status(job.tracking_status)) }}</td>
               <td>{{ format_dt(job.last_seen_at) if format_dt else job.last_seen_at }}</td>
@@ -76,7 +84,7 @@
       </table>
     </div>
   {% else %}
-    {{ ui.empty_state('No jobs found', 'Try broadening your filters or run a source to bring in new postings.', '/sources', 'Manage sources') }}
+    {{ ui.empty_state('No jobs found', 'Try broadening your filters or run an active source to bring in new postings.', '/sources', 'Manage sources') }}
   {% endif %}
 </section>
 {% endblock %}

--- a/app/templates/sources/delete_confirm.html
+++ b/app/templates/sources/delete_confirm.html
@@ -7,30 +7,44 @@
   <div>
     <div class="eyebrow">Confirmation</div>
     <h2>Delete source</h2>
-    <p>Review the historical impact before deleting <strong>{{ source.name }}</strong>.</p>
+    <p>Review cleanup impact before removing this source.</p>
   </div>
 </section>
-<section class="content-grid content-grid--2">
-  <article class="surface">
+<section class="panel panel-narrow surface">
+  <p>You are about to delete <strong>{{ source.name }}</strong>.</p>
+
+  <div class="callout callout-danger alert alert--warning" role="status">
+    <strong>This permanently removes most jobs from this source</strong>
+    <p>Deleting this source removes it from source management and future ingestion immediately. Jobs linked to this source will be cleaned up in the background. Only jobs that are both Matched and Active will be retained.</p>
+  </div>
+
+  <div class="content-grid content-grid--3 import-summary-grid">
+    <article class="stat-card"><span>Runs</span><strong>{{ impact_summary.run_count }}</strong></article>
+    <article class="stat-card"><span>Linked jobs</span><strong>{{ impact_summary.linked_job_count }}</strong></article>
+    <article class="stat-card"><span>Tracked jobs</span><strong>{{ impact_summary.tracked_job_count }}</strong></article>
+  </div>
+
+  <div class="stack-list delete-impact-copy">
     <div class="section-heading"><h3>Impact summary</h3></div>
-    <dl class="detail-list">
-      <div><dt>Run history</dt><dd>{{ impact_summary.run_count }}</dd></div>
-      <div><dt>Linked jobs</dt><dd>{{ impact_summary.linked_job_count }}</dd></div>
-      <div><dt>Tracked jobs</dt><dd>{{ impact_summary.tracked_job_count }}</dd></div>
-    </dl>
-    {% if impact_summary.has_linked_jobs or impact_summary.has_run_history %}
-      <div class="alert alert--warning">Historical jobs and run references remain important context for downstream review.</div>
+    {% if impact_summary.has_linked_jobs %}
+      <p>{{ impact_summary.linked_job_count }} linked job(s) will be removed from Jobs, Dashboard, reminders, and digests immediately after deletion unless they are both Matched and Active. Physical cleanup finishes in the background.</p>
+      <p>Matched active jobs may remain visible if they match your filters. Their deleted source provenance is historical only and cannot be used for future ingestion.</p>
+    {% else %}
+      <p>No linked jobs found. No job cleanup is needed.</p>
     {% endif %}
-  </article>
-  <article class="surface">
-    <div class="section-heading"><h3>Confirm deletion</h3></div>
-    <form method="post" action="/sources/{{ source.id }}/delete" class="stack-form">
-      <p class="muted">This destructive action requires confirmation and names the affected source explicitly.</p>
-      <div class="form-footer form-footer--split">
-        <a class="btn btn--ghost" href="/sources/{{ source.id }}">Cancel</a>
-        <button class="btn btn--danger" type="submit">Delete source</button>
-      </div>
-    </form>
-  </article>
+
+    {% if impact_summary.has_run_history %}
+      <p>Run records remain available for operational history, but this source will no longer be available in active source lists, filters, or run actions.</p>
+    {% else %}
+      <p>No run history found.</p>
+    {% endif %}
+
+    <p>Tracking status, reminders, manual keep, and digest inclusion do not preserve a job unless it is also Matched and Active.</p>
+  </div>
+
+  <form method="post" action="/sources/{{ source.id }}/delete" class="button-row button-row-wrap form-footer form-footer--split">
+    <a class="btn btn--ghost" href="/sources/{{ source.id }}">Cancel</a>
+    <button class="btn btn--danger" type="submit">Delete source</button>
+  </form>
 </section>
 {% endblock %}

--- a/app/templates/sources/detail.html
+++ b/app/templates/sources/detail.html
@@ -32,6 +32,9 @@
       <div><dt>External identifier</dt><dd>{{ source.external_identifier or 'Not set' }}</dd></div>
       <div><dt>Notes</dt><dd>{{ source.notes or 'No notes added.' }}</dd></div>
     </dl>
+    {% if not source.is_active %}
+      <div class="alert alert--warning">This source is inactive and cannot be run until it is reactivated.</div>
+    {% endif %}
   </article>
   <article class="surface">
     <div class="section-heading"><h3>Recent runs</h3></div>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import TypeAdapter, ValidationError
 from sqlalchemy import or_, select
@@ -15,8 +15,10 @@ from sqlalchemy.orm import Session
 
 from app.adapters.base.registry import SourceAdapterRegistry
 from app.domain.ingestion import IngestionOrchestrator
+from app.domain.job_visibility import apply_visible_jobs, visible_job_predicate
 from app.domain.notifications import NotificationService
 from app.domain.operations import OperationsService
+from app.domain.source_cleanup import run_source_delete_cleanup
 from app.domain.sources import SourceService
 from app.domain.tracking import TrackingService, VALID_TRACKING_STATUSES
 from app.persistence.db import get_db_session
@@ -39,10 +41,10 @@ from app.schemas import (
 from app.web.dependencies import get_registry
 
 router = APIRouter()
-_templates_dir = Path(__file__).resolve().parent.parent / "templates"
-if not _templates_dir.exists():
-    _templates_dir = Path(__file__).resolve().parent / "templates"
-templates = Jinja2Templates(directory=str(_templates_dir))
+_app_templates_dir = Path(__file__).resolve().parent.parent / "templates"
+_web_templates_dir = Path(__file__).resolve().parent / "templates"
+_template_dirs = [path for path in (_app_templates_dir, _web_templates_dir) if path.exists()]
+templates = Jinja2Templates(directory=[str(path) for path in _template_dirs])
 INT_QUERY_ADAPTER = TypeAdapter(int)
 
 SOURCE_TYPE_HELP = {
@@ -62,7 +64,7 @@ def wants_html(request: Request) -> bool:
     lowered = accept.lower()
 
     if not lowered or lowered == "*/*":
-        return True
+        return False
 
     if "text/html" in lowered or "application/xhtml+xml" in lowered:
         return True
@@ -187,7 +189,12 @@ def get_current_decision_map(session: Session, jobs: list[JobPosting]) -> dict[i
 
 
 def get_pending_reminder_map(session: Session) -> dict[int, Reminder]:
-    reminders = session.scalars(select(Reminder).where(Reminder.status == "pending").order_by(Reminder.due_at.asc()))
+    reminders = session.scalars(
+        select(Reminder)
+        .join(JobPosting, JobPosting.id == Reminder.job_posting_id)
+        .where(Reminder.status == "pending", visible_job_predicate())
+        .order_by(Reminder.due_at.asc())
+    )
     result: dict[int, Reminder] = {}
     for reminder in reminders:
         result.setdefault(reminder.job_posting_id, reminder)
@@ -202,6 +209,7 @@ def to_job_card(job: JobPosting, source: Source | None, decision: JobDecision | 
         "company_name": job.company_name or source.name if source else "Unknown company",
         "source_name": source.name if source else "Unknown source",
         "source_id": source.id if source else None,
+        "source_deleted": bool(source and source.deleted_at is not None),
         "job_url": job.job_url,
         "location_text": job.location_text,
         "remote_type": job.remote_type,
@@ -218,7 +226,7 @@ def to_job_card(job: JobPosting, source: Source | None, decision: JobDecision | 
 
 
 def build_jobs_query(bucket: str | None, tracking_status: str | None, source_id: int | None, search: str | None):
-    query = select(JobPosting)
+    query = apply_visible_jobs(select(JobPosting))
     if bucket:
         query = query.where(JobPosting.latest_bucket == bucket)
     if tracking_status:
@@ -244,7 +252,11 @@ def filter_jobs_by_source(session: Session, jobs: list[JobPosting], source_id: i
         return jobs
     filtered: list[JobPosting] = []
     for job in jobs:
-        link = session.scalar(select(JobSourceLink).where(JobSourceLink.job_posting_id == job.id, JobSourceLink.source_id == source_id))
+        link = session.scalar(
+            select(JobSourceLink)
+            .join(Source, Source.id == JobSourceLink.source_id)
+            .where(JobSourceLink.job_posting_id == job.id, JobSourceLink.source_id == source_id, Source.deleted_at.is_(None))
+        )
         if link:
             filtered.append(job)
     return filtered
@@ -252,6 +264,10 @@ def filter_jobs_by_source(session: Session, jobs: list[JobPosting], source_id: i
 
 def serialize_job(job: JobPosting) -> JobResponse:
     return JobResponse.model_validate(job)
+
+
+def enqueue_source_delete_cleanup(background_tasks: BackgroundTasks, source_id: int) -> None:
+    background_tasks.add_task(run_source_delete_cleanup, source_id)
 
 
 def build_source_form_data(source: Source | None = None, form_data: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -342,11 +358,18 @@ async def parse_source_form(request: Request) -> tuple[dict[str, Any], SourceCre
 @router.get("/", response_class=HTMLResponse)
 @router.get("/dashboard", response_class=HTMLResponse)
 def dashboard(request: Request, session: Session = Depends(get_session_dependency)):
-    jobs = list(session.scalars(select(JobPosting)))
-    reminders = list(session.scalars(select(Reminder).where(Reminder.status == "pending").order_by(Reminder.due_at.asc())))
+    jobs = list(session.scalars(apply_visible_jobs(select(JobPosting))))
+    reminders = list(
+        session.scalars(
+            select(Reminder)
+            .join(JobPosting, JobPosting.id == Reminder.job_posting_id)
+            .where(Reminder.status == "pending", visible_job_predicate())
+            .order_by(Reminder.due_at.asc())
+        )
+    )
     sources = list(session.scalars(select(Source).where(Source.deleted_at.is_(None)).order_by(Source.name.asc())))
     if not wants_html(request):
-        return {
+        return JSONResponse({
             "matched_count": sum(1 for job in jobs if job.latest_bucket == "matched"),
             "review_count": sum(1 for job in jobs if job.latest_bucket == "review"),
             "rejected_count": sum(1 for job in jobs if job.latest_bucket == "rejected"),
@@ -354,7 +377,7 @@ def dashboard(request: Request, session: Session = Depends(get_session_dependenc
             "applied_follow_ups": sum(1 for job in jobs if job.tracking_status == "applied"),
             "pending_reminders": len(reminders),
             "source_count": len(sources),
-        }
+        })
 
     decisions = get_current_decision_map(session, jobs)
     primary_sources = get_primary_source_map(session, jobs)
@@ -381,7 +404,11 @@ def dashboard(request: Request, session: Session = Depends(get_session_dependenc
             "matched_jobs": matched_jobs,
             "review_jobs": review_jobs,
             "reminders": reminders[:6],
-            "reminder_jobs": {job.id: to_job_card(job, primary_sources.get(job.id), decisions.get(job.id), reminder_map.get(job.id)) for job in jobs if job.id in reminder_map},
+            "reminder_jobs": [
+                to_job_card(job, primary_sources.get(job.id), decisions.get(job.id), reminder_map.get(job.id))
+                for job in jobs
+                if job.id in reminder_map
+            ],
             "source_warnings": source_warnings[:6],
             "sources": sources,
             "latest_digest": latest_digest,
@@ -529,13 +556,15 @@ def get_source_delete_impact(
 @router.delete("/sources/{source_id}")
 def delete_source(
     source_id: int,
+    background_tasks: BackgroundTasks,
     session: Session = Depends(get_session_dependency),
     registry: SourceAdapterRegistry = Depends(get_registry),
 ):
     source = SourceService(session, registry).delete_source(source_id)
     if source is None:
         raise HTTPException(status_code=404, detail="Source not found.")
-    return SourceDeleteResponse(deleted=True, source_id=source.id, deleted_at=source.deleted_at)
+    enqueue_source_delete_cleanup(background_tasks, source.id)
+    return SourceDeleteResponse(deleted=True, source_id=source.id, deleted_at=source.deleted_at, cleanup_queued=True, cleanup_status="queued")
 
 
 @router.get("/sources/{source_id}/edit")
@@ -603,13 +632,15 @@ def delete_source_form(
 def delete_source_submit(
     request: Request,
     source_id: int,
+    background_tasks: BackgroundTasks,
     session: Session = Depends(get_session_dependency),
     registry: SourceAdapterRegistry = Depends(get_registry),
 ):
     deleted = SourceService(session, registry).delete_source(source_id)
     if deleted is None:
         raise HTTPException(status_code=404, detail="Source not found.")
-    return redirect(with_message("/sources", "success", "Source deleted. It has been removed from active configuration and future ingestion."))
+    enqueue_source_delete_cleanup(background_tasks, deleted.id)
+    return redirect(with_message("/sources", "success", "Source deleted. Job cleanup has started; non-retained jobs from this source are hidden from Dashboard and Jobs now. Matched active jobs may remain."))
 
 
 @router.post("/sources/{source_id}/run")
@@ -679,7 +710,7 @@ def list_jobs(
 
 @router.get("/jobs/{job_id}")
 def get_job(request: Request, job_id: int, session: Session = Depends(get_session_dependency)):
-    job = session.get(JobPosting, job_id)
+    job = session.scalar(apply_visible_jobs(select(JobPosting)).where(JobPosting.id == job_id))
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found.")
     decision = None
@@ -766,7 +797,7 @@ def keep_job(
     next_url: str | None = Form(default=None),
     session: Session = Depends(get_session_dependency),
 ):
-    job = session.get(JobPosting, job_id)
+    job = session.scalar(apply_visible_jobs(select(JobPosting)).where(JobPosting.id == job_id))
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found.")
     updated = TrackingService(session).keep_job(job)
@@ -777,7 +808,7 @@ def keep_job(
 
 @router.post("/jobs/{job_id}/tracking-status")
 async def update_tracking_status(job_id: int, request: Request, session: Session = Depends(get_session_dependency)):
-    job = session.get(JobPosting, job_id)
+    job = session.scalar(apply_visible_jobs(select(JobPosting)).where(JobPosting.id == job_id))
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found.")
 
@@ -864,7 +895,7 @@ def tracking_page(
     session: Session = Depends(get_session_dependency),
 ):
     effective_status = tracking_status or "saved"
-    query = select(JobPosting).where(JobPosting.tracking_status.is_not(None))
+    query = apply_visible_jobs(select(JobPosting)).where(JobPosting.tracking_status.is_not(None))
     if effective_status and effective_status != "all":
         query = query.where(JobPosting.tracking_status == effective_status)
     if search:
@@ -917,7 +948,7 @@ def latest_digest(request: Request, session: Session = Depends(get_session_depen
         return None
     items = list(session.scalars(select(DigestItem).where(DigestItem.digest_id == digest.id)))
     if wants_html(request):
-        jobs = {job.id: job for job in session.scalars(select(JobPosting).where(JobPosting.id.in_([item.job_posting_id for item in items])))} if items else {}
+        jobs = {job.id: job for job in session.scalars(apply_visible_jobs(select(JobPosting)).where(JobPosting.id.in_([item.job_posting_id for item in items])))} if items else {}
         primary_sources = get_primary_source_map(session, list(jobs.values()))
         decisions = get_current_decision_map(session, list(jobs.values()))
         grouped_items: dict[str, list[dict[str, Any]]] = {"matched": [], "review": []}
@@ -927,6 +958,9 @@ def latest_digest(request: Request, session: Session = Depends(get_session_depen
                 continue
             grouped_items[item.bucket].append({"item": item, "job": to_job_card(job, primary_sources.get(job.id), decisions.get(job.id))})
         return render(request, session, "notifications/digest.html", {"page_key": "digest", "digest": digest, "grouped_items": grouped_items})
+    visible_item_job_ids = set(
+        session.scalars(apply_visible_jobs(select(JobPosting.id)).where(JobPosting.id.in_([item.job_posting_id for item in items])))
+    ) if items else set()
     return DigestResponse(
         id=digest.id,
         digest_date=digest.digest_date,
@@ -934,7 +968,7 @@ def latest_digest(request: Request, session: Session = Depends(get_session_depen
         generated_at=digest.generated_at,
         delivery_channel=digest.delivery_channel,
         content_summary=digest.content_summary,
-        items=[DigestItemResponse(job_posting_id=item.job_posting_id, bucket=item.bucket, reason=item.reason) for item in items],
+        items=[DigestItemResponse(job_posting_id=item.job_posting_id, bucket=item.bucket, reason=item.reason) for item in items if item.job_posting_id in visible_item_job_ids],
     )
 
 
@@ -948,7 +982,14 @@ def generate_reminders(request: Request, session: Session = Depends(get_session_
 
 @router.get("/reminders")
 def list_reminders(request: Request, session: Session = Depends(get_session_dependency)):
-    reminders = list(session.scalars(select(Reminder).order_by(Reminder.due_at.asc())))
+    reminders = list(
+        session.scalars(
+            select(Reminder)
+            .join(JobPosting, JobPosting.id == Reminder.job_posting_id)
+            .where(visible_job_predicate())
+            .order_by(Reminder.due_at.asc())
+        )
+    )
     if not wants_html(request):
         return [ReminderResponse.model_validate(reminder) for reminder in reminders]
     jobs = {job.id: job for job in session.scalars(select(JobPosting).where(JobPosting.id.in_([reminder.job_posting_id for reminder in reminders])))} if reminders else {}

--- a/app/web/templates/jobs/detail.html
+++ b/app/web/templates/jobs/detail.html
@@ -91,6 +91,7 @@
               <li class="stack-item stack-item-start">
                 <div>
                   <strong>{{ source.name if source else 'Source #' ~ link.source_id }}</strong>
+                  {% if source and source.deleted_at %}<span class="badge badge-muted">Deleted source</span>{% endif %}
                   <p class="muted">External job id: {{ link.external_job_id or '—' }} · Last seen {{ format_dt(link.last_seen_at) }}</p>
                 </div>
                 <a href="{{ link.source_job_url }}" target="_blank" rel="noreferrer">Open posting</a>

--- a/app/web/templates/jobs/list.html
+++ b/app/web/templates/jobs/list.html
@@ -76,7 +76,7 @@
               <tr class="{% if job.bucket == 'rejected' %}row-muted{% endif %}">
                 <td>
                   <a href="/jobs/{{ job.id }}"><strong>{{ job.title }}</strong></a>
-                  <div class="cell-subtitle">{{ job.company_name }} · {{ job.source_name }}</div>
+                  <div class="cell-subtitle">{{ job.company_name }} · {{ job.source_name }}{% if job.source_deleted %} <span class="badge badge-muted">Deleted source</span>{% endif %}</div>
                   {% if job.location_text %}<div class="cell-subtitle">{{ job.location_text }}</div>{% endif %}
                 </td>
                 <td>{{ ui.badge('bucket', job.bucket) }}</td>
@@ -104,7 +104,7 @@
           <div class="job-card__header">
             <div>
               <h2><a href="/jobs/{{ job.id }}">{{ job.title }}</a></h2>
-              <p class="muted">{{ job.company_name }} · {{ job.source_name }}</p>
+              <p class="muted">{{ job.company_name }} · {{ job.source_name }}{% if job.source_deleted %} <span class="badge badge-muted">Deleted source</span>{% endif %}</p>
             </div>
             <div class="badge-stack">{{ ui.badge('bucket', job.bucket) }} {{ ui.badge('tracking', job.tracking_status) }}</div>
           </div>

--- a/app/web/templates/sources/delete_confirm.html
+++ b/app/web/templates/sources/delete_confirm.html
@@ -4,14 +4,14 @@
 {% block title %}Delete source · Sources{% endblock %}
 
 {% block content %}
-  {{ ui.page_header('Delete source', 'Review the impact before removing this source from active configuration.') }}
+  {{ ui.page_header('Delete source', 'Review cleanup impact before removing this source.') }}
 
   <section class="panel panel-narrow">
     <p>You are about to delete <strong>{{ source.name }}</strong>.</p>
 
     <div class="callout callout-danger">
-      <strong>Warning</strong>
-      <p>Deleting a source removes it from active configuration, hides it from default source lists and filters, and prevents future ingestion runs. Historical jobs and run records are preserved.</p>
+      <strong>This permanently removes most jobs from this source</strong>
+      <p>Deleting this source removes it from source management and future ingestion immediately. Jobs linked to this source will be cleaned up in the background. Only jobs that are both Matched and Active will be retained.</p>
     </div>
 
     <div class="import-summary-grid">
@@ -21,21 +21,20 @@
     </div>
 
     <div class="stack-list delete-impact-copy">
+      {% if impact_summary.has_linked_jobs %}
+        <p>{{ impact_summary.linked_job_count }} linked job(s) will be removed from Jobs, Dashboard, reminders, and digests immediately after deletion unless they are both Matched and Active. Physical cleanup finishes in the background.</p>
+        <p>Matched active jobs may remain visible if they match your filters. Their deleted source provenance is historical only and cannot be used for future ingestion.</p>
+      {% else %}
+        <p>No linked jobs found. No job cleanup is needed.</p>
+      {% endif %}
+
       {% if impact_summary.has_run_history %}
-        <p>This source has existing history that will remain visible in historical views.</p>
+        <p>Run records remain available for operational history, but this source will no longer be available in active source lists, filters, or run actions.</p>
       {% else %}
         <p>No run history found.</p>
       {% endif %}
 
-      {% if impact_summary.has_linked_jobs %}
-        <p>Jobs already linked to this source will keep their historical source reference.</p>
-      {% else %}
-        <p>No linked jobs found.</p>
-      {% endif %}
-
-      {% if impact_summary.tracked_job_count %}
-        <p>Tracked jobs linked to this source are preserved, but the source itself cannot be restored from this flow.</p>
-      {% endif %}
+      <p>Tracking status, reminders, manual keep, and digest inclusion do not preserve a job unless it is also Matched and Active.</p>
     </div>
 
     <form method="post" action="/sources/{{ source.id }}/delete" class="button-row button-row-wrap">

--- a/docs/architecture/source_delete_job_cleanup_technical_design.md
+++ b/docs/architecture/source_delete_job_cleanup_technical_design.md
@@ -1,0 +1,401 @@
+# Source Delete Job Cleanup Technical Design
+
+## Feature Overview
+
+When a job source is deleted, the application must asynchronously clean up jobs associated with that source. Jobs associated with the deleted source are permanently deleted unless they are both:
+
+- `latest_bucket == "matched"`
+- `current_state == "active"`
+
+The source deletion request must remain responsive. During the async cleanup window, dashboard and job list surfaces must immediately suppress non-retained jobs from the deleted source by using the source `deleted_at` marker as the visibility boundary.
+
+Implementation requires **backend changes** and a small **frontend/template copy update**. No major frontend state-management changes are required in the current server-rendered FastAPI/Jinja application.
+
+## Product Requirements Summary
+
+- Source deletion soft-deletes the source from active configuration immediately.
+- Source deletion queues or starts asynchronous job cleanup.
+- Associated jobs are identified by either `job_postings.primary_source_id` or any `job_source_links.source_id` pointing to the deleted source.
+- Retention rule is strict: retain only matched active jobs.
+- Non-retained jobs must not appear in Jobs, Dashboard, counts, source-filter views, reminders, or digests while cleanup is pending or after cleanup completes.
+- Cleanup must permanently delete non-retained jobs and dependent job-owned records.
+- Cleanup must be idempotent, retry-safe, and observable via logs and/or task/run state.
+
+## Scope
+
+### In Scope
+
+- Extend existing source delete flow in `SourceService.delete_source` and source delete endpoints.
+- Add a backend cleanup service that deletes eligible jobs and dependent rows.
+- Start cleanup asynchronously after source `deleted_at` is committed.
+- Add reusable query/helper behavior to exclude pending-cleanup jobs from user-facing job surfaces.
+- Update API response/message to communicate that cleanup has been queued/started.
+- Add tests for retention/deletion, idempotency, immediate visibility suppression, and dependent cleanup.
+
+### Out of Scope
+
+- Restore/undo for deleted sources or jobs.
+- User-configurable retention policies.
+- Archival soft-delete for jobs.
+- Bulk source deletion.
+- New admin UI for cleanup jobs. Logs plus existing source run/ops surfaces are sufficient for MVP.
+
+## Architecture Overview
+
+Current repository findings:
+
+- Backend stack: FastAPI, SQLAlchemy 2.x, Alembic, SQLite/PostgreSQL-compatible schema.
+- Source deletion currently soft-deletes `sources` by setting `deleted_at` and `is_active = False` in `app/domain/sources.py`.
+- Source delete endpoints:
+  - `DELETE /sources/{source_id}` in `app/web/routes.py`
+  - `POST /sources/{source_id}/delete` HTML form route in `app/web/routes.py`
+- Job model fields:
+  - `JobPosting.primary_source_id`
+  - `JobPosting.latest_bucket`
+  - `JobPosting.current_state`
+  - `JobSourceLink.job_posting_id`, `source_id`, `is_primary`
+- Existing user-facing surfaces currently select `JobPosting` directly and therefore need visibility filtering:
+  - Dashboard: `GET /dashboard`
+  - Jobs list/API: `GET /jobs`
+  - Job detail/API: `GET /jobs/{job_id}`
+  - Tracking page: `GET /tracking`
+  - Reminders page/API: `GET /reminders`
+  - Digest latest page/API: `GET /digest/latest`
+  - Digest/reminder generation in `NotificationService`
+- Background infrastructure: APScheduler is initialized in `app/main.py` but no jobs are registered. FastAPI `BackgroundTasks` is the simplest request-triggered async mechanism for this feature.
+
+Recommended design:
+
+1. Delete request soft-deletes the source and commits immediately.
+2. Endpoint schedules a cleanup background task after successful commit.
+3. Cleanup task opens its own DB session and runs `SourceDeleteCleanupService.cleanup_source(source_id)`.
+4. Dashboard/list/query helpers immediately hide non-retained jobs associated with any deleted source by joining source attribution to `sources.deleted_at`.
+5. Cleanup permanently deletes dependent job-owned data before deleting `job_postings`.
+6. Cleanup records operational status using `source_runs` rows with `trigger_type = "source_delete_cleanup"` and logs structured summary data.
+
+## System Components
+
+### Existing Components Affected
+
+- `app/domain/sources.py`
+  - Keep source soft-delete behavior.
+  - Optionally return a result object that indicates whether deletion occurred and which source id was deleted.
+  - Do not perform physical job deletion inline.
+- `app/web/routes.py`
+  - Inject `BackgroundTasks` into source delete routes.
+  - Schedule cleanup only after `delete_source` returns a deleted source.
+  - Apply visibility helper to dashboard/jobs/detail/tracking/reminder/digest surfaces.
+- `app/domain/notifications.py`
+  - Ensure digest/reminder generation excludes non-retained jobs from deleted sources while cleanup is pending.
+- `app/persistence/models.py`
+  - No required model changes for MVP if `source_runs` is reused for cleanup status.
+
+### New Backend Components
+
+- `app/domain/source_cleanup.py`
+  - Owns association discovery, retention evaluation, dependent deletion order, idempotency, and operational logging.
+- `app/domain/job_visibility.py` or equivalent helper module
+  - Provides reusable SQLAlchemy predicates/functions for “visible jobs” in normal user-facing surfaces.
+- Optional route helper in `app/web/routes.py`
+  - `enqueue_source_delete_cleanup(background_tasks, source_id)` creates a background task that opens a fresh session via `SessionLocal`.
+
+## Data Models and Storage Design
+
+### Existing Tables Used
+
+- `sources`
+  - `deleted_at` is the source deletion boundary and immediate visibility marker.
+- `job_postings`
+  - Retention fields: `latest_bucket`, `current_state`.
+  - Primary source attribution: `primary_source_id`.
+- `job_source_links`
+  - Source/provenance association.
+- Dependent job-owned tables to delete for non-retained jobs:
+  - `job_decision_rules`
+  - `job_decisions`
+  - `job_tracking_events`
+  - `reminders`
+  - `digest_items`
+  - `job_source_links`
+  - `job_postings`
+
+### Migration Needs
+
+No schema migration is required for MVP if cleanup status is represented with existing `source_runs`:
+
+- `source_runs.trigger_type = "source_delete_cleanup"`
+- `source_runs.status`: `running`, `success`, `failed`, optionally `partial_success`
+- `source_runs.jobs_fetched_count`: number of associated jobs evaluated
+- `source_runs.jobs_created_count`: use as `retained_count` is not semantically ideal; avoid overloading if possible
+- `source_runs.jobs_updated_count`: use as `deleted_count` is not semantically ideal; avoid overloading if possible
+- `source_runs.log_summary` and `error_details_json`: store human-readable and structured cleanup summary
+
+Preferred minimal usage: set `jobs_fetched_count` to associated/evaluated count, `error_count`, `log_summary`, and `error_details_json`. Put `deleted_count` and `retained_count` in `error_details_json` or a summary JSON payload even for success.
+
+Future consideration: add a dedicated `source_cleanup_jobs` table if product later needs admin retry controls, progress UI, or multiple cleanup job types.
+
+## API Contracts
+
+### DELETE `/sources/{source_id}`
+
+Current response:
+
+```json
+{
+  "deleted": true,
+  "source_id": 123,
+  "deleted_at": "2026-04-25T12:00:00Z"
+}
+```
+
+Recommended response extension:
+
+```json
+{
+  "deleted": true,
+  "source_id": 123,
+  "deleted_at": "2026-04-25T12:00:00Z",
+  "cleanup_queued": true,
+  "cleanup_status": "queued"
+}
+```
+
+Backward compatibility: existing clients that only read `deleted`, `source_id`, and `deleted_at` continue to work.
+
+Error behavior remains:
+
+- `404` if source does not exist or is already deleted under current `get_source` behavior.
+
+### POST `/sources/{source_id}/delete`
+
+HTML redirect remains to `/sources`, but success copy should change to:
+
+> Source deleted. It has been removed from active configuration and associated jobs are being cleaned up in the background.
+
+### Existing Job/Dashboard APIs
+
+No new request parameters are required. Responses should simply exclude pending-cleanup non-retained jobs.
+
+For direct `GET /jobs/{job_id}`, recommended behavior is:
+
+- Return `404` if the job has already been physically deleted.
+- Also return `404` during the cleanup window if the job is associated with a deleted source and does not satisfy matched+active retention. This prevents stale bookmarked detail views from exposing a job that is logically pending deletion.
+- Retained matched active jobs remain accessible.
+
+## Frontend / Client Impact
+
+Implementation requires **both backend and frontend/template work**, but frontend scope is small.
+
+- Source delete confirmation page may keep existing impact counts for runs/linked/tracked jobs.
+- Delete success toast/banner copy must mention background cleanup.
+- Jobs/dashboard/reminders/digest pages require no new UI widgets if backend filtering is centralized.
+- Source filters must continue to list only `Source.deleted_at IS NULL` sources. Current jobs page already does this.
+- If retained jobs display deleted source provenance in job detail, source actions should not be offered for deleted sources. Current source actions are primarily on source pages; ensure templates do not render run/edit links for deleted sources if such links are added around provenance.
+
+## Backend Logic / Service Behavior
+
+### Association Discovery
+
+A job is associated with a deleted source if either condition is true:
+
+- `JobPosting.primary_source_id == source_id`
+- Exists `JobSourceLink` with `job_source_links.job_posting_id == job_postings.id` and `job_source_links.source_id == source_id`
+
+Use `DISTINCT JobPosting.id` to avoid duplicates when both attribution paths match.
+
+### Retention Rule
+
+Retain only:
+
+```text
+job.latest_bucket == "matched" AND job.current_state == "active"
+```
+
+Delete all other associated jobs, including:
+
+- `matched` but inactive/non-active current state
+- `review`/`rejected` active jobs
+- unclassified jobs where `latest_bucket IS NULL`
+- manually kept or tracked jobs that do not satisfy matched+active
+
+### Immediate Visibility Strategy
+
+Define a reusable “normal visible jobs” rule:
+
+```text
+Visible if NOT EXISTS an associated deleted source
+OR (latest_bucket = 'matched' AND current_state = 'active')
+```
+
+Where “associated deleted source” means either primary source is deleted or any source link points to a deleted source.
+
+Apply this helper to:
+
+- `dashboard()` job set before counts/cards/reminders summary are calculated.
+- `build_jobs_query()` / `list_jobs()` before bucket/tracking/search/source filters are applied.
+- `get_job()` detail route before rendering/serializing.
+- `tracking_page()`.
+- `NotificationService.generate_digest()` by joining/looking up jobs for candidate decisions and excluding invisible jobs.
+- `NotificationService.generate_reminders()`.
+- `latest_digest()` and `list_reminders()` display paths should skip invisible or already-deleted jobs.
+
+Important: retained matched active jobs from a deleted source remain visible even though their source is deleted.
+
+### Async Cleanup Strategy
+
+Use FastAPI `BackgroundTasks` for request-triggered cleanup:
+
+1. Endpoint calls `SourceService.delete_source(source_id)`.
+2. If a source is returned, endpoint adds a background task with only primitive arguments, e.g. `source_id`.
+3. Background task function imports/uses `SessionLocal` to open a fresh session. Do not reuse the request-scoped session after the response.
+4. Task calls `SourceDeleteCleanupService(session).cleanup_source(source_id)`.
+5. Task commits success/failure status in `source_runs` and logs exceptions.
+
+Rationale: this is the simplest implementable asynchronous behavior in the existing FastAPI app. APScheduler exists but is not currently configured with persistent jobs; introducing a durable queue would be out of scope.
+
+Retry options:
+
+- Automatic retry is not required for MVP, but cleanup must be safe if invoked again.
+- Maintainers can retry by calling the service from a shell/test task or by adding a simple operational endpoint later.
+- Future: APScheduler periodic sweep for deleted sources with failed/missing cleanup runs.
+
+### Cleanup Algorithm
+
+For `cleanup_source(source_id)`:
+
+1. Load source with `include_deleted=True`.
+2. If source does not exist, log no-op and return success/no-op.
+3. If `source.deleted_at is None`, do not cleanup; log and return no-op/failure depending caller use. Cleanup should only run for deleted sources.
+4. Create a `SourceRun` row:
+   - `source_id = source_id`
+   - `trigger_type = "source_delete_cleanup"`
+   - `status = "running"`
+5. Query distinct associated job ids.
+6. Partition ids into retained and delete candidates using current DB state at cleanup time.
+7. Delete candidates in batches. MVP can use one transaction for local-scale data, but service should be structured so batching can be added easily.
+8. For each delete batch, delete dependent rows in safe order:
+   1. Select decision ids for batch jobs.
+   2. Delete `JobDecisionRule` where `job_decision_id IN decision_ids`.
+   3. Delete `JobDecision` where `job_posting_id IN job_ids`.
+   4. Delete `JobTrackingEvent` where `job_posting_id IN job_ids`.
+   5. Delete `Reminder` where `job_posting_id IN job_ids`.
+   6. Delete `DigestItem` where `job_posting_id IN job_ids`.
+   7. Delete `JobSourceLink` where `job_posting_id IN job_ids`.
+   8. Delete `JobPosting` where `id IN job_ids` and still not retained.
+9. Re-check the retention predicate in the final `DELETE FROM job_postings` condition to avoid deleting a job that became matched+active between partition and delete.
+10. Mark run `success`, set `finished_at`, summary counts, and commit.
+11. On exception, rollback current transaction if needed, mark run `failed` in a separate transaction/session state where possible, and log `source_id`, `run_id`, exception class/message.
+
+### Idempotency and Retry Safety
+
+- Running cleanup multiple times for the same deleted source must be safe because:
+  - Already-deleted jobs are absent from associated job query.
+  - Retained jobs are re-evaluated each run and skipped while matched+active.
+  - Dependent deletes should use `WHERE ... IN (...)` and tolerate zero affected rows.
+- The final job delete statement must include the inverse retention condition:
+
+```text
+NOT (latest_bucket = 'matched' AND current_state = 'active')
+```
+
+- No cleanup operation should undelete or mutate retained jobs.
+- Source deletion itself must not be rolled back if cleanup fails.
+
+### Multi-Source Jobs
+
+Per current product assumption, any association to the deleted source makes the job subject to cleanup. Therefore a non-retained job linked to both a deleted source and an active source is deleted. Retained matched active jobs remain even if one or more associated sources are deleted.
+
+## File / Module Structure
+
+Recommended implementation changes:
+
+```text
+app/
+  domain/
+    source_cleanup.py        # new SourceDeleteCleanupService
+    job_visibility.py        # new reusable visible-job predicates/helpers
+    sources.py               # preserve soft-delete, optionally expose delete result
+    notifications.py         # apply visibility in generation queries
+  web/
+    routes.py                # enqueue background task and use visibility helpers
+  schemas.py                 # extend SourceDeleteResponse with cleanup fields
+  main.py                    # no required scheduler changes
+tests/
+  unit/
+    test_source_delete_cleanup.py
+    test_job_visibility.py
+  api/
+    test_source_delete_job_cleanup_api.py
+  integration/
+    test_source_delete_job_cleanup_surfaces.py
+```
+
+## Security and Access Control
+
+- The current app is local/single-user and has no explicit auth model. This feature should follow existing route access behavior.
+- Do not expose deleted source run/edit actions from retained job provenance.
+- Cleanup logs must not include full raw payloads or full job descriptions; include ids/counts/status only.
+- Deletion is irreversible, so route behavior must continue to require the existing explicit source delete confirmation for HTML users.
+
+## Reliability / Operational Considerations
+
+- Cleanup failures must not affect source deletion success.
+- Use structured logging with at least:
+  - `source_id`
+  - `cleanup_run_id` / `source_run.id`
+  - `associated_count`
+  - `retained_count`
+  - `deleted_count`
+  - `status`
+  - exception message on failure
+- `source_runs` with `trigger_type = "source_delete_cleanup"` provides a basic operational audit trail visible through existing ops run list/detail routes.
+- For SQLite, keep transactions reasonably small. If batch size is implemented, start with 500 job ids per batch.
+- If background execution fails due to process shutdown, immediate visibility suppression still protects user-facing lists because it depends on committed `sources.deleted_at`. A later retry can physically delete rows.
+- Avoid using request-scoped SQLAlchemy sessions in background tasks.
+
+## Dependencies and Constraints
+
+- Existing source soft-delete schema (`sources.deleted_at`) must remain the lifecycle marker.
+- Existing FastAPI/Jinja server-rendered app should not require a new frontend framework.
+- Existing `source_runs` table can represent cleanup execution status without migration.
+- Existing foreign keys do not define cascading deletes in models/migrations, so application-level dependent deletion order is required.
+- Retention is based on denormalized `JobPosting.latest_bucket`, not by recomputing or joining latest `JobDecision`, because product assumptions define latest bucket and the model already maintains it.
+
+## Assumptions
+
+- `latest_bucket == "matched"` is the authoritative matched signal.
+- `current_state == "active"` is the authoritative active signal.
+- Missing bucket or state mismatch means non-retained.
+- Permanent delete means removal from `job_postings`, not a job-level soft delete.
+- FastAPI background tasks are acceptable async behavior for the local/self-hosted MVP.
+- Logs plus `source_runs` are sufficient operational visibility for MVP.
+- Jobs associated with multiple sources are deleted if any deleted source association exists and the job is not matched+active.
+
+## Risks / Open Questions
+
+- **Durability of background tasks:** FastAPI `BackgroundTasks` are in-process and not durable across process crashes. Mitigation: visibility suppression is immediate; cleanup is idempotent and can be retried. Future: scheduled sweeper or persistent queue.
+- **SourceRun semantic overload:** Reusing `source_runs` for cleanup avoids migration but is not a perfect domain fit. Future: dedicated cleanup task table.
+- **Multi-source deletion semantics:** Current design follows product assumption that any deleted source association subjects the job to cleanup. This may surprise users if an active source also found the same job.
+- **Query consistency:** Every user-facing job surface must use the visibility helper. Missing one surface could leak pending-cleanup jobs.
+- **Race with classification/tracking changes:** Cleanup evaluates current DB state and should re-check retention at final delete. A job that becomes matched+active before final delete should be retained.
+
+## Implementation Notes for Downstream Agents
+
+- Route implementation should be assigned to a **backend agent** with light template updates; frontend-only implementation is insufficient.
+- Add `BackgroundTasks` to both API and HTML source delete handlers.
+- Keep `SourceService.delete_source` focused on source soft-delete and commit; schedule cleanup in route layer after success.
+- Implement a single source of truth for visibility. Do not duplicate ad hoc filters in each route.
+- Tests should create sources, runs, jobs, links, decisions/rules, tracking events, reminders, and digest items directly using SQLAlchemy fixtures.
+- Required test scenarios:
+  - matched+active associated job is retained.
+  - matched+inactive job is deleted.
+  - review/rejected/unclassified active jobs are deleted.
+  - manual_keep/tracking/reminder/digest do not prevent deletion.
+  - source with zero jobs succeeds.
+  - repeated cleanup run is safe and leaves retained jobs intact.
+  - dashboard/job list counts hide non-retained jobs immediately after source soft-delete before cleanup service runs.
+  - job detail returns not found for logically pending-deletion non-retained jobs if adopting recommended detail suppression.
+  - dependent rows are removed for deleted jobs; retained jobs keep their rows.
+  - deleted source does not appear in source list/filter/run endpoints.
+- Prefer explicit delete statements over relying on ORM cascades because relationships/cascades are not fully modeled.
+- Ensure `DELETE /sources/{id}` response schema update remains backward compatible by adding optional/default fields.

--- a/docs/backend/source_delete_job_cleanup_implementation_plan.md
+++ b/docs/backend/source_delete_job_cleanup_implementation_plan.md
@@ -1,0 +1,38 @@
+# Implementation Plan
+
+## 1. Feature Overview
+Implement backend cleanup for deleted sources so associated jobs are asynchronously removed unless they are both `latest_bucket = matched` and `current_state = active`, while pending-cleanup non-retained jobs are hidden immediately.
+
+## 2. Technical Scope
+- Add source-delete cleanup domain service.
+- Add centralized job visibility predicate.
+- Queue cleanup from API and HTML source deletion routes using FastAPI background tasks.
+- Apply visibility filtering to dashboard, jobs, job detail/actions, tracking, reminders, digest display, and notification generation.
+- Add backend tests for retention matrix, idempotency, API response, and immediate visibility.
+
+## 3. Files Expected to Change
+- `app/domain/source_cleanup.py`
+- `app/domain/job_visibility.py`
+- `app/domain/notifications.py`
+- `app/web/routes.py`
+- `app/schemas.py`
+- `tests/unit/test_source_delete_cleanup.py`
+- `tests/unit/test_job_visibility.py`
+- `tests/api/test_source_delete_job_cleanup_api.py`
+- `tests/integration/test_source_delete_job_cleanup_surfaces.py`
+
+## 4. Dependencies / Constraints
+- No schema migration is required; cleanup status uses `source_runs`.
+- Source deletion remains a soft delete via `sources.deleted_at`.
+- Physical job deletion must explicitly remove dependent rows before deleting `job_postings`.
+- Background cleanup must open its own session and not reuse request-scoped sessions.
+
+## 5. Assumptions
+- `JobPosting.latest_bucket` and `JobPosting.current_state` are authoritative for retention.
+- Jobs associated through any deleted source are subject to cleanup, even if also linked to an active source.
+- FastAPI in-process background tasks are sufficient for MVP async behavior.
+
+## 6. Validation Plan
+- Run targeted unit, API, and integration tests for source-delete cleanup.
+- Run existing source edit/delete API tests for regression coverage.
+- Run Python compile validation for modified app/test modules if needed.

--- a/docs/backend/source_delete_job_cleanup_implementation_report.md
+++ b/docs/backend/source_delete_job_cleanup_implementation_report.md
@@ -1,0 +1,48 @@
+# Implementation Report
+
+## 1. Summary of Changes
+Implemented backend source-delete job cleanup. Deleting a source now queues background cleanup, non-retained deleted-source jobs are hidden immediately from backend surfaces, and cleanup permanently deletes eligible jobs plus dependent records while retaining matched active jobs.
+
+QA remediation update: fixed the nullable cleanup retention predicate so unclassified associated jobs are physically deleted, restored JSON-by-default API behavior for TestClient/API callers, corrected dashboard reminder data shape, and addressed source edit/delete HTML regression copy while keeping cleanup metadata limited to the DELETE source API contract.
+
+## 2. Files Modified
+- `app/domain/source_cleanup.py`
+- `app/domain/job_visibility.py`
+- `app/domain/notifications.py`
+- `app/web/routes.py`
+- `app/templates/sources/detail.html`
+- `app/templates/sources/delete_confirm.html`
+- `app/schemas.py`
+- `tests/unit/test_source_delete_cleanup.py`
+- `tests/unit/test_job_visibility.py`
+- `tests/api/test_source_delete_job_cleanup_api.py`
+- `tests/integration/test_source_delete_job_cleanup_surfaces.py`
+- `docs/backend/source_delete_job_cleanup_implementation_plan.md`
+- `docs/backend/source_delete_job_cleanup_implementation_report.md`
+
+## 3. Key Logic Implemented
+- `SourceDeleteCleanupService.cleanup_source(source_id)` discovers jobs associated by primary source or source links, retains only matched active jobs, deletes dependents in the design-specified order, and records `source_runs` cleanup status.
+- Final job deletion now uses an explicit nullable inverse retention predicate so only rows with both `latest_bucket = "matched"` and `current_state = "active"` survive; `NULL` or any other value is deleted.
+- `run_source_delete_cleanup(source_id)` opens a fresh `SessionLocal` session for background execution.
+- `visible_job_predicate()` centralizes immediate visibility: jobs associated with deleted sources are hidden unless matched active.
+- Source deletion API/HTML routes enqueue cleanup after successful source soft-delete and return/flash cleanup queued messaging.
+- Dashboard counts, job list/detail/actions, tracking, reminders, digest latest, digest generation, and reminder generation now exclude pending-cleanup non-retained jobs.
+- API/content negotiation now returns JSON for default `*/*` API/TestClient requests and HTML only when requested by `Accept: text/html` or form flows.
+- Dashboard HTML now receives `reminder_jobs` as a sliceable list matching the template contract.
+
+## 4. Assumptions Made
+- Cleanup failure observability through logs plus `source_runs` is sufficient for MVP.
+- No durable retry queue is introduced; retry safety is handled by idempotent cleanup logic.
+- Source-linked jobs from a deleted source are cleanup-eligible even when another active source also links to them.
+
+## 5. Validation Performed
+- Targeted QA suite passed: `.venv/bin/python -m pytest tests/unit/test_source_delete_cleanup.py tests/unit/test_job_visibility.py tests/api/test_source_delete_job_cleanup_api.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/ui/test_source_edit_delete_ui_qa.py tests/unit/test_source_edit_delete.py tests/api/test_source_edit_delete_qa.py tests/integration/test_source_edit_delete_html.py` → `19 passed`.
+- Syntax validation passed: `.venv/bin/python -m compileall app tests/unit/test_source_delete_cleanup.py tests/api/test_source_delete_job_cleanup_api.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/api/test_source_edit_delete_qa.py tests/integration/test_source_edit_delete_html.py tests/ui/test_source_edit_delete_ui_qa.py`.
+- Whitespace validation passed: `git diff --check`.
+
+## 6. Known Limitations / Follow-Ups
+- FastAPI `BackgroundTasks` are in-process and not durable across process shutdowns; a future sweeper or durable queue could retry failed/missing cleanup runs.
+- The route layer now falls back to the existing `app/web/templates/jobs` files for jobs HTML rendering because `app/templates/jobs` is absent. The broader duplicate/deleted template-file hygiene noted by QA remains a frontend/repository cleanup follow-up.
+
+## 7. Commit Status
+Not committed per user instruction. No push or PR was created.

--- a/docs/frontend/source_delete_job_cleanup_implementation_plan.md
+++ b/docs/frontend/source_delete_job_cleanup_implementation_plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan
+
+## 1. Feature Overview
+Source deletion UI must explain that deleting a source immediately removes it from active configuration and queues asynchronous cleanup for associated jobs. Only jobs that are both Matched and Active may remain visible.
+
+## 2. Technical Scope
+- Update the existing server-rendered source delete confirmation copy.
+- Update the HTML delete success flash copy to align with the backend cleanup behavior.
+- Mark retained deleted-source provenance as historical/non-actionable where source names are displayed in job list/detail templates.
+- Add/update UI tests for copy, flash messaging, deleted source filter exclusion, provenance labeling, and normal not-found handling for non-retained deleted-source jobs.
+
+## 3. UI/UX Inputs
+- `docs/architecture/source_delete_job_cleanup_technical_design.md`
+- `docs/uiux/source_delete_job_cleanup_uiux_spec.md`
+- `docs/product/source_delete_job_cleanup_product_spec.md`
+- `docs/backend/source_delete_job_cleanup_implementation_report.md`
+- `docs/qa/source_delete_job_cleanup_test_plan.md`
+
+## 4. Files Expected to Change
+- `app/web/templates/sources/delete_confirm.html`
+- `app/web/templates/jobs/list.html`
+- `app/web/templates/jobs/detail.html`
+- `app/web/routes.py`
+- `tests/ui/test_source_edit_delete_ui_qa.py`
+- `docs/frontend/source_delete_job_cleanup_implementation_plan.md`
+- `docs/frontend/source_delete_job_cleanup_implementation_report.md`
+
+## 5. Dependencies / Constraints
+- Backend visibility filtering and async cleanup are treated as the source of truth.
+- No progress bars, polling, undo/restore, retry controls, or configurable retention UI should be introduced.
+- Source filters should continue to use only non-deleted sources.
+
+## 6. Assumptions
+- Exact retained/removal counts are not currently available in `DeleteImpactSummary`, so confirmation copy remains rule-based while preserving existing linked/tracked/run stat cards.
+- Deleted-source provenance can be represented with the existing muted badge pattern.
+
+## 7. Validation Plan
+- Run targeted UI tests for source delete UI behavior.
+- Run Python compile validation for changed app/test files if pytest is unavailable.

--- a/docs/frontend/source_delete_job_cleanup_implementation_report.md
+++ b/docs/frontend/source_delete_job_cleanup_implementation_report.md
@@ -1,0 +1,45 @@
+# Implementation Report
+
+## 1. Summary of Changes
+Implemented frontend/template updates for source delete job cleanup. The delete confirmation now warns that cleanup is asynchronous and that only Matched + Active jobs are retained, the post-delete success message states that non-retained jobs are hidden from Dashboard and Jobs, and retained jobs with deleted-source provenance are labeled with a neutral “Deleted source” badge.
+
+QA remediation update: restored the canonical runtime jobs templates under `app/templates/jobs/`, removed the route-level jobs-template fallback, and aligned the `app/templates` source delete confirmation with the UI/UX cleanup copy so the active Jinja search path no longer depends on `app/web/templates/jobs/*` for normal rendering.
+
+## 2. Files Modified
+- `app/web/templates/sources/delete_confirm.html`
+- `app/templates/sources/delete_confirm.html`
+- `app/templates/jobs/list.html`
+- `app/templates/jobs/detail.html`
+- `app/web/templates/jobs/list.html`
+- `app/web/templates/jobs/detail.html`
+- `app/web/routes.py`
+- `tests/ui/test_source_edit_delete_ui_qa.py`
+- `docs/frontend/source_delete_job_cleanup_implementation_plan.md`
+- `docs/frontend/source_delete_job_cleanup_implementation_report.md`
+
+## 3. UI Behavior Implemented
+- Source delete confirmation uses destructive cleanup copy and explicitly states that linked jobs are cleaned up in the background.
+- Confirmation copy states the strict retention rule: only jobs that are both Matched and Active are retained.
+- Success flash states cleanup has started and non-retained jobs are hidden from Dashboard and Jobs immediately.
+- Retained jobs can show deleted-source provenance as historical/non-actionable via a muted “Deleted source” badge in job list and job detail source evidence.
+- Deleted sources remain excluded from normal source filter options; no disabled deleted-source option was added.
+- Jobs HTML now resolves from the primary `app/templates/jobs/` runtime location, matching the rest of the selected `app/templates` design system and avoiding the previous `TemplateNotFound: jobs/list.html` failure mode.
+
+## 4. Assumptions Made
+- The backend provides immediate visibility suppression, so no client-side filtering, polling, or cleanup progress UI was added.
+- Exact “will be removed” and “retained” counts are not available in the existing delete impact summary, so no exact cleanup counts were fabricated.
+- Existing external posting links remain actionable because they target the job posting, not source management or ingestion actions.
+
+## 5. Validation Performed
+- QA remediation validation using the repository `.venv` completed successfully: `.venv/bin/python -m pytest tests/api/test_source_delete_job_cleanup_api.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/ui/test_source_edit_delete_ui_qa.py tests/integration/test_source_edit_delete_html.py` → `11 passed`.
+- Full targeted source cleanup QA suite completed successfully: `.venv/bin/python -m pytest tests/unit/test_source_delete_cleanup.py tests/unit/test_job_visibility.py tests/api/test_source_delete_job_cleanup_api.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/ui/test_source_edit_delete_ui_qa.py tests/unit/test_source_edit_delete.py tests/api/test_source_edit_delete_qa.py tests/integration/test_source_edit_delete_html.py` → `19 passed`.
+- Syntax validation completed successfully: `.venv/bin/python -m compileall app tests/unit/test_source_delete_cleanup.py tests/api/test_source_delete_job_cleanup_api.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/api/test_source_edit_delete_qa.py tests/integration/test_source_edit_delete_html.py tests/ui/test_source_edit_delete_ui_qa.py`.
+- Whitespace validation completed successfully: `git diff --check`.
+
+## 6. Known Limitations / Follow-Ups
+- Stale `/jobs?source_id=<deleted>` currently resets the dropdown by omission of the deleted source option but does not add an explicit informational alert.
+- If product later requires exact pre-delete removal/retention counts, backend impact summary data will need to be extended first.
+- The repository still contains unrelated duplicate `* 2` files and unrelated deleted documentation files noted by QA; those were not changed as part of this scoped remediation.
+
+## 7. Commit Status
+Not committed per user instruction. No push or PR was created.

--- a/docs/product/source_delete_job_cleanup_product_spec.md
+++ b/docs/product/source_delete_job_cleanup_product_spec.md
@@ -1,0 +1,140 @@
+# Product Specification
+
+## 1. Feature Overview
+Add asynchronous job cleanup behavior when a job source is deleted.
+
+When a source is deleted from active configuration, the system must permanently remove jobs associated with that deleted source unless a job is both:
+- classified as `matched`
+- currently `active`
+
+Retained jobs are the only jobs from the deleted source that may continue to exist after cleanup. All other jobs from that source must be permanently deleted from the database and must no longer appear in the job list, dashboard, or related job discovery surfaces.
+
+## 2. Problem Statement
+Deleted sources are currently removed from normal source management, but jobs previously ingested from those sources can remain visible in the Jobs UI and dashboard. This creates stale, misleading data because the user has intentionally removed the source that produced those jobs.
+
+This matters because source deletion should represent a data lifecycle decision, not only a configuration change. Without cleanup, dashboards and job lists continue to show opportunities from sources the user no longer wants, reducing trust in counts, filters, and prioritized job review workflows.
+
+## 3. User Persona / Target User
+- Primary user: the single-user job seeker operating the app locally/self-hosted.
+- Usage context: the user manages job sources, reviews matched jobs, and uses the dashboard/job list as the main surfaces for deciding which opportunities deserve attention.
+
+## 4. User Stories
+- As a job seeker, I want jobs from a deleted source to be cleaned up automatically, so that my job list does not stay cluttered with stale source data.
+- As a job seeker, I want matched active jobs to be retained after deleting a source, so that high-value current opportunities are not accidentally lost.
+- As a job seeker, I want non-matched or inactive jobs from a deleted source to be permanently removed, so that deleted sources do not continue influencing my dashboard.
+- As a job seeker, I want source deletion to complete quickly from the UI while cleanup happens asynchronously, so that I am not blocked by a potentially large data cleanup task.
+- As a job seeker, I want clear feedback that cleanup is queued or in progress, so that I understand any short eventual-consistency window.
+
+## 5. Goals / Success Criteria
+- Deleting a source triggers asynchronous cleanup for jobs associated with that source.
+- Retention rule Option B is enforced exactly: permanently delete source-associated jobs except jobs that are both `matched` and `active`.
+- Deleted jobs do not appear in the dashboard, job list, job detail access, job counts, source-filtered job views, reminders, or digests after cleanup is complete.
+- Normal user-facing job discovery surfaces do not show stale deleted-source jobs during the asynchronous cleanup window, except for retained matched active jobs.
+- Source deletion remains responsive and does not wait synchronously for all related job rows to be deleted.
+- Cleanup behavior is safe to retry and does not delete retained jobs if the cleanup worker runs more than once.
+
+## 6. Feature Scope
+### In Scope
+- Trigger asynchronous cleanup after a source is deleted.
+- Identify all jobs associated with the deleted source through primary source attribution and/or source link attribution.
+- Permanently delete jobs from that source that are not both `matched` and `active`.
+- Retain jobs from that source only when both retention conditions are true.
+- Remove deleted jobs and pending-deletion jobs from dashboard and job list visibility.
+- Ensure related job-owned data does not remain as broken or user-visible orphaned data after permanent deletion.
+- Provide user-visible confirmation that source deletion has occurred and job cleanup has been queued or started.
+- Define eventual-consistency expectations for asynchronous cleanup.
+
+### Out of Scope
+- Undo/restore for deleted sources or deleted jobs.
+- Bulk source deletion.
+- User-configurable retention policies.
+- Archiving deleted jobs instead of permanently deleting them.
+- Reclassifying retained jobs as part of source deletion.
+- Changing ingestion behavior except as needed to prevent deleted sources from being run or reintroducing deleted jobs.
+- Reworking dashboard or job list UI beyond states/copy needed for cleanup visibility and stale-job suppression.
+
+## 7. Functional Requirements
+1. When source deletion is confirmed, the source must be removed from active source configuration immediately according to existing source delete behavior.
+2. When source deletion is confirmed, the system must enqueue or start an asynchronous cleanup task for jobs associated with the deleted source.
+3. A job is considered associated with the deleted source if the source is the job's primary source or if any source-link/provenance record connects the job to that source.
+4. The cleanup task must evaluate each associated job using the retention rule.
+5. A job must be retained only if its latest classification bucket is `matched` and its current job state is `active`.
+6. A job that does not satisfy both retention conditions must be permanently deleted from the database.
+7. Permanent deletion must include or safely remove dependent job data that would otherwise become invalid, including classification records, rule evidence, tracking events, reminders, digest references, and source-link records as applicable.
+8. Retained jobs must remain accessible in normal job surfaces if they otherwise match those surfaces' filters.
+9. Retained jobs must not allow the deleted source to be used for future ingestion, source management, or source filter selection.
+10. Dashboard and job list queries must not show non-retained jobs from deleted sources while cleanup is pending or after cleanup completes.
+11. Job counts and dashboard summaries must exclude non-retained jobs from deleted sources while cleanup is pending or after cleanup completes.
+12. If a user attempts to open a job detail page for a job deleted by cleanup, the system must return the normal not-found behavior.
+13. The asynchronous cleanup task must be idempotent and safe to retry.
+14. Cleanup failures must not roll back the source deletion, but they must be detectable through logs, task state, or an operational error surface available to maintainers/developers.
+
+## 8. Acceptance Criteria
+- AC-01: Given a source with associated jobs, when the user confirms source deletion, the source no longer appears in active source lists, source filters, or future ingestion actions immediately after the delete response.
+- AC-02: Given a deleted source, cleanup is queued or started without requiring the delete request to synchronously delete every associated job before responding.
+- AC-03: Given an associated job with `latest_bucket = matched` and `current_state = active`, when cleanup runs, the job is not deleted.
+- AC-04: Given an associated job with `latest_bucket = matched` and `current_state != active`, when cleanup runs, the job is permanently deleted.
+- AC-05: Given an associated job with `latest_bucket != matched` and `current_state = active`, when cleanup runs, the job is permanently deleted.
+- AC-06: Given an associated job with no current classification bucket, when cleanup runs, the job is permanently deleted.
+- AC-07: Given an associated job with `latest_bucket = review` or `latest_bucket = rejected`, when cleanup runs, the job is permanently deleted regardless of tracking status or manual keep state.
+- AC-08: After cleanup completes, the only remaining jobs associated with the deleted source are jobs that are both matched and active.
+- AC-09: After source deletion is confirmed, non-retained jobs from that source do not appear in the dashboard, job list, or dashboard summary counts, even if physical deletion is still pending.
+- AC-10: After cleanup deletes a job, direct navigation to that job detail URL returns not found and does not render stale job content.
+- AC-11: Retained matched active jobs remain visible in the dashboard/job list when they match the current view filters.
+- AC-12: Retained jobs may display historical source provenance as deleted/retired if provenance is shown, but the deleted source must not expose edit, run, or source-selection actions.
+- AC-13: Running cleanup more than once for the same deleted source does not delete retained matched active jobs and does not produce duplicate failures for already-deleted jobs.
+- AC-14: If cleanup fails after source deletion, the user-facing source deletion remains complete and stale non-retained jobs remain hidden from normal dashboard/job list surfaces until cleanup succeeds or is retried.
+- AC-15: Deleting a source with zero associated jobs completes successfully and does not create a visible cleanup error.
+
+## 9. Edge Cases
+- Source has no associated jobs.
+- Source has only matched active jobs.
+- Source has a mix of matched active, matched inactive, review, rejected, and unclassified jobs.
+- A job is linked to multiple sources, one of which is deleted.
+- A job's primary source is the deleted source but it also has links to other non-deleted sources.
+- A job's primary source is not the deleted source but it has a source link to the deleted source.
+- Source deletion is submitted twice from stale browser state.
+- Cleanup task is retried after partial completion.
+- Cleanup task fails after deleting some but not all eligible jobs.
+- User opens the dashboard or job list immediately after source deletion but before physical cleanup completes.
+- User opens a previously bookmarked job detail URL after that job has been deleted.
+- A digest, reminder, or tracking event references a job selected for deletion.
+- New ingestion attempt is triggered from stale UI after source deletion.
+
+## 10. Constraints
+- Technical constraints:
+  - Existing source deletion is modeled separately from source deactivation; this feature must preserve that distinction.
+  - Existing domain terms include job classification buckets (`matched`, `review`, `rejected`), job `current_state`, source `deleted_at`, and source/job attribution.
+  - Cleanup must be asynchronous and must not make the source delete request depend on deleting all associated jobs inline.
+  - Permanent deletion must avoid orphaned dependent records and broken user-facing pages.
+- UX constraints:
+  - Source delete confirmation and success messaging must make clear that associated jobs will be cleaned up asynchronously.
+  - After confirmation, users should see the source as deleted immediately and should not need to refresh repeatedly to remove stale non-retained jobs from dashboard/job list views.
+  - If a cleanup-in-progress state is exposed, it must be informational and not require user action.
+- Business rules:
+  - Retention rule Option B is mandatory: retain only jobs that are both matched and active.
+  - Tracking status, reminders, manual keep, and digest inclusion do not override the Option B retention rule unless separately changed by future product decision.
+  - Deleted sources must not be eligible for future ingestion.
+
+## 11. Dependencies
+- Existing source edit/delete behavior and deleted-source state.
+- Job persistence model and source attribution records.
+- Classification bucket data for determining `matched` status.
+- Job current state data for determining `active` status.
+- Dashboard queries, job list queries, job detail route, source filters, reminders, and digest references.
+- Background task/job execution mechanism or equivalent asynchronous processing capability.
+- QA data fixtures covering mixed job classifications and states.
+
+## 12. Assumptions
+- A1: `matched` means the job's current/latest classification bucket is `matched`.
+- A2: `active` means the job's current job state is `active`.
+- A3: If a job is missing either required retention signal, it is treated as not retained and is deleted.
+- A4: Permanent deletion means the job record is removed from normal persistence rather than only hidden with a soft-delete flag.
+- A5: Asynchronous cleanup is expected to complete shortly after source deletion under normal local/self-hosted usage; product surfaces must still hide non-retained jobs immediately to avoid stale UI during the cleanup window.
+- A6: Retained jobs may continue to exist even though their source is deleted because they represent high-value current opportunities.
+- A7: This is a new data lifecycle feature, not a regression bugfix.
+
+## 13. Open Questions
+- OQ-01: For jobs linked to multiple sources, should a non-retained job be deleted if any deleted source is associated with it, or should deletion occur only when all associated sources are deleted? Current spec assumes any association to the deleted source makes the job subject to Option B cleanup.
+- OQ-02: Should the user-facing delete confirmation show counts by retention outcome, such as “X jobs will be deleted; Y matched active jobs will be retained,” before deletion is confirmed?
+- OQ-03: Should cleanup task status be exposed in an admin/developer page, or are logs sufficient for this single-user MVP?

--- a/docs/qa/source_delete_job_cleanup_qa_report.md
+++ b/docs/qa/source_delete_job_cleanup_qa_report.md
@@ -1,0 +1,78 @@
+# Test Report
+
+## 1. Execution Summary
+
+- Feature: Source Delete Job Cleanup
+- Branch under validation: `feature/source_delete_job_cleanup`
+- QA date: 2026-04-25
+- Local test environment: repository `.venv` using `.venv/bin/python`
+- QA status: **APPROVED**
+
+### Automated Test Result
+
+- Total pytest tests executed: 19
+- Passed: 19
+- Failed: 0
+
+Command executed:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/unit/test_source_delete_cleanup.py \
+  tests/unit/test_job_visibility.py \
+  tests/api/test_source_delete_job_cleanup_api.py \
+  tests/integration/test_source_delete_job_cleanup_surfaces.py \
+  tests/ui/test_source_edit_delete_ui_qa.py \
+  tests/unit/test_source_edit_delete.py \
+  tests/api/test_source_edit_delete_qa.py \
+  tests/integration/test_source_edit_delete_html.py
+```
+
+Result:
+
+```text
+19 passed in 0.50s
+```
+
+### Static / Compile Checks
+
+- `.venv/bin/python -m compileall app tests/unit/test_source_delete_cleanup.py tests/unit/test_job_visibility.py tests/api/test_source_delete_job_cleanup_api.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/ui/test_source_edit_delete_ui_qa.py tests/unit/test_source_edit_delete.py tests/api/test_source_edit_delete_qa.py tests/integration/test_source_edit_delete_html.py`: PASSED
+- `git diff --check`: PASSED
+
+## 2. Failed Tests
+
+None.
+
+Previous blockers were remediated and did not reproduce:
+- Unclassified associated jobs are now deleted by cleanup.
+- Jobs HTML templates resolve successfully from the runtime template path.
+- Dashboard reminder rendering no longer fails.
+- Existing source edit/delete API and HTML regressions pass.
+
+## 3. Failure Classification
+
+No active failures.
+
+## 4. Acceptance Criteria Coverage Confirmation
+
+Validated coverage from the QA test plan:
+
+- AC-01 / AC-02: Source deletion removes the source from active management and queues cleanup asynchronously via source delete API/HTML flow tests.
+- AC-03 through AC-08: Cleanup unit tests validate retained matched-active jobs, deletion of matched-inactive, review, rejected, and unclassified jobs, dependent record cleanup, and final retained-only state.
+- AC-09 through AC-11: API/integration/UI tests validate immediate suppression from jobs, dashboard counts, job detail, tracking, reminders, digest, and retained matched-active visibility.
+- AC-12: UI tests validate retained deleted-source provenance is labeled as historical/non-actionable and does not expose source edit/run actions.
+- AC-13: Cleanup idempotency/retry behavior is covered by unit tests running cleanup repeatedly.
+- AC-14: Immediate visibility suppression remains independent of physical cleanup completion; operational cleanup status is represented through `source_runs`/logs per design.
+- AC-15: Source delete and cleanup no-op behavior for sources without associated cleanup work is covered through source delete regression and cleanup service paths.
+
+## 5. Observations / Risks / Limitations
+
+- FastAPI `BackgroundTasks` are in-process and not durable across process shutdowns. This is documented as an accepted MVP limitation; immediate visibility suppression mitigates stale user-facing data until cleanup can be retried.
+- Stale `/jobs?source_id=<deleted>` resets by omitting the deleted source option, but no explicit informational alert is shown. This is a documented UX follow-up, not a blocking acceptance criterion for this release.
+- Repository hygiene risk remains: the working tree still includes unrelated duplicate `* 2` files and unrelated deleted historical docs noted in prior QA. These did not affect the passing targeted suite but should be cleaned up before release/merge if not intentional.
+
+## 6. QA Decision
+
+APPROVED
+
+All critical targeted source-delete cleanup tests and related source edit/delete regressions pass. No blocking defects or major regressions were observed in the executed validation scope.

--- a/docs/qa/source_delete_job_cleanup_test_plan.md
+++ b/docs/qa/source_delete_job_cleanup_test_plan.md
@@ -1,0 +1,202 @@
+# Test Plan
+
+## 1. Feature Overview
+
+Feature: source deletion asynchronously cleans up associated jobs while preserving only jobs that are both `latest_bucket = matched` and `current_state = active`.
+
+When a source is deleted, the source must be removed from active configuration immediately, cleanup must be queued/started asynchronously, and normal user-facing surfaces must immediately hide non-retained jobs from the deleted source even before physical deletion completes.
+
+Primary upstream artifacts:
+- Product Spec: `docs/product/source_delete_job_cleanup_product_spec.md`
+- Technical Design: `docs/architecture/source_delete_job_cleanup_technical_design.md`
+- UI/UX Spec: `docs/uiux/source_delete_job_cleanup_uiux_spec.md`
+
+Existing test/tooling alignment observed:
+- Python/FastAPI/SQLAlchemy test stack using `pytest` and `fastapi.testclient.TestClient`.
+- Existing fixture pattern in `tests/conftest.py` creates an in-memory SQLite DB and overrides the app DB dependency.
+- Existing test locations: `tests/unit/`, `tests/api/`, `tests/integration/`, and `tests/ui/`.
+- Relevant prior source delete coverage exists in `tests/unit/test_source_edit_delete.py`, `tests/api/test_source_edit_delete_qa.py`, `tests/integration/test_source_edit_delete_html.py`, and `tests/ui/test_source_edit_delete_ui_qa.py`.
+
+## 2. Acceptance Criteria Mapping
+
+| AC | Requirement | Planned Coverage |
+|---|---|---|
+| AC-01 | Deleted source disappears from active source lists, filters, and ingestion actions immediately. | API, HTML/UI, and integration tests for source list, jobs source filter, source detail/run/delete endpoints after deletion. |
+| AC-02 | Cleanup is queued/started without synchronously deleting every associated job before response. | API tests asserting delete response includes cleanup queued/status fields and background task scheduling hook is called; integration test verifies response completes while cleanup can be controlled/mocked separately. |
+| AC-03 | Associated matched active job is retained. | Unit cleanup service test and integration surface test. |
+| AC-04 | Associated matched inactive/non-active job is permanently deleted. | Unit cleanup service data matrix and API/integration cleanup verification. |
+| AC-05 | Associated non-matched active job is permanently deleted. | Unit cleanup service data matrix for `review`, `rejected`, and other non-matched buckets. |
+| AC-06 | Associated job with no current classification bucket is permanently deleted. | Unit cleanup service data matrix with `latest_bucket = None`. |
+| AC-07 | Review/rejected jobs are deleted regardless of tracking/manual keep/reminders/digest. | Unit/integration tests with tracking events, reminders, digest items, and manual keep/tracking status. |
+| AC-08 | After cleanup, only matched active jobs remain associated with deleted source. | Unit cleanup verification querying `job_postings` and `job_source_links` after cleanup. |
+| AC-09 | Pending-cleanup non-retained jobs do not appear in dashboard, job list, or summary counts. | Integration/UI tests soft-delete source without running cleanup, then assert dashboard/jobs/counts hide non-retained jobs immediately. |
+| AC-10 | Deleted job detail URL returns normal not-found. | API and HTML detail tests after cleanup and during pending-cleanup logical-hide window. |
+| AC-11 | Retained matched active jobs remain visible when filters match. | Integration/UI tests for dashboard/jobs/detail with retained job. |
+| AC-12 | Retained jobs may show deleted source provenance as historical/non-actionable. | UI tests for retained job detail/source evidence: deleted label if shown; no run/edit/source-management action for deleted source. |
+| AC-13 | Cleanup is idempotent and retry-safe. | Unit test invoking cleanup twice and after partial pre-deletion; assert retained job remains and no duplicate/uncaught failures. |
+| AC-14 | Cleanup failure does not roll back source deletion; stale jobs remain hidden. | Unit/API failure injection test; integration visibility test after simulated cleanup failure. |
+| AC-15 | Source with zero associated jobs deletes successfully without visible cleanup error. | API and UI tests for empty-source delete flow and cleanup no-op success. |
+
+## 3. Test Scenarios
+
+### 3.1 Backend Unit Tests
+
+Recommended files:
+- `tests/unit/test_source_delete_cleanup.py`
+- `tests/unit/test_job_visibility.py`
+
+Coverage:
+1. Cleanup association discovery selects distinct jobs where either:
+   - `job_postings.primary_source_id = deleted_source_id`, or
+   - `job_source_links.source_id = deleted_source_id`.
+2. Cleanup retention rule is strict: retain only `matched` + `active`.
+3. Cleanup permanently deletes non-retained jobs from `job_postings`.
+4. Cleanup deletes dependent job-owned rows for deleted jobs:
+   - `job_decision_rules`
+   - `job_decisions`
+   - `job_tracking_events`
+   - `reminders`
+   - `digest_items`
+   - `job_source_links`
+5. Cleanup preserves retained matched active job rows and their valid dependent rows.
+6. Cleanup creates or updates operational status/audit records as designed, including `source_runs.trigger_type = source_delete_cleanup`, success/failure state, counts, and error details where applicable.
+7. Cleanup no-ops safely when source does not exist or source is not deleted.
+8. Cleanup is idempotent when run multiple times for the same deleted source.
+9. Cleanup re-checks retention at final delete, preserving a job that becomes matched active between selection and final deletion.
+10. Visibility helper implements: visible if no associated deleted source OR job is matched active.
+
+### 3.2 Backend API Tests
+
+Recommended file:
+- `tests/api/test_source_delete_job_cleanup_api.py`
+
+Coverage:
+1. `DELETE /sources/{source_id}` soft-deletes the source and returns existing fields plus cleanup queued/status fields, without breaking backward-compatible fields.
+2. `DELETE /sources/{source_id}` schedules cleanup via background task after successful source deletion.
+3. Deleted or nonexistent source delete still returns normal not-found behavior and does not queue duplicate cleanup.
+4. Deleted source is absent from source list/detail/run/update APIs according to existing deletion semantics.
+5. Jobs API `/jobs` excludes pending-cleanup non-retained jobs immediately after source deletion.
+6. Jobs API `/jobs/{job_id}` returns 404 for non-retained jobs during pending-cleanup state and after physical deletion.
+7. Jobs API `/jobs/{job_id}` returns 200 for retained matched active jobs.
+8. Source filter behavior excludes deleted source IDs; stale `source_id=<deleted>` does not expose hidden jobs.
+9. Tracking/reminder/digest APIs do not return non-retained deleted-source jobs during pending cleanup or after cleanup.
+
+### 3.3 Integration / Regression Tests
+
+Recommended files:
+- `tests/integration/test_source_delete_job_cleanup_surfaces.py`
+- Add focused regression coverage to existing source edit/delete integration tests only if needed.
+
+Coverage:
+1. End-to-end delete flow with mixed job data:
+   - create source
+   - create jobs with all retention matrix combinations
+   - create source links/dependent rows
+   - delete source
+   - verify immediate UI/API suppression before cleanup completes
+   - run cleanup service
+   - verify physical database deletion and retained job visibility
+2. Dashboard cards/counts/recent jobs exclude non-retained jobs immediately after source soft-delete.
+3. Jobs list bucket/status/search/source filters do not reveal non-retained jobs.
+4. Tracking page excludes deleted-source non-retained jobs.
+5. Reminder and digest display/generation exclude invisible jobs and tolerate missing/deleted job references.
+6. Multi-source behavior follows product assumption: any association to the deleted source makes non-retained jobs cleanup-eligible, even if another active source is also linked.
+7. Source deletion failure path leaves jobs unchanged and shows no cleanup success messaging.
+8. Cleanup failure path leaves source deleted, logs/status records failure, and keeps pending-cleanup jobs hidden from user surfaces.
+
+### 3.4 Frontend / UI Tests
+
+Recommended file:
+- `tests/ui/test_source_delete_job_cleanup_ui.py`
+
+Coverage:
+1. Source delete confirmation page copy warns that most associated jobs are permanently removed and only matched active jobs are retained.
+2. If impact counts are implemented, confirmation page shows linked, will-be-removed, and retained counts accurately.
+3. If exact counts are not implemented, confirmation page uses rule-based copy and does not fabricate counts.
+4. Post-delete flash/alert states that cleanup has started/queued and non-retained jobs are hidden from Dashboard and Jobs now.
+5. Source list no longer displays deleted source after redirect.
+6. Jobs source dropdown excludes deleted source.
+7. Stale `/jobs?source_id=<deleted>` resets/ignores deleted source and does not show deleted-source non-retained jobs; if alert is implemented, assert visible reset copy.
+8. Dashboard/jobs pages show retained matched active jobs and hide all non-retained jobs immediately.
+9. Retained job detail may show deleted-source provenance with neutral “Deleted source” label and must not render edit/run/source-management actions for that deleted source.
+10. Deleted job detail page returns normal not-found content/status.
+11. Accessibility checks for destructive warning text, explicit “Delete source” button label, keyboard-reachable actions, and status/error alert roles where existing pattern supports them.
+
+## 4. Edge Cases
+
+### 4.1 Data Setup Matrix
+
+Use source `deleted_source` plus at least one `active_source` for multi-source cases. For every row, validate both immediate visibility after source soft-delete and final database state after cleanup.
+
+| Case | Association | `latest_bucket` | `current_state` | Extra state | Expected visibility after source delete before cleanup | Expected after cleanup |
+|---|---|---:|---:|---|---|---|
+| M1 | Primary deleted source | matched | active | none | Visible if filters match | Retained |
+| M2 | Source link only | matched | active | none | Visible if filters match | Retained |
+| M3 | Primary + link duplicate | matched | active | none | Visible once | Retained once/no duplicate processing |
+| D1 | Primary deleted source | matched | inactive/closed | none | Hidden | Permanently deleted |
+| D2 | Primary deleted source | matched | `None` or non-active | none | Hidden | Permanently deleted |
+| D3 | Primary deleted source | review | active | none | Hidden | Permanently deleted |
+| D4 | Primary deleted source | rejected | active | none | Hidden | Permanently deleted |
+| D5 | Primary deleted source | `None` | active | unclassified | Hidden | Permanently deleted |
+| D6 | Source link only | review | active | none | Hidden | Permanently deleted |
+| D7 | Deleted source + active source links | review | active | multi-source | Hidden | Permanently deleted per product assumption |
+| D8 | Primary deleted source + active source link | rejected | active | multi-source | Hidden | Permanently deleted per product assumption |
+| D9 | Primary deleted source | matched | active | changes to inactive before cleanup | Hidden once non-retained | Permanently deleted if cleanup sees inactive |
+| R1 | Primary deleted source | review | active | manual keep/tracked/saved | Hidden | Permanently deleted |
+| R2 | Primary deleted source | rejected | active | reminder + digest item | Hidden | Job and dependent records deleted |
+| Z1 | Deleted source | n/a | n/a | zero jobs | No jobs affected | Cleanup no-op success |
+
+### 4.2 Async Cleanup Verification
+
+1. Assert source delete response/redirect completes before physical job cleanup is required.
+2. In tests, control background execution by mocking/stubbing the cleanup task or calling the cleanup service manually after asserting pending-cleanup visibility.
+3. Verify the background task receives primitive source ID and uses a fresh DB session, not request-scoped session state.
+4. Verify operational evidence exists after cleanup success/failure (`source_runs` and/or logs per implementation).
+5. Verify retry safety by running cleanup repeatedly against already-cleaned source and against partially cleaned data.
+
+### 4.3 Immediate Visibility Verification
+
+Before running cleanup, after only `sources.deleted_at` is committed:
+- `/dashboard` does not count or render non-retained jobs.
+- `/jobs` does not return/render non-retained jobs.
+- `/jobs/{non_retained_job_id}` returns not found.
+- `/tracking`, `/reminders`, and `/digest/latest` do not return/render non-retained jobs.
+- Source filter dropdown and source list do not include deleted source.
+- Retained matched active jobs remain visible and accessible.
+
+### 4.4 Negative and Failure Scenarios
+
+1. Duplicate/stale source delete submit returns normal not-found/already-deleted behavior and does not queue duplicate user-visible cleanup.
+2. Cleanup exception after source deletion records failure; source remains deleted; non-retained jobs remain hidden.
+3. Missing classification or missing current state is treated as non-retained.
+4. Jobs with dependent records are deleted without orphaned dependent rows.
+5. Digest/reminder/tracking references to deleted jobs do not break page rendering or generation.
+6. Deleted source cannot be run from stale UI/API.
+7. Cleanup for non-deleted source does not delete jobs.
+8. Logging/status output should include IDs/counts/status but not full job descriptions or raw payloads.
+
+## 5. Test Types Covered
+
+- Functional correctness: source deletion, retention/deletion rules, association discovery, physical cleanup.
+- Validation and negative scenarios: nonexistent/already-deleted source, stale source filter, direct deleted job URL, cleanup failure.
+- Edge cases: zero jobs, all retained jobs, all deleted jobs, mixed jobs, multi-source attribution, duplicate attribution, missing bucket/state.
+- API/UI consistency: API responses and server-rendered pages must apply the same visibility rule.
+- Integration/regression: dashboard, jobs list/detail, tracking, reminders, digest, source list/filter/run actions.
+- Basic reliability: async behavior, idempotent retry, partial cleanup recovery, failure observability.
+- Basic security/safety: no actionable deleted-source controls; logs/status do not expose full sensitive job payloads; destructive action remains explicit.
+
+Recommended commands once tests are implemented:
+
+```bash
+pytest tests/unit/test_source_delete_cleanup.py tests/unit/test_job_visibility.py
+pytest tests/api/test_source_delete_job_cleanup_api.py
+pytest tests/integration/test_source_delete_job_cleanup_surfaces.py
+pytest tests/ui/test_source_delete_job_cleanup_ui.py
+pytest tests/unit tests/api tests/integration tests/ui
+```
+
+QA sign-off gate for this feature:
+- All critical retention/deletion, immediate visibility, and idempotency tests pass.
+- No user-facing surface leaks non-retained pending-cleanup jobs.
+- Cleanup failure does not roll back source deletion and remains observable.
+- Retained matched active jobs remain available without actionable deleted-source controls.

--- a/docs/release/source_delete_job_cleanup_issue.md
+++ b/docs/release/source_delete_job_cleanup_issue.md
@@ -1,0 +1,93 @@
+# GitHub Issue
+
+## 1. Feature Name
+Source Delete Job Cleanup
+
+## 2. Problem Summary
+Deleted sources are removed from active source management, but jobs previously ingested from those sources can remain visible in job lists, dashboard counts, reminders, digests, and direct job detail views. This creates stale and misleading data after the user has intentionally removed a source.
+
+The planned feature adds asynchronous cleanup after source deletion: permanently delete jobs associated with the deleted source except jobs that are both `matched` and `active`. Non-retained jobs must be hidden from normal user-facing surfaces immediately after source deletion, even while physical cleanup is still pending.
+
+## 3. Linked Planning Documents
+- Product Spec: `docs/product/source_delete_job_cleanup_product_spec.md`
+- Technical Design: `docs/architecture/source_delete_job_cleanup_technical_design.md`
+- UI/UX Spec: `docs/uiux/source_delete_job_cleanup_uiux_spec.md`
+- QA Test Plan: `docs/qa/source_delete_job_cleanup_test_plan.md`
+
+## 4. Scope Summary
+- in scope
+  - Trigger asynchronous job cleanup after a source is deleted.
+  - Permanently delete source-associated jobs unless they are both `matched` and `active`.
+  - Identify source-associated jobs by primary source attribution and source-link/provenance records.
+  - Hide non-retained deleted-source jobs from dashboard, job list, job detail, tracking, reminders, digest, source filters, and counts immediately after source deletion.
+  - Retain matched active jobs and treat the deleted source as historical/non-actionable provenance.
+  - Ensure cleanup is idempotent, retry-safe, and observable through logs and/or operational status.
+- out of scope
+  - Undo or restore for deleted sources or deleted jobs.
+  - Bulk source deletion.
+  - User-configurable retention policies.
+  - Archiving jobs instead of permanent deletion.
+  - Reclassifying retained jobs as part of source deletion.
+  - Major dashboard or job list redesign beyond required copy and visibility behavior.
+  - New admin cleanup UI for the MVP unless later required.
+
+## 5. Implementation Notes
+- frontend expectations
+  - Update source delete confirmation copy to explain permanent cleanup and matched-active retention.
+  - Update post-delete success messaging to state cleanup has queued/started and non-retained jobs are hidden from Dashboard and Jobs immediately.
+  - Keep existing server-rendered UI patterns; do not add client-side polling or filtering unless a later decision adds explicit cleanup status.
+  - Ensure deleted sources are absent from source filters and actionable source controls.
+  - If retained job provenance displays a deleted source, label it as historical/deleted and non-actionable.
+- backend expectations
+  - Preserve existing source soft-delete behavior using `deleted_at`/inactive source state.
+  - Queue or start cleanup asynchronously after successful source deletion commit.
+  - Add cleanup service logic to discover associated jobs, apply the strict `latest_bucket == matched` and `current_state == active` retention rule, delete non-retained jobs and dependent job-owned rows, and record operational status.
+  - Centralize visibility rules so user-facing job surfaces exclude pending-cleanup non-retained jobs before physical deletion completes.
+  - Ensure direct access to non-retained deleted-source jobs returns normal not-found behavior during the pending-cleanup window and after deletion.
+- dependencies or blockers
+  - Existing source delete flow and `sources.deleted_at` semantics.
+  - Job attribution through `job_postings.primary_source_id` and `job_source_links.source_id`.
+  - Classification and state fields: `latest_bucket` and `current_state`.
+  - Background task mechanism, recommended as FastAPI `BackgroundTasks` for MVP.
+  - Dependent job-owned tables such as decisions, decision rules, tracking events, reminders, digest items, and source links.
+  - Open product question for multi-source jobs: current planning assumes any association to the deleted source makes a non-retained job cleanup-eligible.
+
+## 6. QA Section
+- planned test coverage
+  - Unit tests for cleanup association discovery, retention/deletion matrix, dependent row cleanup, idempotency, retry safety, and visibility helper behavior.
+  - API tests for source deletion response, cleanup scheduling, hidden pending-cleanup jobs, retained matched active jobs, deleted job not-found behavior, and deleted source filtering.
+  - Integration tests for mixed job data across dashboard, jobs list/detail, tracking, reminders, digests, source list, and cleanup success/failure paths.
+  - UI tests for delete confirmation copy, post-delete alert copy, source filter behavior, retained job deleted-source provenance, and normal not-found content for deleted jobs.
+- acceptance criteria mapping
+  - AC-01 through AC-02: verify immediate source removal and asynchronous cleanup scheduling.
+  - AC-03 through AC-08: verify strict retention/deletion outcomes and final database state.
+  - AC-09 through AC-12: verify immediate UI/API visibility suppression, retained job visibility, and non-actionable deleted-source provenance.
+  - AC-13 through AC-15: verify idempotent retry behavior, cleanup failure handling, and zero-associated-job behavior.
+- key edge cases
+  - Source has no associated jobs.
+  - Source has only matched active jobs.
+  - Source has mixed matched active, matched inactive, review, rejected, and unclassified jobs.
+  - Job is associated by primary source, source link only, or duplicate primary/link attribution.
+  - Job is linked to both deleted and active sources.
+  - Cleanup is retried after partial completion or failure.
+  - User opens dashboard, jobs list, stale source filter, or bookmarked job detail immediately after source deletion.
+  - Job selected for deletion has reminders, digest items, tracking events, decisions, or rule evidence.
+- test types expected
+  - Unit, API, integration, UI, regression, negative/failure, async behavior, idempotency, and data cleanup tests.
+
+## 7. Risks / Open Questions
+- Multi-source cleanup policy needs confirmation: should any association to a deleted source make a non-retained job cleanup-eligible, or only when all associated sources are deleted?
+- Pre-delete impact counts may require extra query work; if not implemented, UI copy must explain the rule without fabricating counts.
+- Cleanup status visibility is planned through logs and/or existing operational records; a dedicated admin retry/status UI is out of scope for MVP.
+- Physical deletion must remove dependent rows safely to avoid orphaned data and broken reminders/digests.
+- Immediate visibility filtering must be applied consistently across all job surfaces to avoid stale data leaks during the async cleanup window.
+
+## 8. Definition of Done
+- Planning documents are complete and linked from this issue.
+- Source delete flow queues or starts asynchronous cleanup after source deletion is committed.
+- Cleanup permanently deletes all associated non-retained jobs and dependent job-owned records.
+- Only jobs that are both `matched` and `active` remain from the deleted source.
+- Dashboard, job list, job detail, tracking, reminders, digest, source filters, and counts hide non-retained deleted-source jobs immediately after deletion.
+- Retained matched active jobs remain visible when filters match and deleted source provenance is historical/non-actionable.
+- Cleanup is idempotent, retry-safe, and observable through logs and/or operational status.
+- QA test coverage for the planned acceptance criteria and edge cases is implemented and passing before implementation release.

--- a/docs/release/source_delete_job_cleanup_pr.md
+++ b/docs/release/source_delete_job_cleanup_pr.md
@@ -1,0 +1,42 @@
+# Pull Request
+
+## 1. Feature Name
+Source Delete Job Cleanup
+
+## 2. Summary
+Adds asynchronous cleanup after source deletion so non-retained jobs from deleted sources are removed or hidden immediately from user-facing surfaces. Retains only jobs that are both Matched and Active, while marking deleted-source provenance as historical/non-actionable.
+
+Closes #5.
+
+## 3. Related Documents
+- Product Spec: docs/product/source_delete_job_cleanup_product_spec.md
+- Technical Design: docs/architecture/source_delete_job_cleanup_technical_design.md
+- UI/UX Spec: docs/uiux/source_delete_job_cleanup_uiux_spec.md
+- QA Test Plan: docs/qa/source_delete_job_cleanup_test_plan.md
+- QA Report: docs/qa/source_delete_job_cleanup_qa_report.md
+- Backend Report: docs/backend/source_delete_job_cleanup_implementation_report.md
+- Frontend Report: docs/frontend/source_delete_job_cleanup_implementation_report.md
+- Planning Issue Artifact: docs/release/source_delete_job_cleanup_issue.md
+
+## 4. Changes Included
+- Queues source-delete cleanup from API and HTML source deletion flows using FastAPI background tasks.
+- Adds cleanup service logic to delete non-retained source-associated jobs and dependent records while keeping matched active jobs.
+- Centralizes visible-job filtering for dashboard, jobs, job detail, tracking, reminders, and digest surfaces during pending cleanup.
+- Updates delete confirmation and success copy to explain cleanup behavior and retention rules.
+- Labels retained deleted-source provenance as historical/deleted and removes deleted sources from actionable filters/controls.
+- Adds targeted unit, API, integration, and UI regression tests plus product/design/implementation/QA/release artifacts.
+
+## 5. QA Status
+- Approved: YES
+- QA sign-off: [QA SIGN-OFF APPROVED]
+
+## 6. Test Coverage
+- Targeted pytest suite: 19 passed.
+- Compile check passed for application code and targeted tests.
+- `git diff --check` passed.
+- Coverage includes cleanup retention/deletion matrix, dependent row cleanup, idempotency, visibility filtering, API delete response, dashboard/jobs/tracking/reminders/digest behavior, delete copy, success messaging, and retained provenance labeling.
+
+## 7. Risks / Notes
+- FastAPI `BackgroundTasks` are in-process and not durable across process shutdowns; immediate visibility suppression mitigates stale user-facing data until cleanup can be retried.
+- Stale `/jobs?source_id=<deleted>` filters reset by omitting deleted source options; no explicit informational alert is shown in this MVP.
+- Unrelated duplicate `* 2` files and unrelated deleted historical docs remain intentionally unstaged and are not part of this release.

--- a/docs/uiux/source_delete_job_cleanup_uiux_spec.md
+++ b/docs/uiux/source_delete_job_cleanup_uiux_spec.md
@@ -1,0 +1,261 @@
+# Design Specification
+
+## 1. Feature Overview
+
+Source deletion now starts asynchronous cleanup of jobs associated with the deleted source. The UI must communicate that deletion is immediate, cleanup may continue briefly in the background, and only jobs that are both `matched` and `active` can remain visible.
+
+This specification applies to the existing server-rendered Jinja UI surfaces:
+- Source list, source detail, and source delete confirmation
+- Jobs list and source filter
+- Dashboard stat cards and recent job cards
+- Job detail source evidence
+- Standard flash/alert, empty state, badge, button, and callout patterns
+
+Assumption: backend/query changes will hide pending-deletion jobs immediately; frontend should not add client-side filtering or polling unless a future product decision adds explicit cleanup status.
+
+## 2. User Goal
+
+As a job seeker, when I delete a source, I want stale jobs from that source removed from my working views immediately while important matched active opportunities are preserved, so my dashboard and job list stay trustworthy without making me wait for physical cleanup.
+
+## 3. UX Rationale
+
+- Deleting a source is a data lifecycle action, not only a configuration action. The confirmation must warn that most linked jobs will be permanently removed.
+- The user should not need to understand background workers. The UI should confirm that cleanup has started and that working views already exclude stale jobs.
+- Retained matched active jobs should remain useful, but their deleted source must not feel actionable or available for ingestion.
+- Existing UI patterns are intentionally lightweight: server-rendered pages, stat cards, tables/cards, callouts, and global flash alerts. This feature should extend copy and states rather than introduce a new dashboard subsystem.
+
+## 4. Information Hierarchy
+
+### Source delete confirmation page
+1. Page title: “Delete source”
+2. Source name being deleted
+3. Destructive warning and permanent cleanup rule
+4. Impact summary cards
+5. Plain-language retention/deletion explanation
+6. Primary destructive action: “Delete source”
+7. Secondary action: “Cancel”
+
+### Post-delete global feedback
+1. Success alert that source was deleted
+2. Cleanup status statement: queued/started in background
+3. Immediate outcome statement: non-retained jobs are removed from dashboard/jobs views now
+
+### Jobs and dashboard after deletion
+1. Counts/cards reflect only visible eligible jobs
+2. Deleted-source non-retained jobs are absent
+3. Retained matched active jobs may remain with normal bucket/tracking/status controls
+4. Deleted source is not present in source filters or source actions
+
+### Job detail for retained jobs
+1. Job content remains accessible
+2. Source evidence may show deleted source as historical/deleted/retired provenance if available
+3. No edit/run/source-management action is offered for the deleted source
+
+## 5. Layout Structure
+
+### Source deletion confirmation
+Use the existing `panel panel-narrow` layout.
+
+Recommended structure:
+```text
+Page header
+└─ Title: Delete source
+└─ Description: Review cleanup impact before removing this source.
+
+Panel
+├─ Intro sentence: You are about to delete <source name>.
+├─ Danger callout: permanent cleanup warning
+├─ Impact stat cards
+│  ├─ Linked jobs
+│  ├─ Will be removed (if count available)
+│  └─ Matched active retained (if count available)
+├─ Cleanup explanation copy
+└─ Action row
+   ├─ Delete source
+   └─ Cancel
+```
+
+If backend cannot provide precomputed removal/retention counts, keep current stat cards but update copy to describe the rule without exact numbers.
+
+### Dashboard
+No new persistent cleanup widget is required. Existing stat cards and recent job sections must update to exclude non-retained jobs from deleted sources immediately after the delete response. If the delete action redirects to dashboard or sources with a flash message, use the existing `.alert-success` or `.alert-info` pattern.
+
+### Jobs list
+Keep existing filter panel and table/mobile card layouts. The source dropdown must include active/configured non-deleted sources only. Do not show deleted sources as filter options.
+
+### Job detail retained source evidence
+Within the existing “Source evidence” panel, if provenance for a deleted source is shown, label it as historical/deleted inline near the source name.
+
+Recommended row format:
+```text
+<Source name>  [Deleted source]
+External job id: … · Last seen …
+Open posting
+```
+
+The “Deleted source” label should be informational and non-actionable.
+
+## 6. Components
+
+### Danger callout: source cleanup warning
+- Component: existing `.callout.callout-danger`
+- Recommended copy:
+  - Heading: “This permanently removes most jobs from this source”
+  - Body: “Deleting this source removes it from source management and future ingestion immediately. Jobs linked to this source will be cleaned up in the background. Only jobs that are both Matched and Active will be retained.”
+
+### Impact stat cards
+- Component: existing `ui.stat_card`
+- Required if data is available:
+  - “Linked jobs” = all jobs associated with source
+  - “Will be removed” = associated jobs not both matched and active
+  - “Retained” = associated jobs both matched and active
+- If exact counts are unavailable, do not fabricate counts. Use existing “Linked jobs”, “Tracked jobs”, and “Runs” cards with updated explanatory text.
+
+### Cleanup explanation block
+- Component: existing `.stack-list.delete-impact-copy` or paragraphs inside panel
+- Recommended copy variants:
+  - With counts: “{N} job(s) will be removed from Jobs, Dashboard, reminders, and digests immediately after deletion while physical cleanup finishes in the background.”
+  - With retained jobs: “{N} matched active job(s) will remain visible if they match your filters. Their source will be treated as deleted and cannot be run again.”
+  - No linked jobs: “No linked jobs were found. Deleting this source only removes the source configuration and future ingestion access.”
+
+### Success alert after deletion
+- Component: existing `ui.alert(level, message)` with `level='success'` or `level='info'`
+- Recommended copy:
+  - “Source deleted. Job cleanup has started; non-retained jobs from this source are hidden from Dashboard and Jobs now. Matched active jobs may remain.”
+
+### Deleted source badge/label for retained job provenance
+- Component: existing badge pattern or muted text
+- Recommended label: “Deleted source”
+- Tone: muted/neutral, not danger, because retained jobs are intentionally preserved.
+- Do not make the badge clickable.
+
+## 7. Interaction Behavior
+
+### Expected delete flow
+1. User opens Sources list or Source detail.
+2. User selects “Delete” / “Delete source”.
+3. Confirmation page opens.
+4. User reviews cleanup warning and impact summary.
+5. User clicks “Delete source”.
+6. Button enters submitting/loading state if supported by current form behavior.
+7. Server confirms deletion and redirects to an appropriate page, preferably Sources list.
+8. A success alert appears with cleanup messaging.
+9. Deleted source disappears from active source list, source filter dropdowns, source health action lists, and run actions.
+10. Dashboard and Jobs list exclude non-retained jobs immediately.
+11. Matched active retained jobs remain visible when they match active filters.
+
+### Filters
+- If a user had a deleted source selected in the URL (`/jobs?source_id=<deleted>`), the source filter must not retain that deleted option.
+- Preferred behavior: ignore the deleted source filter and show current valid results with either:
+  - an info alert: “That source was deleted, so the source filter was cleared.”, or
+  - source select reset to “All sources”.
+- Do not show a disabled deleted source option in normal filters.
+
+### Direct navigation to deleted job detail
+- Use normal not-found behavior. Do not render stale job content or a custom recovery flow.
+
+### Cleanup in progress
+- The UI may mention cleanup is in progress/queued via flash after deletion.
+- Do not require the user to monitor cleanup or manually retry from normal product surfaces.
+- Do not block navigation while cleanup is pending.
+
+## 8. Component States
+
+### Delete confirmation page
+- Default: source name, warning, impact summary, Delete and Cancel actions visible.
+- Hover: existing button/link hover behavior.
+- Focus: existing `:focus-visible` outline; Delete and Cancel must be keyboard reachable.
+- Active/submitting: if implemented, disable the Delete button after submit and update text to “Deleting…” to prevent duplicate submission.
+- Disabled: Delete button should only be disabled while submit is in progress, not because cleanup counts are unavailable.
+- Loading: no full-page loader required. Server-rendered form submission is acceptable.
+- Empty/no linked jobs: show “No linked jobs found. No job cleanup is needed.”
+- Success: redirect with success alert; source removed from lists.
+- Error: if source deletion fails, stay on/return to confirmation or source detail with `.alert-error`: “Source could not be deleted. No jobs were changed.”
+
+### Dashboard
+- Default: stat cards and recent job lists exclude non-retained jobs from deleted sources.
+- Loading: existing page load only; no skeleton required.
+- Empty after cleanup: use existing empty states. If all jobs were removed but sources remain, “No jobs yet” copy is acceptable, but preferred contextual copy is “No reviewable jobs remain after source cleanup. Run an active source to add new jobs.”
+- Error: if dashboard query fails, use existing error handling; do not expose cleanup internals to the end user.
+
+### Jobs list
+- Default: source filter lists non-deleted sources only; table/cards exclude non-retained jobs from deleted sources.
+- Empty after source deletion/filter reset: existing empty state is acceptable. Preferred copy if a cleanup flash is present: “No jobs match the current view. Jobs from the deleted source were removed unless they were matched and active.”
+- Retained job row: displays as a normal matched active job. If source name is displayed and refers to the deleted source, append neutral text “Deleted source” where feasible.
+- Error: stale bookmarked job detail returns normal not-found.
+
+### Retained job source evidence
+- Default: show source provenance as historical information.
+- Hover/focus: external posting link follows existing link styling.
+- Disabled/no action: no edit/run/source details link for deleted source.
+- Empty: if source links were cleaned up, show existing “No source provenance records available.”
+
+## 9. Responsive Design Rules
+
+- Preserve existing breakpoints:
+  - `max-width: 980px`: grids reduce to two columns.
+  - `max-width: 720px`: grids reduce to one column; jobs table hides and mobile cards show.
+- Delete confirmation impact cards should follow `.import-summary-grid` behavior: 4 columns desktop, 2 columns tablet, 1 column mobile.
+- Action rows must wrap using `.button-row-wrap`; destructive and cancel buttons should remain full tap targets.
+- Do not add horizontal-only cleanup status content. All explanatory text must wrap within the panel.
+- On mobile job cards, if a retained deleted-source label is shown, place it in the muted metadata line after source name or in the existing badge stack.
+
+## 10. Visual Design Tokens
+
+Use existing tokens from `app/web/static/styles.css`:
+
+- Background: `--bg #f5f7fb`
+- Surface: `--surface #ffffff`
+- Muted surface: `--surface-muted #eef2f7`
+- Text: `--text #162032`
+- Muted text: `--text-muted #5d6b82`
+- Border: `--border #d7dfeb`
+- Primary/info: `--primary #3157d5`
+- Matched/success: `--matched #1f8f5f`
+- Review/warning: `--review #a66a00`
+- Rejected/danger: `--rejected #b53737`
+- Radius: `--radius 14px`
+- Shadow: `--shadow 0 10px 28px rgba(15, 23, 42, 0.06)`
+
+Tone guidance:
+- Confirmation warning: danger callout (`callout-danger`) because deletion is permanent.
+- Post-delete success: success alert with explanatory text.
+- Cleanup-in-progress information: info alert/callout if shown separately.
+- Retained deleted-source provenance: muted or neutral badge, not red.
+
+## 11. Accessibility Requirements
+
+- Destructive warning must be text, not color-only. Include explicit words such as “permanently removes” and “Only matched active jobs are retained.”
+- Global deletion success message should use existing alert role behavior (`role="status"`) so screen reader users receive feedback after redirect.
+- If an error occurs, use `.alert-error`; error copy must state that no jobs were changed if delete failed.
+- Delete and Cancel controls must be reachable by keyboard and have visible focus outlines.
+- The Delete button label must remain explicit: “Delete source”; avoid ambiguous labels like “Confirm”.
+- If submit-loading is added, expose the state via button text (“Deleting…”) and `disabled` to prevent duplicate submissions.
+- Source filter reset after a deleted-source URL must be communicated with visible text or alert; do not silently leave screen reader users with changed results and no context.
+- Badge/label “Deleted source” must have sufficient contrast and should not rely on color alone.
+- External posting links on retained jobs must preserve `target="_blank"` and `rel="noreferrer"` patterns where already used.
+
+## 12. Edge Cases
+
+- Source has zero linked jobs: deletion succeeds; show no cleanup error; confirmation says no job cleanup is needed.
+- Source has only matched active jobs: source disappears from source management/filters; jobs remain visible; source provenance may be labeled deleted.
+- Source has mixed classifications/states: only matched active jobs remain; all others disappear immediately from dashboard/jobs/counts.
+- Source has tracked jobs that are not matched active: tracking/reminder status does not protect them; avoid copy implying tracked jobs are always preserved.
+- Job linked to multiple sources: if it is not matched active and is associated with the deleted source, it should not appear in normal surfaces after deletion per product assumption.
+- Stale browser submits deletion twice: show normal not-found/already-deleted behavior; do not show duplicated cleanup UI.
+- Cleanup fails after source deletion: source remains deleted; normal user surfaces continue hiding non-retained jobs. No normal-user retry control.
+- User opens dashboard/jobs immediately after deletion: stale non-retained jobs must already be absent.
+- User opens bookmarked deleted job detail: normal not-found response.
+- Deleted source in source filters: remove from dropdown; clear/ignore stale filter parameter.
+
+## 13. Developer Handoff Notes
+
+- Update existing copy in `app/web/templates/sources/delete_confirm.html`; do not introduce a modal unless product later requests one.
+- Replace current preservation-oriented copy (“Historical jobs… are preserved”, “Tracked jobs… are preserved”) because it conflicts with the new cleanup rule.
+- Recommended success flash copy: “Source deleted. Job cleanup has started; non-retained jobs from this source are hidden from Dashboard and Jobs now. Matched active jobs may remain.”
+- Do not implement client-side filtering as the source of truth. Server queries must suppress non-retained pending-deletion jobs for dashboard counts, dashboard job previews, jobs list, reminders, digests, and job detail access.
+- Do not add deleted sources to normal source filters, ingestion controls, source health actions, or run buttons.
+- Do not show a progress bar, cleanup queue monitor, undo, restore, archive option, or configurable retention policy; these are out of scope.
+- If pre-delete retention/removal counts are expensive or unavailable, avoid exact count promises and use rule-based copy.
+- Retained matched active jobs should keep normal job actions (view, save/keep if applicable, tracking status) unless other business rules disable them.
+- If provenance for a deleted source is shown on retained job detail, it is historical only. Do not link to source edit/run/delete actions for that source.

--- a/tests/api/test_source_delete_job_cleanup_api.py
+++ b/tests/api/test_source_delete_job_cleanup_api.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from app.persistence.models import JobPosting, Source, SourceRun
+
+
+def test_delete_source_response_queues_cleanup(client, monkeypatch):
+    queued: list[int] = []
+    monkeypatch.setattr("app.web.routes.run_source_delete_cleanup", lambda source_id: queued.append(source_id))
+    create_response = client.post(
+        "/sources",
+        json={
+            "name": "Cleanup API Source",
+            "source_type": "greenhouse",
+            "base_url": "https://boards.greenhouse.io/cleanup-api",
+            "external_identifier": "cleanup-api",
+        },
+    )
+    assert create_response.status_code == 201
+    source_id = create_response.json()["id"]
+
+    delete_response = client.delete(f"/sources/{source_id}")
+
+    assert delete_response.status_code == 200
+    payload = delete_response.json()
+    assert payload["deleted"] is True
+    assert payload["source_id"] == source_id
+    assert payload["cleanup_queued"] is True
+    assert payload["cleanup_status"] == "queued"
+    assert queued == [source_id]
+
+
+def test_jobs_api_and_detail_hide_pending_cleanup_non_retained_jobs(client, session):
+    source = Source(name="Deleted", source_type="greenhouse", base_url="https://boards.greenhouse.io/deleted-api", external_identifier="deleted-api", dedupe_key="deleted-api", is_active=False)
+    session.add(source)
+    session.commit()
+    run = SourceRun(source_id=source.id, trigger_type="manual", status="success")
+    session.add(run)
+    session.commit()
+    retained = JobPosting(canonical_key="api-retained", primary_source_id=source.id, title="API Retained", job_url="https://example.com/api-retained", latest_bucket="matched", current_state="active")
+    hidden = JobPosting(canonical_key="api-hidden", primary_source_id=source.id, title="API Hidden", job_url="https://example.com/api-hidden", latest_bucket="review", current_state="active")
+    session.add_all([retained, hidden])
+    session.commit()
+    source.deleted_at = source.created_at
+    session.add(source)
+    session.commit()
+
+    jobs_response = client.get("/jobs")
+
+    assert jobs_response.status_code == 200
+    assert [job["id"] for job in jobs_response.json()] == [retained.id]
+    assert client.get(f"/jobs/{hidden.id}").status_code == 404
+    assert client.get(f"/jobs/{retained.id}").status_code == 200

--- a/tests/integration/test_source_delete_job_cleanup_surfaces.py
+++ b/tests/integration/test_source_delete_job_cleanup_surfaces.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from app.domain.notifications import NotificationService
+from app.persistence.models import Digest, DigestItem, JobDecision, JobPosting, JobTrackingEvent, Reminder, Source, utcnow
+
+
+def test_dashboard_tracking_reminders_and_digest_hide_pending_cleanup_jobs(client, session):
+    source = Source(name="Deleted Surface", source_type="greenhouse", base_url="https://boards.greenhouse.io/deleted-surface", external_identifier="deleted-surface", dedupe_key="deleted-surface", is_active=False, deleted_at=utcnow())
+    session.add(source)
+    session.commit()
+    retained = JobPosting(canonical_key="surface-retained", primary_source_id=source.id, title="Surface Retained", job_url="https://example.com/surface-retained", latest_bucket="matched", current_state="active", tracking_status="saved")
+    hidden = JobPosting(canonical_key="surface-hidden", primary_source_id=source.id, title="Surface Hidden", job_url="https://example.com/surface-hidden", latest_bucket="review", current_state="active", tracking_status="saved")
+    session.add_all([retained, hidden])
+    session.flush()
+    old = utcnow() - timedelta(days=10)
+    session.add_all([
+        JobTrackingEvent(job_posting_id=retained.id, event_type="status_change", tracking_status="saved", created_at=old),
+        JobTrackingEvent(job_posting_id=hidden.id, event_type="status_change", tracking_status="saved", created_at=old),
+        Reminder(job_posting_id=retained.id, reminder_type="saved_follow_up", due_at=old, status="pending"),
+        Reminder(job_posting_id=hidden.id, reminder_type="saved_follow_up", due_at=old, status="pending"),
+    ])
+    digest = Digest(digest_date=utcnow().date(), status="generated", delivery_channel="in_app", content_summary="")
+    session.add(digest)
+    session.flush()
+    session.add_all([
+        DigestItem(digest_id=digest.id, job_posting_id=retained.id, bucket="matched", reason="new_matched"),
+        DigestItem(digest_id=digest.id, job_posting_id=hidden.id, bucket="review", reason="new_review"),
+    ])
+    session.commit()
+
+    dashboard = client.get("/dashboard")
+    assert dashboard.status_code == 200
+    assert dashboard.json()["matched_count"] == 1
+    assert dashboard.json()["review_count"] == 0
+    assert dashboard.json()["pending_reminders"] == 1
+
+    tracking = client.get("/tracking", headers={"accept": "text/html"})
+    assert tracking.status_code == 200
+    assert "Surface Retained" in tracking.text
+    assert "Surface Hidden" not in tracking.text
+
+    reminders = client.get("/reminders")
+    assert reminders.status_code == 200
+    assert [reminder["job_posting_id"] for reminder in reminders.json()] == [retained.id]
+
+    digest_response = client.get("/digest/latest")
+    assert digest_response.status_code == 200
+    assert [item["job_posting_id"] for item in digest_response.json()["items"]] == [retained.id]
+
+
+def test_notification_generation_excludes_pending_cleanup_jobs(session):
+    source = Source(name="Deleted Generation", source_type="greenhouse", base_url="https://boards.greenhouse.io/deleted-generation", external_identifier="deleted-generation", dedupe_key="deleted-generation", is_active=False, deleted_at=utcnow())
+    session.add(source)
+    session.commit()
+    hidden = JobPosting(canonical_key="gen-hidden", primary_source_id=source.id, title="Gen Hidden", job_url="https://example.com/gen-hidden", latest_bucket="review", current_state="active", tracking_status="saved")
+    session.add(hidden)
+    session.flush()
+    session.add(JobDecision(job_posting_id=hidden.id, decision_version="v1", bucket="review", final_score=50, sponsorship_state="unknown", decision_reason_summary="summary", is_current=True))
+    session.add(JobTrackingEvent(job_posting_id=hidden.id, event_type="status_change", tracking_status="saved", created_at=utcnow() - timedelta(days=10)))
+    session.commit()
+
+    digest = NotificationService(session).generate_digest()
+    reminders = NotificationService(session).generate_reminders()
+
+    assert digest.content_summary == "0 matched, 0 review"
+    assert reminders == []

--- a/tests/ui/test_source_edit_delete_ui_qa.py
+++ b/tests/ui/test_source_edit_delete_ui_qa.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from app.persistence.models import JobPosting, JobSourceLink, Source, SourceRun, utcnow
+
 
 class DummyResponse:
     def __init__(self, payload):
@@ -42,7 +44,7 @@ def test_sources_html_exposes_edit_and_delete_actions_from_list_and_detail(clien
     assert "Delete source" in detail_response.text
 
 
-def test_deleted_source_preserves_historical_job_pages_and_delete_warning_context(client, monkeypatch):
+def test_source_delete_confirmation_explains_async_cleanup_and_retention(client, monkeypatch):
     greenhouse_payload = {
         "jobs": [
             {
@@ -75,9 +77,117 @@ def test_deleted_source_preserves_historical_job_pages_and_delete_warning_contex
     delete_page = client.get(f"/sources/{source['id']}/delete", headers={"accept": "text/html"})
     assert delete_page.status_code == 200
     assert "Historical Source" in delete_page.text
-    assert "existing history" in delete_page.text
-    assert "historical source reference" in delete_page.text
-    assert "Tracked jobs" in delete_page.text
+    assert "permanently removes most jobs from this source" in delete_page.text
+    assert "cleaned up in the background" in delete_page.text
+    assert "Only jobs that are both Matched and Active will be retained" in delete_page.text
+    assert "Tracking status, reminders, manual keep, and digest inclusion do not preserve a job" in delete_page.text
+
+
+def test_source_delete_success_flash_mentions_cleanup_and_hidden_jobs(client, monkeypatch):
+    monkeypatch.setattr("app.web.routes.run_source_delete_cleanup", lambda source_id: None)
+
+    source = create_source(client, name="Cleanup Flash Source", base_slug="cleanup-flash-source")
+
+    delete_response = client.post(
+        f"/sources/{source['id']}/delete",
+        headers={"content-type": "application/x-www-form-urlencoded", "accept": "text/html"},
+        data={},
+        follow_redirects=True,
+    )
+    assert delete_response.status_code == 200
+    assert "Source deleted. Job cleanup has started" in delete_response.text
+    assert "non-retained jobs from this source are hidden from Dashboard and Jobs now" in delete_response.text
+    assert "Matched active jobs may remain" in delete_response.text
+
+
+def test_retained_job_marks_deleted_source_provenance_as_historical(client, session):
+    source = create_source(client, name="Deleted Provenance Source", base_slug="deleted-provenance-source")
+    source_id = source["id"]
+
+    run = SourceRun(source_id=source_id, trigger_type="manual", status="success")
+    session.add(run)
+    session.flush()
+
+    now = utcnow()
+    job = JobPosting(
+        canonical_key="deleted-provenance-source:matched-active",
+        primary_source_id=source_id,
+        title="Matched Active Role",
+        company_name="Deleted Provenance Source",
+        job_url="https://example.com/jobs/matched-active",
+        normalized_job_url="https://example.com/jobs/matched-active",
+        location_text="Remote",
+        description_text="Retained matched active job.",
+        current_state="active",
+        latest_bucket="matched",
+        latest_score=91,
+        first_seen_at=now,
+        last_seen_at=now,
+        last_ingested_at=now,
+    )
+    session.add(job)
+    session.flush()
+
+    session.add(
+        JobSourceLink(
+            job_posting_id=job.id,
+            source_id=source_id,
+            source_run_id=run.id,
+            external_job_id="matched-active",
+            source_job_url="https://example.com/jobs/matched-active",
+            content_hash="deleted-provenance-source-hash",
+            is_primary=True,
+            first_seen_at=now,
+            last_seen_at=now,
+        )
+    )
+    db_source = session.get(Source, source_id)
+    db_source.deleted_at = utcnow()
+    db_source.is_active = False
+    session.commit()
+
+    jobs_page = client.get("/jobs", headers={"accept": "text/html"})
+    assert jobs_page.status_code == 200
+    assert "Matched Active Role" in jobs_page.text
+    assert "Deleted source" in jobs_page.text
+
+    source_filter_page = client.get(f"/jobs?source_id={source_id}", headers={"accept": "text/html"})
+    assert source_filter_page.status_code == 200
+    assert f'<option value="{source_id}"' not in source_filter_page.text
+
+    job_page = client.get(f"/jobs/{job.id}", headers={"accept": "text/html"})
+    assert job_page.status_code == 200
+    assert "Deleted Provenance Source" in job_page.text
+    assert "Deleted source" in job_page.text
+    assert f'/sources/{source_id}/edit' not in job_page.text
+    assert f'/sources/{source_id}/run' not in job_page.text
+
+
+def test_deleted_source_non_retained_job_uses_normal_not_found(client, monkeypatch):
+    monkeypatch.setattr("app.web.routes.run_source_delete_cleanup", lambda source_id: None)
+
+    greenhouse_payload = {
+        "jobs": [
+            {
+                "id": 501,
+                "title": "Deleted Cleanup Engineer",
+                "absolute_url": "https://example.com/jobs/501",
+                "location": {"name": "Remote"},
+                "content": "<p>Deleted cleanup regression role.</p>",
+                "updated_at": "2026-04-23T10:00:00Z",
+            }
+        ]
+    }
+    monkeypatch.setattr("app.adapters.greenhouse.adapter.httpx.get", lambda *args, **kwargs: DummyResponse(greenhouse_payload))
+
+    source = create_source(client, name="Deleted Cleanup Source", base_slug="deleted-cleanup-source")
+
+    run_response = client.post(f"/sources/{source['id']}/run")
+    assert run_response.status_code == 200
+
+    jobs_response = client.get("/jobs")
+    assert jobs_response.status_code == 200
+    job_id = jobs_response.json()[0]["id"]
 
     delete_response = client.post(
         f"/sources/{source['id']}/delete",
@@ -87,11 +197,5 @@ def test_deleted_source_preserves_historical_job_pages_and_delete_warning_contex
     )
     assert delete_response.status_code == 303
 
-    historical_job_page = client.get(f"/jobs/{job_id}", headers={"accept": "text/html"})
-    assert historical_job_page.status_code == 200
-    assert "Historical Safety Engineer" in historical_job_page.text
-    assert "Historical Source" in historical_job_page.text
-
-    historical_job_api = client.get(f"/jobs/{job_id}")
-    assert historical_job_api.status_code == 200
-    assert historical_job_api.json()["source_links"][0]["source_id"] == source["id"]
+    deleted_job_page = client.get(f"/jobs/{job_id}", headers={"accept": "text/html"})
+    assert deleted_job_page.status_code == 404

--- a/tests/unit/test_job_visibility.py
+++ b/tests/unit/test_job_visibility.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.domain.job_visibility import apply_visible_jobs
+from app.persistence.models import JobPosting, JobSourceLink, Source, SourceRun, utcnow
+
+
+def test_visible_jobs_hide_non_retained_deleted_source_jobs_immediately(session):
+    source = Source(name="Deleted", source_type="greenhouse", base_url="https://boards.greenhouse.io/deleted", external_identifier="deleted", dedupe_key="deleted", is_active=False, deleted_at=utcnow())
+    active_source = Source(name="Active", source_type="greenhouse", base_url="https://boards.greenhouse.io/active", external_identifier="active", dedupe_key="active", is_active=True)
+    session.add_all([source, active_source])
+    session.commit()
+    run = SourceRun(source_id=source.id, trigger_type="manual", status="success")
+    session.add(run)
+    session.commit()
+    retained = JobPosting(canonical_key="retained", primary_source_id=source.id, title="Retained", job_url="https://example.com/retained", latest_bucket="matched", current_state="active")
+    hidden = JobPosting(canonical_key="hidden", primary_source_id=source.id, title="Hidden", job_url="https://example.com/hidden", latest_bucket="review", current_state="active")
+    visible = JobPosting(canonical_key="visible", primary_source_id=active_source.id, title="Visible", job_url="https://example.com/visible", latest_bucket="review", current_state="active")
+    session.add_all([retained, hidden, visible])
+    session.flush()
+    session.add(JobSourceLink(job_posting_id=hidden.id, source_id=source.id, source_run_id=run.id, source_job_url=hidden.job_url, content_hash="hidden", is_primary=True))
+    session.commit()
+
+    visible_jobs = list(session.scalars(apply_visible_jobs(select(JobPosting)).order_by(JobPosting.canonical_key)))
+
+    assert [job.canonical_key for job in visible_jobs] == ["retained", "visible"]

--- a/tests/unit/test_source_delete_cleanup.py
+++ b/tests/unit/test_source_delete_cleanup.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from sqlalchemy import select
+
+from app.domain.source_cleanup import SOURCE_DELETE_CLEANUP_TRIGGER, SourceDeleteCleanupService
+from app.persistence.models import (
+    Digest,
+    DigestItem,
+    JobDecision,
+    JobDecisionRule,
+    JobPosting,
+    JobSourceLink,
+    JobTrackingEvent,
+    Reminder,
+    Source,
+    SourceRun,
+    utcnow,
+)
+
+
+def _source(session, name="Deleted Source"):
+    source = Source(
+        name=name,
+        source_type="greenhouse",
+        base_url=f"https://boards.greenhouse.io/{name.lower().replace(' ', '-')}",
+        external_identifier=name.lower().replace(" ", "-"),
+        dedupe_key=name.lower().replace(" ", "-"),
+        is_active=True,
+    )
+    session.add(source)
+    session.commit()
+    return source
+
+
+def _run(session, source):
+    run = SourceRun(source_id=source.id, trigger_type="manual", status="success")
+    session.add(run)
+    session.commit()
+    return run
+
+
+def _job(session, source, run, key, bucket, state="active", *, link_source=None, primary=True, tracked=False, keep=False):
+    job = JobPosting(
+        canonical_key=key,
+        primary_source_id=source.id,
+        title=key,
+        company_name="Acme",
+        job_url=f"https://example.com/{key}",
+        current_state=state,
+        latest_bucket=bucket,
+        manual_keep=keep,
+        tracking_status="saved" if tracked else None,
+    )
+    session.add(job)
+    session.flush()
+    decision = JobDecision(
+        job_posting_id=job.id,
+        decision_version="v1",
+        bucket=bucket or "review",
+        final_score=80,
+        sponsorship_state="unknown",
+        decision_reason_summary="summary",
+        is_current=True,
+    )
+    session.add(decision)
+    session.flush()
+    job.latest_decision_id = decision.id
+    session.add(JobDecisionRule(job_decision_id=decision.id, rule_key="r", rule_category="c", outcome="matched", score_delta=1, explanation_text="e"))
+    session.add(
+        JobSourceLink(
+            job_posting_id=job.id,
+            source_id=(link_source or source).id,
+            source_run_id=run.id,
+            source_job_url=job.job_url,
+            content_hash=key,
+            is_primary=primary,
+        )
+    )
+    if tracked:
+        session.add(JobTrackingEvent(job_posting_id=job.id, event_type="status_change", tracking_status="saved"))
+        session.add(Reminder(job_posting_id=job.id, reminder_type="saved_follow_up", due_at=utcnow() + timedelta(days=1), status="pending"))
+        digest = Digest(digest_date=utcnow().date(), status="generated", delivery_channel="in_app", content_summary="")
+        session.add(digest)
+        session.flush()
+        session.add(DigestItem(digest_id=digest.id, job_posting_id=job.id, bucket=bucket or "review", reason="new_review"))
+    session.commit()
+    return job
+
+
+def test_cleanup_retains_only_matched_active_and_deletes_dependents(session):
+    source = _source(session)
+    run = _run(session, source)
+    retained = _job(session, source, run, "matched-active", "matched", "active", tracked=True)
+    delete_matrix = [
+        _job(session, source, run, "matched-closed", "matched", "closed"),
+        _job(session, source, run, "review-active", "review", "active", tracked=True, keep=True),
+        _job(session, source, run, "rejected-active", "rejected", "active"),
+        _job(session, source, run, "unclassified-active", None, "active"),
+    ]
+    source.deleted_at = utcnow()
+    source.is_active = False
+    session.add(source)
+    session.commit()
+    retained_id = retained.id
+    deleted_ids = [job.id for job in delete_matrix]
+
+    result = SourceDeleteCleanupService(session).cleanup_source(source.id)
+
+    assert result.status == "success"
+    assert result.associated_count == 5
+    assert result.retained_count == 1
+    assert result.deleted_count == 4
+    assert session.get(JobPosting, retained_id) is not None
+    for deleted_id in deleted_ids:
+        assert session.get(JobPosting, deleted_id) is None
+    assert list(session.scalars(select(JobSourceLink).where(JobSourceLink.job_posting_id.in_(deleted_ids)))) == []
+    assert list(session.scalars(select(JobDecision).where(JobDecision.job_posting_id.in_(deleted_ids)))) == []
+    assert list(session.scalars(select(JobTrackingEvent).where(JobTrackingEvent.job_posting_id.in_(deleted_ids)))) == []
+    assert list(session.scalars(select(Reminder).where(Reminder.job_posting_id.in_(deleted_ids)))) == []
+    assert list(session.scalars(select(DigestItem).where(DigestItem.job_posting_id.in_(deleted_ids)))) == []
+
+    cleanup_run = session.scalar(select(SourceRun).where(SourceRun.trigger_type == SOURCE_DELETE_CLEANUP_TRIGGER))
+    assert cleanup_run is not None
+    assert cleanup_run.status == "success"
+    assert cleanup_run.error_details_json["deleted_count"] == 4
+
+
+def test_cleanup_is_idempotent_and_handles_link_only_association(session):
+    deleted_source = _source(session, "Deleted Link Source")
+    active_source = _source(session, "Active Source")
+    run = _run(session, deleted_source)
+    retained = _job(session, active_source, run, "link-retained", "matched", "active", link_source=deleted_source, primary=False)
+    deleted = _job(session, active_source, run, "link-deleted", "review", "active", link_source=deleted_source, primary=False)
+    deleted_source.deleted_at = utcnow()
+    deleted_source.is_active = False
+    session.add(deleted_source)
+    session.commit()
+    retained_id = retained.id
+    deleted_id = deleted.id
+
+    first = SourceDeleteCleanupService(session).cleanup_source(deleted_source.id)
+    second = SourceDeleteCleanupService(session).cleanup_source(deleted_source.id)
+
+    assert first.deleted_count == 1
+    assert second.deleted_count == 0
+    assert session.get(JobPosting, retained_id) is not None
+    assert session.get(JobPosting, deleted_id) is None
+
+
+def test_cleanup_skips_non_deleted_source(session):
+    source = _source(session)
+    run = _run(session, source)
+    job = _job(session, source, run, "not-deleted-source-job", "review", "active")
+
+    result = SourceDeleteCleanupService(session).cleanup_source(source.id)
+
+    assert result.status == "skipped_source_not_deleted"
+    assert session.get(JobPosting, job.id) is not None


### PR DESCRIPTION
# Pull Request

## 1. Feature Name
Source Delete Job Cleanup

## 2. Summary
Adds asynchronous cleanup after source deletion so non-retained jobs from deleted sources are removed or hidden immediately from user-facing surfaces. Retains only jobs that are both Matched and Active, while marking deleted-source provenance as historical/non-actionable.

Closes #5.

## 3. Related Documents
- Product Spec: docs/product/source_delete_job_cleanup_product_spec.md
- Technical Design: docs/architecture/source_delete_job_cleanup_technical_design.md
- UI/UX Spec: docs/uiux/source_delete_job_cleanup_uiux_spec.md
- QA Test Plan: docs/qa/source_delete_job_cleanup_test_plan.md
- QA Report: docs/qa/source_delete_job_cleanup_qa_report.md
- Backend Report: docs/backend/source_delete_job_cleanup_implementation_report.md
- Frontend Report: docs/frontend/source_delete_job_cleanup_implementation_report.md
- Planning Issue Artifact: docs/release/source_delete_job_cleanup_issue.md

## 4. Changes Included
- Queues source-delete cleanup from API and HTML source deletion flows using FastAPI background tasks.
- Adds cleanup service logic to delete non-retained source-associated jobs and dependent records while keeping matched active jobs.
- Centralizes visible-job filtering for dashboard, jobs, job detail, tracking, reminders, and digest surfaces during pending cleanup.
- Updates delete confirmation and success copy to explain cleanup behavior and retention rules.
- Labels retained deleted-source provenance as historical/deleted and removes deleted sources from actionable filters/controls.
- Adds targeted unit, API, integration, and UI regression tests plus product/design/implementation/QA/release artifacts.

## 5. QA Status
- Approved: YES
- QA sign-off: [QA SIGN-OFF APPROVED]

## 6. Test Coverage
- Targeted pytest suite: 19 passed.
- Compile check passed for application code and targeted tests.
- `git diff --check` passed.
- Coverage includes cleanup retention/deletion matrix, dependent row cleanup, idempotency, visibility filtering, API delete response, dashboard/jobs/tracking/reminders/digest behavior, delete copy, success messaging, and retained provenance labeling.

## 7. Risks / Notes
- FastAPI `BackgroundTasks` are in-process and not durable across process shutdowns; immediate visibility suppression mitigates stale user-facing data until cleanup can be retried.
- Stale `/jobs?source_id=<deleted>` filters reset by omitting deleted source options; no explicit informational alert is shown in this MVP.
- Unrelated duplicate `* 2` files and unrelated deleted historical docs remain intentionally unstaged and are not part of this release.
