### PR TITLE
Hide rejected jobs from actionable views

### DIFF
--- a/app/domain/job_visibility.py
+++ b/app/domain/job_visibility.py
@@ -42,3 +42,27 @@ def visible_job_predicate():
 
 def apply_visible_jobs(query: Select) -> Select:
     return query.where(visible_job_predicate())
+
+
+def actionable_job_status_predicate():
+    """Status visibility for the main actionable jobs display.
+
+    Only jobs explicitly classified as rejected are hidden. Jobs with NULL or
+    unknown non-rejected buckets remain visible for backward compatibility and
+    to preserve unclassified ingestion results.
+    """
+
+    return or_(JobPosting.latest_bucket.is_(None), JobPosting.latest_bucket != "rejected")
+
+
+def main_display_job_predicate():
+    """Main Jobs/Dashboard display visibility.
+
+    Composes normal source-delete visibility with the actionable status rule.
+    """
+
+    return visible_job_predicate() & actionable_job_status_predicate()
+
+
+def apply_main_display_jobs(query: Select) -> Select:
+    return query.where(main_display_job_predicate())

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -38,7 +38,7 @@
         {% endfor %}
       </div>
     {% else %}
-      {{ ui.empty_state('No jobs need review', 'Matched and rejected jobs are up to date right now.') }}
+      {{ ui.empty_state('No jobs need review', 'Matched and review jobs that need attention will appear here.') }}
     {% endif %}
   </article>
 

--- a/app/templates/jobs/list.html
+++ b/app/templates/jobs/list.html
@@ -21,8 +21,8 @@
     <input id="jobs-search" type="search" name="search" value="{{ filters.search }}" placeholder="Search title, company, or description">
     <label class="sr-only" for="jobs-bucket">Bucket</label>
     <select id="jobs-bucket" name="bucket">
-      <option value="">All buckets</option>
-      {% for value in ['matched', 'review', 'rejected'] %}
+      <option value="">All actionable</option>
+      {% for value in ['matched', 'review'] %}
         <option value="{{ value }}" {% if filters.bucket == value %}selected{% endif %}>{{ value|title }}</option>
       {% endfor %}
     </select>
@@ -51,6 +51,7 @@
   </form>
 
   {% if jobs %}
+    <p class="muted">{{ jobs|length }} actionable job(s) found.</p>
     <div class="table-wrap">
       <table>
         <thead>
@@ -84,7 +85,7 @@
       </table>
     </div>
   {% else %}
-    {{ ui.empty_state('No jobs found', 'Try broadening your filters or run an active source to bring in new postings.', '/sources', 'Manage sources') }}
+    {{ ui.empty_state('No actionable jobs found', 'Matched and review jobs that meet your filters will appear here. Rejected jobs are hidden from this main view.', '/sources', 'Manage sources') }}
   {% endif %}
 </section>
 {% endblock %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from app.adapters.base.registry import SourceAdapterRegistry
 from app.domain.ingestion import IngestionOrchestrator
-from app.domain.job_visibility import apply_visible_jobs, visible_job_predicate
+from app.domain.job_visibility import apply_main_display_jobs, apply_visible_jobs, visible_job_predicate
 from app.domain.notifications import NotificationService
 from app.domain.operations import OperationsService
 from app.domain.source_cleanup import run_source_delete_cleanup
@@ -226,7 +226,7 @@ def to_job_card(job: JobPosting, source: Source | None, decision: JobDecision | 
 
 
 def build_jobs_query(bucket: str | None, tracking_status: str | None, source_id: int | None, search: str | None):
-    query = apply_visible_jobs(select(JobPosting))
+    query = apply_main_display_jobs(select(JobPosting))
     if bucket:
         query = query.where(JobPosting.latest_bucket == bucket)
     if tracking_status:
@@ -358,7 +358,7 @@ async def parse_source_form(request: Request) -> tuple[dict[str, Any], SourceCre
 @router.get("/", response_class=HTMLResponse)
 @router.get("/dashboard", response_class=HTMLResponse)
 def dashboard(request: Request, session: Session = Depends(get_session_dependency)):
-    jobs = list(session.scalars(apply_visible_jobs(select(JobPosting))))
+    jobs = list(session.scalars(apply_main_display_jobs(select(JobPosting))))
     reminders = list(
         session.scalars(
             select(Reminder)

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -119,6 +119,12 @@ def parse_optional_source_id(source_id: str | None = Query(default=None)) -> int
     return parse_optional_int_query("source_id", source_id)
 
 
+def parse_form_checkbox(value: Any) -> bool:
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"on", "true", "1", "yes"}
+
+
 def redirect(url: str, status_code: int = status.HTTP_303_SEE_OTHER) -> RedirectResponse:
     return RedirectResponse(url=url, status_code=status_code)
 
@@ -340,7 +346,7 @@ async def parse_source_form(request: Request) -> tuple[dict[str, Any], SourceCre
         "external_identifier": str(form.get("external_identifier", "")),
         "adapter_key": str(form.get("adapter_key", "")),
         "notes": str(form.get("notes", "")),
-        "is_active": form.get("is_active") == "on",
+        "is_active": parse_form_checkbox(form.get("is_active")),
     }
     payload = SourceCreateRequest(
         name=form_data["name"],

--- a/app/web/templates/dashboard/index.html
+++ b/app/web/templates/dashboard/index.html
@@ -9,7 +9,6 @@
   <section class="stat-grid">
     {{ ui.stat_card('Matched', summary.matched, 'matched', '/jobs?bucket=matched') }}
     {{ ui.stat_card('Review', summary.review, 'review', '/jobs?bucket=review') }}
-    {{ ui.stat_card('Rejected', summary.rejected, 'rejected', '/jobs?bucket=rejected') }}
     {{ ui.stat_card('Saved needing action', summary.saved, 'default', '/tracking?tracking_status=saved') }}
     {{ ui.stat_card('Applied follow-up', summary.applied, 'default', '/tracking?tracking_status=applied') }}
   </section>
@@ -17,7 +16,7 @@
   {% if not sources %}
     {{ ui.empty_state('No sources configured yet', 'Add a Greenhouse or Lever source first, then run ingestion to populate the dashboard.', '/sources', 'Add Source') }}
   {% elif not has_jobs %}
-    {{ ui.empty_state('No jobs yet', 'Sources exist, but ingestion has not produced reviewable jobs yet. Run a source from the Sources page to continue.', '/sources', 'Open Sources') }}
+    {{ ui.empty_state('No actionable jobs yet', 'Matched and review jobs will appear here after ingestion. Rejected jobs are hidden from the dashboard queue.', '/sources', 'Open Sources') }}
   {% endif %}
 
   <div class="dashboard-grid">

--- a/app/web/templates/jobs/list.html
+++ b/app/web/templates/jobs/list.html
@@ -15,10 +15,9 @@
       <div class="field-group">
         <label for="bucket">Automated bucket</label>
         <select id="bucket" name="bucket">
-          <option value="">All buckets</option>
+          <option value="">All actionable</option>
           <option value="matched" {% if filters.bucket == 'matched' %}selected{% endif %}>Matched</option>
           <option value="review" {% if filters.bucket == 'review' %}selected{% endif %}>Review</option>
-          <option value="rejected" {% if filters.bucket == 'rejected' %}selected{% endif %}>Rejected</option>
         </select>
       </div>
       <div class="field-group">
@@ -57,7 +56,7 @@
 
   {% if jobs %}
     <section class="panel jobs-table-panel">
-      <p class="results-summary">{{ jobs|length }} job(s) found. Automated bucket, tracking status, and source health remain separate in this view.</p>
+      <p class="results-summary">{{ jobs|length }} actionable job(s) found. Automated bucket, tracking status, and source health remain separate in this view.</p>
       <div class="table-scroll">
         <table>
           <thead>
@@ -119,6 +118,6 @@
       {% endfor %}
     </section>
   {% else %}
-    {{ ui.empty_state('No jobs match the current view', 'Either ingestion has not produced jobs yet, or the current filters narrow the list to zero results.', '/sources', 'Open Sources') }}
+    {{ ui.empty_state('No actionable jobs found', 'Matched and review jobs that meet your filters will appear here. Rejected jobs are hidden from this main view.', '/sources', 'Open Sources') }}
   {% endif %}
 {% endblock %}

--- a/docs/architecture/hide_rejected_job_openings_technical_design.md
+++ b/docs/architecture/hide_rejected_job_openings_technical_design.md
@@ -1,0 +1,266 @@
+# Hide Rejected Job Openings Technical Design
+
+## Feature Overview
+
+Hide job openings whose current display classification is `rejected` from the primary user-facing job openings display by default. Rejected jobs remain persisted and remain available to non-main/admin/debug paths unless those paths intentionally reuse the main display query.
+
+The implementation should be primarily backend/query-layer filtering, with a small frontend/template update to avoid exposing a rejected bucket option on the main Jobs page.
+
+## Product Requirements Summary
+
+- The main job openings display must exclude jobs classified as `rejected`.
+- Jobs classified as `matched` or `review` must remain visible when they satisfy existing filters.
+- Rejected jobs must not be deleted or reclassified by this feature.
+- Filtering must happen before user-facing list counts and pagination where those exist.
+- Search, sort, source, tracking, and bucket filters must not accidentally reintroduce rejected jobs.
+- Direct rejected-job detail access is not changed unless the existing detail route uses the same visibility rules.
+
+## Scope
+
+### In Scope
+
+- Update the Jobs list/API (`GET /jobs`) default query to exclude explicitly rejected jobs.
+- Keep rejected jobs hidden even when `bucket=rejected` is supplied to `GET /jobs`.
+- Update Dashboard job summaries/previews that represent the actionable jobs surface to use the same non-rejected visibility rule.
+- Preserve existing source-delete visibility behavior while adding rejected-status filtering.
+- Remove or suppress the `rejected` option from the main Jobs page bucket selector.
+- Add tests for API, HTML, search/filter behavior, status transitions, and source-delete compatibility.
+
+### Out of Scope
+
+- Deleting, archiving, or reclassifying rejected jobs.
+- Adding a rejected-jobs management page or explicit “show rejected” toggle.
+- Changing the classification algorithm.
+- Changing ingestion behavior.
+- Hiding rejected jobs from every route that references jobs, unless that route is part of the main display or intentionally shares its query.
+
+## Architecture Overview
+
+Current repository findings:
+
+- Stack: FastAPI, SQLAlchemy 2.x, Jinja templates, SQLite/PostgreSQL-compatible schema.
+- Canonical display classification currently used by list/dashboard code is `JobPosting.latest_bucket`.
+- Classification writes both `job_decisions` and denormalized fields on `job_postings`: `latest_bucket`, `latest_score`, `latest_decision_id`.
+- Existing source-delete feature centralizes normal job visibility in `app/domain/job_visibility.py` via `visible_job_predicate()` and `apply_visible_jobs()`.
+- `GET /jobs` currently builds from `apply_visible_jobs(select(JobPosting))`, then applies bucket/tracking/search SQL filters, source filtering in memory, and in-memory sort. There is no current pagination or explicit total-count response.
+- `GET /dashboard` currently loads all `apply_visible_jobs(select(JobPosting))` jobs and calculates matched/review/rejected counts in memory.
+- `GET /jobs/{job_id}` currently uses `apply_visible_jobs()` for source-delete visibility. Product spec says direct detail route behavior should not change for rejected jobs.
+
+Recommended design:
+
+1. Add a reusable actionable-main-display predicate that composes with existing source-delete visibility.
+2. Apply that predicate at the base SQL query for `GET /jobs` and Dashboard job summary/previews.
+3. Do not apply the new rejected filter to `GET /jobs/{job_id}` or job mutation routes solely because a job is rejected.
+4. Update the Jobs HTML bucket filter to show only `All actionable`, `Matched`, and `Review`.
+
+## System Components
+
+### Backend Components Affected
+
+- `app/domain/job_visibility.py`
+  - Add helper(s) for main display/actionable jobs, for example:
+    - `actionable_job_status_predicate()`
+    - `main_display_job_predicate()`
+    - `apply_main_display_jobs(query)`
+  - The new helper must include the existing source-delete visibility predicate and exclude explicit `latest_bucket == "rejected"`.
+- `app/web/routes.py`
+  - `dashboard()` should use the main-display helper for actionable job counts/cards.
+  - `build_jobs_query()` should use the main-display helper as its base query.
+  - `get_job()`, `keep_job()`, and `update_tracking_status()` should continue using `apply_visible_jobs()` only, not the main-display helper, unless product later decides direct rejected detail access should 404.
+- `app/domain/notifications.py`
+  - No required change for digest generation because it already selects only current decisions with bucket in `matched`/`review`.
+  - Reminder generation/listing currently may include rejected tracked jobs if source-visible. This is out of the main Jobs display; do not change unless product defines reminders/tracking as part of the main display.
+
+### Frontend / Template Components Affected
+
+- `app/templates/jobs/list.html`
+  - Remove `rejected` from the bucket dropdown.
+  - Prefer option label `All actionable` or retain `All buckets` if minimal copy change is preferred. The returned set is no longer all stored buckets.
+- `app/web/templates/jobs/list.html`
+  - Repository contains duplicate template paths. Keep this copy in sync if it is still used by `Jinja2Templates` fallback order.
+- Dashboard template does not currently show rejected count; no required template change.
+
+## Data Models and Storage Design
+
+No schema migration is required.
+
+Relevant existing fields:
+
+- `job_postings.latest_bucket`: denormalized current/latest display bucket. Expected values include `matched`, `review`, `rejected`; may be `NULL`.
+- `job_postings.latest_decision_id`: points to the latest `job_decisions` row.
+- `job_decisions.bucket` and `job_decisions.is_current`: historical classification records. Existing list code does not join this table.
+
+Storage behavior:
+
+- Rejected jobs remain in `job_postings`, `job_decisions`, `job_source_links`, tracking, reminders, and digest history unless affected by unrelated cleanup features.
+- Filtering should not mutate `latest_bucket` or decision rows.
+
+## API Contracts
+
+### GET `/jobs`
+
+Request parameters remain unchanged:
+
+- `bucket`: optional string
+- `tracking_status`: optional string
+- `source_id`: optional integer
+- `search`: optional string
+- `sort`: optional string
+
+Response remains the existing list of `JobPosting` objects for JSON clients, or the existing HTML page for browser clients.
+
+New behavior:
+
+- Base result set excludes explicit `latest_bucket == "rejected"` before other filters are applied.
+- `GET /jobs?bucket=matched` returns matched actionable jobs.
+- `GET /jobs?bucket=review` returns review actionable jobs.
+- `GET /jobs?bucket=rejected` returns an empty list / no-results HTML state. No 400 is required for backward compatibility, but the HTML UI should stop presenting this option.
+- Search/source/tracking filters only operate inside the non-rejected result set.
+
+### GET `/dashboard`
+
+JSON counts and HTML summary/cards should be based on the actionable main-display set:
+
+- `matched_count`: count of visible actionable matched jobs.
+- `review_count`: count of visible actionable review jobs.
+- `rejected_count`: should be `0` or omitted in a future contract. For backward compatibility, keep the field and return `0` after filtering.
+- Dashboard preview cards must not include rejected jobs.
+
+### GET `/jobs/{job_id}`
+
+No behavior change for rejected jobs in this feature.
+
+- A rejected job detail URL remains accessible if the job passes existing source-delete visibility rules.
+- A rejected job may still return 404 if hidden/deleted by existing source-delete cleanup rules.
+
+## Frontend / Client Impact
+
+Both backend and frontend changes are needed.
+
+- Backend is required to ensure search, counts, and any future pagination are correct and rejected jobs are not merely hidden visually.
+- Frontend/template impact is limited to main Jobs filter copy/options and tests expecting rejected in the dropdown.
+- Empty state can reuse the existing `No jobs found` message. If all jobs are rejected, the Jobs page should show the existing no-results state without error language.
+
+## Backend Logic / Service Behavior
+
+### Status Handling
+
+Use `JobPosting.latest_bucket` as the main-display status source for MVP because it is the field currently used by Jobs and Dashboard and is updated by `ClassificationService.classify_job()`.
+
+Default inclusion rule:
+
+```text
+main display eligible = source-delete-visible AND latest_bucket IS NOT "rejected"
+```
+
+This means:
+
+- `matched`: shown.
+- `review`: shown.
+- `rejected`: hidden.
+- `NULL` / missing classification: shown as actionable/unclassified for MVP.
+- Unknown non-`rejected` values: shown for backward compatibility, but should be monitored/tested; product may later choose to restrict to only `matched` and `review`.
+
+Rationale for null/unknown default: the product spec explicitly mandates hiding rejected jobs and identifies null/unknown handling as open. Preserving non-rejected visibility avoids accidentally hiding newly ingested or partially classified jobs.
+
+### Query Predicate Shape
+
+In `app/domain/job_visibility.py`, compose predicates rather than duplicating route logic:
+
+```text
+main_display_job_predicate = visible_job_predicate AND actionable_status_predicate
+```
+
+When implementing in SQLAlchemy, account for SQL three-valued logic: `latest_bucket != "rejected"` alone does not include `NULL`; include an explicit `IS NULL` branch.
+
+### Counts and Pagination Expectations
+
+- Current code has no pagination and no Jobs total count field.
+- Dashboard counts must be calculated after applying the main-display predicate.
+- If pagination is added later, `apply_main_display_jobs()` must be applied before `COUNT(*)`, `LIMIT`, and `OFFSET`.
+- Avoid UI-only filtering because it would create short pages and inflated counts once pagination/counts exist.
+
+### Source Filtering and Sorting
+
+- Current `source_id` filtering is performed in memory by `filter_jobs_by_source()` after the SQL query. This is acceptable for current no-pagination behavior but is not suitable if pagination/counts are added.
+- Future pagination work should move source filtering and sorting into SQL before `COUNT/LIMIT/OFFSET`.
+
+## File / Module Structure
+
+Likely files to modify downstream:
+
+- `app/domain/job_visibility.py`
+  - Add main-display/actionable visibility helpers.
+- `app/web/routes.py`
+  - Import and use `apply_main_display_jobs` in `dashboard()` and `build_jobs_query()`.
+  - Keep detail/mutation routes on `apply_visible_jobs`.
+- `app/templates/jobs/list.html`
+  - Remove rejected bucket option; update all-buckets label if desired.
+- `app/web/templates/jobs/list.html`
+  - Mirror template change if duplicate path remains active.
+- Tests:
+  - `tests/unit/test_job_visibility.py`
+  - `tests/integration/test_api_flow.py` or a new integration test for `/jobs` filtering.
+  - `tests/integration/test_html_views.py`
+  - `tests/ui/test_saas_dashboard_ui_revamp.py` if selectors/snapshots include bucket options.
+
+## Security and Access Control
+
+- This feature is display filtering, not access control.
+- Do not rely on hidden list membership to protect rejected job data.
+- Direct details remain accessible per product spec; if rejected jobs become sensitive later, a separate authorization/access-control design is required.
+- No sensitive job content should be added to telemetry/logs.
+
+## Reliability / Operational Considerations
+
+- The predicate is simple and index-friendly if `latest_bucket` is indexed in the future; no migration is required now.
+- Because filtering is centralized in `job_visibility.py`, future routes can opt in consistently.
+- Existing source-delete visibility must continue to work; tests should cover composition of deleted-source filtering and rejected-status filtering.
+- Stale browser pages may show a job until refresh after its classification changes to rejected; this matches product acceptance requiring refresh/reload after persistence.
+
+## Dependencies and Constraints
+
+- Depends on existing `latest_bucket` denormalization staying synchronized with current `JobDecision` records.
+- No durable frontend state-management layer exists; this is server-rendered Jinja plus JSON routes.
+- No current pagination implementation exists for `/jobs`.
+- Existing source-delete cleanup has its own visibility rules that must not be regressed.
+
+## Assumptions
+
+- `latest_bucket` is the canonical display status for current list surfaces.
+- Main job openings display means `GET /jobs` and Dashboard actionable job summaries/previews.
+- Null/missing classification should remain visible by default to preserve current behavior and avoid hiding unclassified jobs.
+- Direct rejected job detail URLs remain accessible if otherwise source-visible.
+- API clients can tolerate `bucket=rejected` returning an empty list instead of a validation error.
+
+## Risks / Open Questions
+
+- Product may prefer strict inclusion of only `matched` and `review`, which would hide null/unknown statuses. Confirm before implementation if possible.
+- Dashboard JSON currently exposes `rejected_count`; returning `0` preserves shape but may confuse clients that expected inventory counts.
+- Tracking/reminders may still surface rejected jobs outside the main Jobs display if they are tracked. Confirm whether those surfaces should also become actionable-only.
+- Duplicate template directories (`app/templates` and `app/web/templates`) can drift; downstream implementation should verify which path is active and update both if necessary.
+
+## Implementation Notes for Downstream Agents
+
+Suggested implementation sequence:
+
+1. Add main-display predicate/helper functions in `app/domain/job_visibility.py` and unit-test them with matched, review, rejected, null, unknown, and deleted-source fixtures.
+2. Update `build_jobs_query()` in `app/web/routes.py` to use the new main-display helper as the base query.
+3. Update `dashboard()` to load jobs from the new main-display helper before summary counts and preview cards are calculated.
+4. Keep `get_job()`, `keep_job()`, and `update_tracking_status()` on existing `apply_visible_jobs()` to preserve direct-detail behavior.
+5. Update Jobs list templates to remove the rejected bucket option.
+6. Add/adjust integration tests:
+   - `/jobs` JSON excludes rejected and includes matched/review/null.
+   - `/jobs?bucket=rejected` returns no jobs.
+   - Search matching only a rejected job returns no jobs/no-results HTML.
+   - Dashboard counts/cards exclude rejected; `rejected_count` remains `0` if field retained.
+   - Reclassified job with `latest_bucket` changed to `rejected` disappears after refresh.
+   - Reclassified job changed from `rejected` to `review`/`matched` reappears.
+   - Source-delete retained matched active job remains visible; source-visible rejected job is hidden from main display.
+7. Run existing source-delete cleanup tests to ensure composed visibility does not break retained matched active behavior.
+
+Test implications:
+
+- Fixtures that ingest/classify jobs as rejected and then assume `/jobs` returns the first created job must be updated to use matched/review data.
+- HTML tests should assert the rejected option is absent from the main Jobs bucket selector.
+- No migration tests are required.

--- a/docs/backend/hide_rejected_job_openings_implementation_plan.md
+++ b/docs/backend/hide_rejected_job_openings_implementation_plan.md
@@ -1,0 +1,40 @@
+# Implementation Plan
+
+## 1. Feature Overview
+
+Hide jobs whose current display classification is explicitly `rejected` from the main Jobs and Dashboard actionable surfaces while preserving storage records and direct detail access.
+
+## 2. Technical Scope
+
+- Add reusable main-display visibility helpers in `app/domain/job_visibility.py` that compose existing source-delete visibility with non-rejected status filtering.
+- Apply the main-display helper to `/jobs` query construction and dashboard actionable jobs data flow.
+- Preserve `/jobs/{job_id}` and job mutation route behavior on the existing source-delete visibility helper.
+- Add backend tests for predicate behavior, route filtering, dashboard counts/previews, direct detail access, and reclassification transitions.
+
+## 3. Files Expected to Change
+
+- `app/domain/job_visibility.py`
+- `app/web/routes.py`
+- `tests/unit/test_job_visibility.py`
+- `tests/integration/test_hide_rejected_job_openings_surfaces.py`
+- Existing regression tests requiring actionable fixture data updates.
+- Backend implementation report under `docs/backend/`.
+
+## 4. Dependencies / Constraints
+
+- Use `JobPosting.latest_bucket` as the current display classification source of truth.
+- Preserve existing source-delete visibility semantics.
+- Do not change schema, ingestion, classification, direct detail authorization, or rejected-record persistence.
+- Do not push or create a PR.
+
+## 5. Assumptions
+
+- `NULL` and unknown non-`rejected` bucket values remain visible on the main display.
+- `/jobs?bucket=rejected` should return an empty result set through predicate composition, not validation failure.
+- Dashboard `rejected_count` remains in the JSON contract with value `0` after filtering.
+
+## 6. Validation Plan
+
+- Run focused backend tests for visibility helpers and new Jobs/Dashboard integration coverage.
+- Run backend unit/API/integration regression suites.
+- Run the full test suite to identify any remaining non-backend/UI test issues.

--- a/docs/backend/hide_rejected_job_openings_implementation_report.md
+++ b/docs/backend/hide_rejected_job_openings_implementation_report.md
@@ -1,0 +1,48 @@
+# Implementation Report
+
+## 1. Summary of Changes
+
+Implemented backend query-layer filtering for the Hide Rejected Job Openings feature. The main Jobs endpoint and Dashboard actionable data now exclude jobs with `latest_bucket == "rejected"` while keeping matched, review, `NULL`, and unknown non-rejected buckets visible.
+
+## 2. Files Modified
+
+- `app/domain/job_visibility.py`
+- `app/web/routes.py`
+- `tests/unit/test_job_visibility.py`
+- `tests/integration/test_hide_rejected_job_openings_surfaces.py`
+- `tests/integration/test_html_views.py`
+- `tests/ui/test_source_edit_delete_ui_qa.py`
+- `docs/backend/hide_rejected_job_openings_implementation_plan.md`
+- `docs/backend/hide_rejected_job_openings_implementation_report.md`
+
+## 3. Key Logic Implemented
+
+- Added `actionable_job_status_predicate()` to exclude only explicit rejected buckets and include SQL `NULL` buckets correctly.
+- Added `main_display_job_predicate()` and `apply_main_display_jobs()` to compose source-delete visibility with rejected filtering.
+- Updated `/jobs` base query to use `apply_main_display_jobs()`, so bucket, tracking, search, source filtering, and sorting operate within the non-rejected result set.
+- Updated Dashboard actionable jobs loading to use `apply_main_display_jobs()`, causing matched/review counts and previews to exclude rejected jobs and `rejected_count` to remain `0`.
+- Left direct job detail and mutation routes on `apply_visible_jobs()` so rejected records remain directly accessible when source-visible.
+- Added tests for predicate behavior, `/jobs?bucket=rejected`, rejected-only search, source-filter compatibility, dashboard counts/previews, direct rejected detail access, and persisted reclassification transitions.
+
+## 4. Assumptions Made
+
+- `JobPosting.latest_bucket` is the canonical current display bucket for Jobs and Dashboard surfaces.
+- Unknown non-rejected bucket values and `NULL` bucket values remain visible to preserve existing behavior.
+- Template removal of the `Rejected` bucket option remains a frontend handoff item; backend filtering prevents exposure of rejected jobs even if stale UI/query parameters request them.
+
+## 5. Validation Performed
+
+- `./.venv/bin/python -m pytest tests/unit/test_job_visibility.py tests/integration/test_hide_rejected_job_openings_surfaces.py` — **passed**, 8 tests.
+- `./.venv/bin/python -m pytest tests/unit/test_job_visibility.py tests/integration/test_hide_rejected_job_openings_surfaces.py tests/integration/test_api_flow.py tests/integration/test_html_views.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/api/test_source_delete_job_cleanup_api.py` — **passed**, 20 tests.
+- `./.venv/bin/python -m pytest tests/unit tests/api tests/integration` — **passed**, 34 tests.
+- `./.venv/bin/python -m pytest` — **failed**, 44 passed / 5 failed. Remaining failures are in `tests/ui/test_saas_dashboard_ui_revamp.py` and appear tied to UI test harness expectations for HTML responses without an HTML `Accept` header and fixed seed data/detail assumptions, not to rejected-job backend filtering.
+
+## 6. Known Limitations / Follow-Ups
+
+- Frontend should remove the `Rejected` option from the Jobs bucket selector and update copy to `All actionable` per UI/UX spec.
+- Frontend/QA should review `tests/ui/test_saas_dashboard_ui_revamp.py` because it requests JSON-default routes without HTML `Accept` headers while asserting HTML shells.
+- Reminder/tracking-specific surfaces intentionally continue to use existing source-delete visibility and may still surface rejected jobs outside the main display.
+
+## 7. Commit Status
+
+Included in the backend feature commit for hide rejected job openings.

--- a/docs/backend/source_active_checkbox_run_blocker_fix_implementation_plan.md
+++ b/docs/backend/source_active_checkbox_run_blocker_fix_implementation_plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan
+
+## 1. Feature Overview
+
+Fix the source active checkbox form parsing bug that caused checked `is_active=true` submissions to persist inactive sources and block source runs with an inactive-source `409`.
+
+## 2. Technical Scope
+
+- Update backend form parsing to treat common checked checkbox values as truthy.
+- Ensure both create and edit source HTML form flows use the corrected parsing path.
+- Add regression tests for `true`, `on`, omitted checkbox behavior, edit behavior, and run flow behavior.
+
+## 3. Files Expected to Change
+
+- `app/web/routes.py`
+- `tests/integration/test_source_edit_delete_html.py`
+- `docs/backend/source_active_checkbox_run_blocker_fix_implementation_report.md`
+
+## 4. Dependencies / Constraints
+
+- Preserve current omitted-checkbox behavior as inactive.
+- Do not alter source templates unless backend robustness is insufficient.
+- Do not modify or undo the hide-rejected-job implementation.
+
+## 5. Assumptions
+
+- Checked checkbox values of `on`, `true`, `1`, and `yes` should persist `is_active=True`.
+- Missing checkbox values represent unchecked and should persist `is_active=False` for HTML form submissions.
+- Existing create and edit source flows share `parse_source_form()`, so a parser fix covers both.
+
+## 6. Validation Plan
+
+- Run focused source edit/delete HTML integration tests.
+- Run backend unit/API/integration test suites.
+- Run the full test suite and document any unrelated existing UI failures.

--- a/docs/backend/source_active_checkbox_run_blocker_fix_implementation_report.md
+++ b/docs/backend/source_active_checkbox_run_blocker_fix_implementation_report.md
@@ -1,0 +1,45 @@
+# Implementation Report
+
+## 1. Summary of Changes
+
+Fixed backend parsing for the source active checkbox so checked HTML form values such as `true`, `on`, `1`, and `yes` persist sources as active. This prevents sources created from the active template checkbox value `is_active=true` from being incorrectly saved inactive and blocked from running.
+
+## 2. Files Modified
+
+- `app/web/routes.py`
+- `tests/integration/test_source_edit_delete_html.py`
+- `docs/backend/source_active_checkbox_run_blocker_fix_implementation_plan.md`
+- `docs/backend/source_active_checkbox_run_blocker_fix_implementation_report.md`
+
+## 3. Key Logic Implemented
+
+- Added `parse_form_checkbox()` in `app/web/routes.py`.
+- Updated `parse_source_form()` to use the checkbox parser instead of comparing only to the literal value `"on"`.
+- Covered both source create and source edit flows because both use `parse_source_form()`.
+- Added regression tests proving:
+  - `is_active=true` persists active.
+  - `is_active=on` still persists active.
+  - Omitted `is_active` persists inactive.
+  - Edit form submission with `is_active=true` updates/preserves active state.
+  - A source created with `is_active=true` can enter the run flow without the inactive-source `409`.
+
+## 4. Assumptions Made
+
+- Missing checkbox values continue to mean unchecked/inactive for HTML form submissions.
+- Template changes are not required because the backend now robustly handles both active template styles.
+
+## 5. Validation Performed
+
+- `./.venv/bin/python -m pytest tests/integration/test_source_edit_delete_html.py tests/integration/test_api_flow.py tests/unit tests/api tests/integration` — **passed**, 28 tests.
+- `./.venv/bin/python -m pytest tests/unit tests/api tests/integration` — **passed**, 39 tests.
+- `./.venv/bin/python -m pytest` — **failed**, 54 passed / 5 failed. Remaining failures are in `tests/ui/test_saas_dashboard_ui_revamp.py` and pre-exist this fix path: those tests request JSON-default routes without HTML `Accept` headers and assume seeded HTML/detail data.
+
+## 6. Known Limitations / Follow-Ups
+
+- QA should verify the browser create form now persists `Active` for the rendered `value="true"` checkbox.
+- Duplicate source templates still differ in checkbox value behavior, but backend parsing now accepts both observed values.
+- Full-suite UI failures remain for unrelated HTML negotiation/fixture assumptions and should be handled by frontend/UI test ownership.
+
+## 7. Commit Status
+
+Included in the source active checkbox run blocker fix commit.

--- a/docs/bugs/source_active_checkbox_run_blocker.md
+++ b/docs/bugs/source_active_checkbox_run_blocker.md
@@ -1,0 +1,72 @@
+# Source Active Checkbox Run Blocker
+
+## Observed Behavior
+- A user creates a Greenhouse source with the `Source is active` checkbox checked.
+- The created source appears in the Sources inventory with an `Inactive` badge.
+- Clicking/run-submitting the source sends `POST /sources/9/run?next=/sources` and receives `409 Conflict` with `{"detail":"Source is inactive and cannot be run."}`.
+- The source can still show `adapter=greenhouse`, `health=Healthy`, and `last run=Never run`, but `is_active=False` blocks ingestion.
+
+## Expected Behavior
+- A checked `Source is active` checkbox should persist the source with `is_active=True`.
+- Newly created active sources should render as `Active` and expose/allow the run action.
+- `POST /sources/{id}/run` should not return the inactive-source `409` for a source created with the checkbox checked.
+
+## Reproduction Steps
+1. Open the Sources create form.
+2. Enter:
+   - `source_type`: `greenhouse`
+   - `base_url`: `https://job-boards.greenhouse.io/devrev`
+   - `external_identifier`: `devrev`
+   - `adapter_key`: blank
+   - leave/check `Source is active` as checked
+3. Submit `Create source`.
+4. Observe the created source row renders `Inactive`.
+5. Submit/run the source.
+6. Observe `409 Conflict` with `{"detail":"Source is inactive and cannot be run."}`.
+
+## Evidence / Code References
+- Active template resolution prefers `app/templates` before `app/web/templates`: `app/web/routes.py:44-47` builds `Jinja2Templates(directory=[app/templates, app/web/templates])`.
+- The active create/edit templates in `app/templates` submit the checked checkbox as `is_active=true`:
+  - `app/templates/sources/index.html:83`: `<input type="checkbox" name="is_active" value="true" ...> Source is active`
+  - `app/templates/sources/edit.html:22`: `<input type="checkbox" name="is_active" value="true" ...> Source is active`
+- Backend form parsing only treats the literal browser-default value `on` as active:
+  - `app/web/routes.py:333-344`, especially `app/web/routes.py:343`: `"is_active": form.get("is_active") == "on"`
+- The domain service persists the parsed payload value directly:
+  - `app/domain/sources.py:86-101`, especially `is_active=payload.is_active` at line 100.
+- Run blocking is based on persisted `source.is_active`:
+  - `app/domain/sources.py:177-183`, especially line 182 raises `ValueError("Source is inactive and cannot be run.")`.
+  - `app/web/routes.py:646-658` converts that `ValueError` into `409 Conflict`.
+- Schema/model defaults are not the cause for this HTML path:
+  - `app/schemas.py:8-16` defaults `SourceCreateRequest.is_active` to `True`, but `parse_source_form` explicitly passes `False` when form value is `true` instead of `on`.
+  - `app/persistence/models.py:39` defaults `Source.is_active` to `True`, but `SourceService.create_source` explicitly assigns the parsed payload value.
+- Existing coverage misses this exact mismatch:
+  - `tests/integration/test_html_views.py:88-103` posts form data with `"is_active": "on"`, so it matches the parser but not the rendered `app/templates` checkbox value.
+  - API tests use JSON booleans and do not exercise the HTML checkbox serialization path.
+- There is also a newer duplicate template under `app/web/templates/sources/index.html:62` whose checkbox omits `value`, causing browsers to submit `on`; however, because `app/templates` is first in the template directory list, the `app/templates` version is the likely rendered form.
+
+## Suspected Root Cause
+Confirmed root cause: frontend/backend contract mismatch on the HTML checkbox value.
+
+The rendered Sources create/edit form submits `is_active=true`, but `parse_source_form()` only accepts `is_active == "on"`. Therefore a checked checkbox from the active template is parsed as `False`, persisted as inactive, rendered inactive in inventory, and subsequently rejected by `get_runnable_source()` with the reported `409`.
+
+This is not a rendering-only mismatch and not a schema/model default issue; the source is actually persisted with `is_active=False` on the HTML form path.
+
+## Impact / Severity
+- Severity: High validation blocker.
+- Impact: Users cannot run newly created sources from the UI when the checked active checkbox is submitted as `true`. This blocks initial ingestion for affected sources and creates a confusing state (`Healthy` but `Inactive`/never runnable).
+
+## Recommended Fix Owner and Fix Approach
+- Owner: Backend-primary, with frontend/template coordination.
+- Recommended backend fix: update `parse_source_form()` to parse standard truthy checkbox values, e.g. treat `{"on", "true", "1", "yes"}` as active and missing/false-like values as inactive.
+- Recommended frontend/template cleanup: align duplicate source templates so they use a consistent checkbox value/label and avoid divergence between `app/templates` and `app/web/templates`.
+- Consider verifying whether both template trees are still intended; if not, remove or de-prioritize stale templates to reduce future mismatches.
+
+## Regression Tests to Add / Update
+- Add an HTML form integration test that posts `is_active=true` to `POST /sources` and asserts the created source is active in the response/page/database.
+- Update/extend `tests/integration/test_html_views.py::test_html_forms_redirect_for_source_and_tracking` to use the exact checkbox value rendered by the active template (`true`) or to fetch the form first and submit its actual input value.
+- Add a test for `POST /sources/{id}/edit` with `is_active=true` to ensure active state remains/updates to active.
+- Add a run validation test: create via HTML form with checked `is_active=true`, then `POST /sources/{id}/run` and assert it does not fail with the inactive-source `409`.
+
+## Open Questions / Missing Evidence
+- No browser/network capture from the user's session was available beyond the report. The code strongly indicates the submitted form value was `true`, matching the active `app/templates` form.
+- Confirm at runtime which template tree is intended long term (`app/templates` vs `app/web/templates`) before deleting or consolidating templates.

--- a/docs/frontend/hide_rejected_job_openings_implementation_plan.md
+++ b/docs/frontend/hide_rejected_job_openings_implementation_plan.md
@@ -1,0 +1,48 @@
+# Implementation Plan
+
+## 1. Feature Overview
+
+Hide rejected job openings from the main Jobs UI and dashboard actionable presentation while preserving direct detail access and backend filtering implemented upstream.
+
+## 2. Technical Scope
+
+- Remove the visible `Rejected` bucket option from server-rendered Jobs list templates.
+- Update the default bucket copy to `All actionable`.
+- Keep stale/manual `/jobs?bucket=rejected` rendering as a normal empty actionable-jobs state.
+- Remove the user-facing rejected stat card/link from dashboard templates where present.
+- Add frontend/UI regression coverage for Jobs filter options, empty states, hidden rejected rows/cards, and dashboard rejected-card removal.
+
+## 3. UI/UX Inputs
+
+- Product Spec: `docs/product/hide_rejected_job_openings_product_spec.md`
+- Technical Design: `docs/architecture/hide_rejected_job_openings_technical_design.md`
+- UI/UX Spec: `docs/uiux/hide_rejected_job_openings_uiux_spec.md`
+- QA Test Plan: `docs/qa/hide_rejected_job_openings_test_plan.md`
+
+## 4. Files Expected to Change
+
+- `app/templates/jobs/list.html`
+- `app/web/templates/jobs/list.html`
+- `app/templates/dashboard/index.html`
+- `app/web/templates/dashboard/index.html`
+- `tests/ui/test_hide_rejected_job_openings_ui.py`
+- `docs/frontend/hide_rejected_job_openings_implementation_plan.md`
+- `docs/frontend/hide_rejected_job_openings_implementation_report.md`
+
+## 5. Dependencies / Constraints
+
+- Backend query-layer filtering from commit `1971d70` is authoritative and must not be undone.
+- No rejected-jobs management page or show-rejected toggle is in scope.
+- Duplicate template paths must remain consistent because the active Jinja search path uses `app/templates` first while older tests/specs still reference `app/web/templates`.
+
+## 6. Assumptions
+
+- `app/templates/*` is the active rendered template set for current HTML routes due to Jinja template search order.
+- `app/web/templates/*` is still maintained as a duplicate/fallback template set.
+- Existing backend behavior ensures rejected jobs are absent from Jobs/Dashboard data; frontend changes should avoid exposing stale rejected navigation affordances.
+
+## 7. Validation Plan
+
+- Run targeted UI tests for this feature.
+- Run related HTML/dashboard regression tests.
+- Run backend hide-rejected integration tests to confirm frontend changes do not conflict with upstream behavior.

--- a/docs/frontend/hide_rejected_job_openings_implementation_report.md
+++ b/docs/frontend/hide_rejected_job_openings_implementation_report.md
@@ -1,0 +1,51 @@
+# Implementation Report
+
+## 1. Summary of Changes
+
+Implemented the frontend/UI portion of Hide Rejected Job Openings for server-rendered Jobs and Dashboard surfaces. The Jobs bucket filter now presents actionable options only, dashboard UI no longer links users to a rejected bucket queue, and empty/result copy now describes actionable jobs.
+
+## 2. Files Modified
+
+- `app/templates/jobs/list.html`
+- `app/web/templates/jobs/list.html`
+- `app/templates/dashboard/index.html`
+- `app/web/templates/dashboard/index.html`
+- `tests/ui/test_hide_rejected_job_openings_ui.py`
+- `docs/frontend/hide_rejected_job_openings_implementation_plan.md`
+- `docs/frontend/hide_rejected_job_openings_implementation_report.md`
+
+## 3. UI Behavior Implemented
+
+- Main Jobs bucket select now shows only:
+  - `All actionable`
+  - `Matched`
+  - `Review`
+- The visible `Rejected` bucket option was removed from both Jobs list template paths.
+- Manual `/jobs?bucket=rejected` continues to render through the normal empty state because backend filtering returns no rejected rows; the select has no rejected option and visually falls back to the first actionable option.
+- Jobs result copy now reports actionable job counts rather than implying all stored jobs are included.
+- Jobs empty state now uses non-error actionable copy and explicitly states rejected jobs are hidden from the main view.
+- The duplicate dashboard template path no longer renders a clickable Rejected stat card to `/jobs?bucket=rejected`.
+- Dashboard empty/help copy was adjusted to avoid positioning rejected jobs as part of the actionable queue.
+
+## 4. Assumptions Made
+
+- Backend commit `1971d70` remains responsible for query-layer exclusion from `/jobs` and `/dashboard` data.
+- `app/templates/*` is the active template set because it appears first in the Jinja template directory list; `app/web/templates/*` was kept in sync per the UI/UX handoff.
+- Tracking/reminders and direct rejected job detail pages remain out of scope and may still surface rejected status where existing routes allow it.
+
+## 5. Validation Performed
+
+- `./.venv/bin/python -m pytest tests/ui/test_hide_rejected_job_openings_ui.py` — passed, 5 tests.
+- `./.venv/bin/python -m pytest tests/integration/test_hide_rejected_job_openings_surfaces.py tests/integration/test_html_views.py` — passed, 8 tests.
+- `./.venv/bin/python -m pytest tests/integration/test_hide_rejected_job_openings_surfaces.py tests/integration/test_html_views.py tests/ui/test_saas_dashboard_ui_revamp.py` — failed, 11 passed / 5 failed. Failures are existing `tests/ui/test_saas_dashboard_ui_revamp.py` expectations that request routes without an HTML `Accept` header and assume seed data/detail IDs.
+- `./.venv/bin/python -m pytest` — failed, 49 passed / 5 failed. The same `tests/ui/test_saas_dashboard_ui_revamp.py` failures remain.
+
+## 6. Known Limitations / Follow-Ups
+
+- Full-suite validation is blocked by pre-existing UI revamp test harness assumptions documented by the backend handoff: several tests expect HTML responses without sending an HTML `Accept` header, and one detail test assumes `/jobs/1` exists.
+- This feature does not add a rejected-jobs management view or show-rejected toggle.
+- Direct rejected job details can still show rejected status badges by design.
+
+## 7. Commit Status
+
+Included in the frontend feature commit for hide rejected job openings; final commit hash is reported in the orchestration response.

--- a/docs/product/hide_rejected_job_openings_product_spec.md
+++ b/docs/product/hide_rejected_job_openings_product_spec.md
@@ -1,0 +1,139 @@
+# Product Specification
+
+## 1. Feature Overview
+Feature name: Hide Rejected Job Openings
+
+Update the main job openings display so that jobs classified as outright `rejected` are excluded by default. The main display must continue to show jobs that require user review and jobs that are matched.
+
+The feature is intended to keep the user's active opportunity review surface focused on actionable jobs only: jobs worth reviewing further and jobs already identified as matches.
+
+## 2. Problem Statement
+The main job openings display currently includes jobs that have been classified as rejected. This creates unnecessary clutter and makes the list less useful because outright rejected jobs are not actionable for the user.
+
+This matters because the job openings display is a primary workflow surface for deciding which opportunities deserve attention. Showing rejected jobs reduces scanning efficiency, inflates visible job counts, and may cause the user to revisit jobs the system has already determined should not be pursued.
+
+## 3. User Persona / Target User
+- Primary user: a job seeker using the job intelligence platform to review newly discovered job openings.
+- Usage context: the user opens the main job openings view to find jobs that are either strong matches or still need review.
+
+## 4. User Stories
+- As a job seeker, I want outright rejected jobs hidden from the main job openings display, so that I only spend time on actionable opportunities.
+- As a job seeker, I want review jobs to remain visible, so that I can evaluate opportunities that still need a decision.
+- As a job seeker, I want matched jobs to remain visible, so that strong opportunities stay easy to access.
+- As a job seeker, I want hidden rejected jobs to remain stored unless explicitly deleted by another feature, so that filtering does not unintentionally destroy data.
+
+## 5. Goals / Success Criteria
+- The main job openings display excludes jobs whose current/latest classification status is `rejected`.
+- Jobs whose current/latest classification status is `review` remain visible in the main job openings display when they otherwise match existing filters.
+- Jobs whose current/latest classification status is `matched` remain visible in the main job openings display when they otherwise match existing filters.
+- Rejected jobs are not deleted or reclassified solely because they are hidden from the main display.
+- User-facing counts associated with the main job openings display align with the displayed results and do not include hidden rejected jobs.
+
+## 6. Feature Scope
+### In Scope
+- Exclude outright rejected jobs from the main job openings display by default.
+- Retain `review` jobs in the main job openings display.
+- Retain `matched` jobs in the main job openings display.
+- Ensure default job-opening list counts, pagination, and empty states reflect the filtered result set.
+- Apply the same default exclusion consistently to the primary data source used by the main job openings display, not only through client-side visual hiding.
+- Preserve existing storage records for rejected jobs unless existing architecture already uses deletion as the only supported mechanism for removing jobs from this display.
+
+### Out of Scope
+- Deleting rejected jobs from storage unless existing architecture requires otherwise.
+- Changing matching, review, or rejection classification logic unless needed to support filtering by current/latest classification status.
+- Adding a new rejected-jobs management page.
+- Adding bulk delete, restore, archive, or export flows for rejected jobs.
+- Changing source ingestion behavior.
+- Changing the visual design of job cards/rows beyond any text or empty-state adjustments required by the filtered list.
+- Hiding rejected jobs from every administrative, debug, audit, or historical surface unless that surface is the same main job openings display or shares its default query intentionally.
+
+## 7. Functional Requirements
+1. The system must determine each job opening's display classification using the current/latest classification status available to the main job openings display.
+2. The main job openings display must include jobs with display classification `matched` when they satisfy all other existing display filters.
+3. The main job openings display must include jobs with display classification `review` when they satisfy all other existing display filters.
+4. The main job openings display must exclude jobs with display classification `rejected` regardless of source, title, company, location, or other existing list filters.
+5. The rejected-job exclusion must be applied before pagination so that pages are filled from eligible `matched` and `review` jobs rather than showing short pages due to hidden rejected rows.
+6. The rejected-job exclusion must be applied before main-list result counts are calculated so that displayed counts match the visible list.
+7. The rejected-job exclusion must work with existing search, sort, and filter controls on the main job openings display.
+8. If a job changes classification from `review` to `rejected`, it must no longer appear in the main job openings display after the classification change is persisted and the view is refreshed or reloaded.
+9. If a job changes classification from `rejected` to `review` or `matched`, it must appear in the main job openings display when it satisfies all other filters.
+10. The feature must not physically delete rejected job records unless existing architecture has no separate display-filtering mechanism and deletion is explicitly approved as an implementation necessity.
+11. The feature must not alter the classification status assigned to any job.
+12. Direct access to a rejected job detail page is not changed by this feature unless the existing product behavior routes detail visibility through the same main job openings display eligibility rules.
+
+## 8. Acceptance Criteria
+- AC-01: Given a job with current/latest classification `rejected`, when the user opens the main job openings display, then that job is not shown in the list.
+- AC-02: Given a job with current/latest classification `review`, when the user opens the main job openings display and the job satisfies all other active filters, then that job is shown in the list.
+- AC-03: Given a job with current/latest classification `matched`, when the user opens the main job openings display and the job satisfies all other active filters, then that job is shown in the list.
+- AC-04: Given a result set containing both rejected and non-rejected jobs, when the main job openings display calculates total results, then the total equals only the number of eligible `review` and `matched` jobs that satisfy active filters.
+- AC-05: Given pagination is enabled, when rejected jobs exist before or between eligible jobs in the underlying dataset, then the first page still contains eligible `review` and `matched` jobs up to the normal page size where enough eligible jobs exist.
+- AC-06: Given the user searches by a term that matches a rejected job and no eligible jobs, when the main job openings display loads search results, then the display shows the normal empty state and does not show the rejected job.
+- AC-07: Given the user filters by source, company, location, or other existing filters, when matching jobs include rejected jobs, then rejected jobs remain excluded and eligible `review`/`matched` jobs remain visible.
+- AC-08: Given a visible `review` job is reclassified as `rejected`, when the classification is persisted and the main job openings display is refreshed or reloaded, then the job is absent from the list and count.
+- AC-09: Given a hidden `rejected` job is reclassified as `review` or `matched`, when the classification is persisted and the main job openings display is refreshed or reloaded, then the job is visible if it satisfies all other active filters.
+- AC-10: Given a rejected job is hidden from the main job openings display, when storage is inspected through normal persistence mechanisms, then the job record still exists unless another pre-existing cleanup feature has deleted it.
+- AC-11: Given an empty state occurs because all jobs are rejected, when the main job openings display loads, then the UI must not imply an error; it must use the existing no-results/no-jobs empty state or equivalent copy.
+- AC-12: Given analytics or telemetry exists for the main job openings display, when the display loads, then emitted list/count metrics must be based on the filtered visible set or clearly distinguish total stored jobs from visible actionable jobs.
+
+## 9. Edge Cases
+- All stored jobs are `rejected`, resulting in an empty main job openings display.
+- A page of underlying data contains only rejected jobs but later pages contain eligible jobs; pagination must not show an empty page if eligible jobs exist for that page request.
+- A job has no classification status or a null/unknown classification.
+- A job has multiple classification records with different statuses.
+- A job's classification changes while the user is viewing the list.
+- Existing filters/search terms match only rejected jobs.
+- Rejected jobs exist with active tracking, reminders, saved state, or other user metadata.
+- Dashboard widgets, badges, or counts share the same data source as the main job openings display.
+- Direct navigation to a hidden rejected job detail URL.
+- Import/ingestion creates jobs already classified as rejected.
+
+## 10. Constraints
+- Technical constraints:
+  - Filtering must use the canonical current/latest classification status used elsewhere in the product.
+  - Filtering should be implemented in the data/query layer for the main display where feasible so counts and pagination are correct.
+  - The feature must preserve rejected job records unless a separately approved architecture constraint requires deletion.
+- UX constraints:
+  - The default main job openings experience should remain focused on actionable jobs only.
+  - Existing list controls should not expose rejected jobs accidentally through search, sort, pagination, or filters.
+  - Empty states should remain understandable when all available jobs are filtered out as rejected.
+- Business rules:
+  - `matched` and `review` are considered actionable for the main job openings display.
+  - `rejected` is considered non-actionable for the main job openings display.
+  - Hiding a job from the main display is not equivalent to deleting it.
+
+## 11. Dependencies
+- Existing job openings display and its backing API/query/data source.
+- Existing classification/status model for `matched`, `review`, and `rejected` jobs.
+- Existing list search, sort, filtering, pagination, and count behavior.
+- Any dashboard or summary components that intentionally reuse the main job openings display query.
+- Existing test fixtures or seed data for matched, review, and rejected jobs.
+- Analytics/telemetry framework, if currently implemented for list views or job counts.
+
+## 12. Assumptions
+- A1: `matched`, `review`, and `rejected` are existing classification states or buckets in the product.
+- A2: `rejected` means the job has been outright rejected and should not be part of the user's default actionable review workflow.
+- A3: `review` means the job still needs user attention or decision and should remain visible.
+- A4: `matched` means the job is considered a fit and should remain visible.
+- A5: The main job openings display means the primary user-facing list of job openings, not necessarily every admin/debug/reporting surface that can access job records.
+- A6: Current/latest classification status is the correct source of truth when multiple classification records exist.
+- A7: Jobs with no classification are not explicitly requested in this change; unless existing behavior maps them to `review`, their treatment requires clarification.
+
+## 13. Open Questions
+- OQ-01: Should jobs with missing, null, or unknown classification be shown as `review` or hidden from the main job openings display?
+- OQ-02: Are there any secondary surfaces, such as dashboard previews or job counts, that product considers part of the “main job openings display” and must also exclude rejected jobs?
+- OQ-03: Should users have any way to intentionally view rejected jobs in the future, or is rejected-job visibility limited to non-main/admin/debug surfaces?
+- OQ-04: Should direct job-detail URLs for rejected jobs remain accessible, or should they follow the same hidden behavior as the main job openings display?
+- OQ-05: If analytics currently records total job inventory, should rejected jobs be excluded from those metrics or reported separately from visible actionable jobs?
+
+## 14. Analytics / Telemetry Considerations
+- If list-view telemetry exists, track the count of visible actionable jobs after rejected jobs are excluded.
+- If total stored job counts are reported, distinguish them from visible main-display counts to avoid interpreting hidden rejected jobs as missing data.
+- No new analytics event is required solely for hiding rejected jobs unless the existing analytics model already tracks filter application or list composition.
+- Do not log job titles, descriptions, or other sensitive job content as part of telemetry for this feature.
+
+## 15. Risks
+- Counts or pagination may become inconsistent if rejected jobs are filtered only in the UI after data retrieval.
+- Existing tests or user expectations may assume rejected jobs appear in the main list for debugging or audit purposes.
+- Ambiguous treatment of null/unknown classifications could either hide actionable jobs or show jobs that should be excluded.
+- Shared queries may unintentionally hide rejected jobs from surfaces where historical or administrative visibility is still needed.
+- If classification changes occur while a user is viewing the list, the visible state may appear stale until refresh/reload unless existing real-time update behavior handles it.

--- a/docs/qa/hide_rejected_job_openings_test_plan.md
+++ b/docs/qa/hide_rejected_job_openings_test_plan.md
@@ -1,0 +1,188 @@
+# Test Plan
+
+## 1. Feature Overview
+
+Feature: Hide Rejected Job Openings
+
+The main Jobs display and dashboard actionable job summaries must exclude jobs whose current/latest classification is explicitly `rejected`, while preserving visibility for `matched`, `review`, `NULL`, and unknown non-rejected statuses where they otherwise satisfy existing visibility, search, sort, source, tracking, and bucket filters.
+
+Primary upstream artifacts:
+- Product Spec: `docs/product/hide_rejected_job_openings_product_spec.md`
+- Technical Design: `docs/architecture/hide_rejected_job_openings_technical_design.md`
+- UI/UX Spec: `docs/uiux/hide_rejected_job_openings_uiux_spec.md`
+
+Primary behavior under test:
+- `/jobs` HTML and JSON/API-equivalent results exclude rejected jobs at the query/data layer.
+- `/jobs?bucket=rejected` returns an empty/no-results state and does not reveal rejected jobs.
+- Dashboard actionable counts and matched/review previews exclude rejected jobs.
+- Direct `/jobs/{job_id}` access remains unchanged for rejected jobs unless existing source-delete visibility rules hide the job.
+- Rejected jobs remain persisted and are not reclassified or deleted by this feature.
+- The Jobs bucket selector no longer exposes `Rejected`; preferred all option label is `All actionable`.
+
+## 2. Acceptance Criteria Mapping
+
+| AC | Requirement | Planned Coverage |
+|---|---|---|
+| AC-01 | Rejected jobs are not shown in the main job openings display. | Unit predicate tests; API `/jobs` tests; HTML/UI list tests asserting no rejected rows/cards/badges. |
+| AC-02 | `review` jobs remain visible when they satisfy existing filters. | API, integration, and UI list tests with mixed `review`/`rejected` data. |
+| AC-03 | `matched` jobs remain visible when they satisfy existing filters. | API, integration, dashboard, and UI tests with mixed `matched`/`rejected` data. |
+| AC-04 | Main-display result totals/counts include only eligible non-rejected jobs. | Dashboard count tests; Jobs results-summary tests where present; JSON response length assertions. |
+| AC-05 | Filtering occurs before pagination so pages are filled with eligible jobs. | Design-level regression test if pagination exists; otherwise unit/query test asserting main-display predicate is applied before any future count/limit path and document current no-pagination behavior. |
+| AC-06 | Search matching only rejected jobs shows normal empty state and no rejected result. | API search test and HTML empty-state/UI test using a unique rejected-only title/company term. |
+| AC-07 | Existing filters do not reintroduce rejected jobs; eligible jobs remain visible. | API/integration matrix for bucket, tracking status, source, search, sort; UI filter tests. |
+| AC-08 | A visible `review` job reclassified to `rejected` disappears after persistence and refresh/reload. | Integration/API transition test updating latest/current classification, then reloading `/jobs` and dashboard. |
+| AC-09 | A hidden `rejected` job reclassified to `review` or `matched` appears after persistence and refresh/reload if otherwise eligible. | Integration/API transition tests for `rejected -> review` and `rejected -> matched`. |
+| AC-10 | Hidden rejected jobs remain in storage unless another cleanup feature deletes them. | Persistence assertions after `/jobs`, dashboard, and bucket-filter requests; verify `job_postings` and decisions unchanged. |
+| AC-11 | All-rejected datasets show normal no-results/no-jobs empty state, not an error. | HTML/UI empty-state test and API empty-list test. |
+| AC-12 | List/count telemetry, if present, uses filtered visible set or distinguishes stored totals. | Unit/integration test or log/event assertion where telemetry hooks exist; otherwise QA observation confirming no telemetry path implemented. |
+
+Additional explicit technical/UI requirements:
+
+| Requirement | Planned Coverage |
+|---|---|
+| `NULL` classification remains visible for MVP. | Unit predicate and `/jobs` API tests with `latest_bucket = NULL`. |
+| Unknown non-`rejected` classification remains visible for backward compatibility. | Unit predicate and `/jobs` API tests with `latest_bucket = "unknown"` or equivalent. |
+| `/jobs?bucket=rejected` must not reveal rejected jobs. | API and HTML/UI tests for direct bookmarked/stale URL. |
+| Direct rejected detail route is unchanged. | API/HTML detail test confirms rejected job detail returns existing success behavior when source-visible, and existing 404 behavior for source-hidden/deleted jobs. |
+| Dashboard actionable summaries/previews exclude rejected jobs. | Dashboard API/HTML tests for matched/review counts, rejected count `0` or omitted per contract, and preview-card contents. |
+| Jobs bucket selector excludes Rejected. | HTML/UI tests for select options and accessible label. |
+| Rejected jobs are not deleted or reclassified. | DB assertions before/after list/dashboard access and filter requests. |
+
+## 3. Test Scenarios
+
+### 3.1 Test Data Needs
+
+Create deterministic fixtures with unique titles/company/source values so search/filter assertions are unambiguous:
+
+| Fixture | `latest_bucket` | Current/decision state | Source state | Tracking | Expected `/jobs` default visibility |
+|---|---|---|---|---|---|
+| `qa_matched_actionable` | `matched` | current latest decision matched | active source | none | Visible |
+| `qa_review_actionable` | `review` | current latest decision review | active source | none | Visible |
+| `qa_rejected_hidden` | `rejected` | current latest decision rejected | active source | none | Hidden |
+| `qa_null_bucket_visible` | `NULL` | no current bucket/decision optional | active source | none | Visible per technical design |
+| `qa_unknown_bucket_visible` | non-`rejected` unknown value | latest unknown/nonstandard bucket | active source | none | Visible per technical design |
+| `qa_rejected_tracked_hidden` | `rejected` | current rejected | active source | tracked/saved | Hidden from main Jobs and dashboard actionable surfaces |
+| `qa_rejected_deleted_source` | `rejected` | current rejected | deleted/hidden source | any | Hidden; direct detail follows existing source-delete behavior |
+| `qa_matched_deleted_source_retained` | `matched` | current matched | deleted source with existing retention behavior | active/current state where applicable | Visible only if existing source-delete visibility permits |
+
+Data setup must preserve original classification rows and denormalized fields so tests can verify this feature does not mutate or delete records.
+
+### 3.2 Backend Unit Tests
+
+Recommended files:
+- `tests/unit/test_job_visibility.py`
+- Add focused tests to existing route/query unit tests if present.
+
+Coverage:
+1. Main-display/actionable visibility predicate composes existing source-delete visibility with status filtering.
+2. Predicate excludes only explicit `latest_bucket == "rejected"`.
+3. Predicate includes `matched`, `review`, `NULL`, and unknown non-rejected buckets.
+4. Predicate handles SQL `NULL` correctly with an explicit `IS NULL` branch, not only `!= "rejected"`.
+5. Predicate preserves existing deleted-source visibility rules.
+6. `apply_main_display_jobs()` or equivalent helper does not mutate `JobPosting.latest_bucket`, `latest_decision_id`, or `JobDecision` rows.
+7. Route query construction for `/jobs` and dashboard uses main-display helper; detail/mutation routes continue using existing visibility helper only.
+8. If telemetry/count helper exists, counts are derived from the filtered main-display set.
+
+### 3.3 Backend API / Integration Tests
+
+Recommended files:
+- `tests/api/test_hide_rejected_job_openings_api.py`
+- `tests/integration/test_hide_rejected_job_openings_surfaces.py`
+
+Coverage:
+1. `GET /jobs` returns `matched`, `review`, `NULL`, and unknown non-rejected jobs; excludes `rejected` jobs.
+2. `GET /jobs?bucket=matched` returns matched jobs only and excludes rejected jobs.
+3. `GET /jobs?bucket=review` returns review jobs only and excludes rejected jobs.
+4. `GET /jobs?bucket=rejected` returns an empty list/no-results response and no rejected job payloads.
+5. `GET /jobs?search=<rejected-only-term>` returns empty/no-results and no rejected payloads.
+6. `GET /jobs?search=<shared-term>` returns only eligible non-rejected matches when both rejected and non-rejected jobs match.
+7. Existing source, tracking, sort, and combined filters operate only within the non-rejected result set.
+8. Dashboard endpoint/page uses filtered actionable data: matched/review counts exclude rejected jobs; rejected count is `0` or omitted per implementation contract; previews contain no rejected jobs.
+9. Direct `GET /jobs/{rejected_job_id}` remains accessible for a source-visible rejected job if that was existing behavior.
+10. Direct `GET /jobs/{source_hidden_rejected_job_id}` follows existing source-delete not-found behavior.
+11. Reclassification `review -> rejected` removes the job from `/jobs` and dashboard after persisted update and reload.
+12. Reclassification `rejected -> review` and `rejected -> matched` makes the job visible after persisted update and reload when all other filters match.
+13. Rejected jobs remain present in normal persistence mechanisms after list/dashboard requests; no unintended delete/archive/reclassification occurs.
+14. All-rejected dataset returns empty `/jobs` and dashboard actionable counts/previews without server error.
+
+### 3.4 Frontend / UI Tests
+
+Recommended file:
+- `tests/ui/test_hide_rejected_job_openings_ui.py`
+
+Coverage:
+1. Jobs page default load renders only non-rejected table rows/cards.
+2. No rejected badge, rejected row/card, `.row-muted`, or `.job-card-muted` appears on `/jobs` for rejected fixture data.
+3. Bucket select contains only actionable options: all/default (`All actionable` preferred), `Matched`, and `Review`.
+4. Bucket select does not contain visible, hidden, disabled, or selected `Rejected` option.
+5. Stale/bookmarked `/jobs?bucket=rejected` shows normal empty state and the select visually falls back to the default actionable option.
+6. Results summary, if present, matches rendered non-rejected result count and does not imply total stored jobs include rejected entries.
+7. Empty state appears when all matching jobs are rejected and uses non-error copy.
+8. Search/filter form retains accessible labels and keyboard tab order after removing the rejected option.
+9. Dashboard matched/review stat cards and preview sections exclude rejected jobs; no clickable rejected dashboard card routes to `/jobs?bucket=rejected` unless retained as non-actionable contract fallback with value `0`.
+10. Direct rejected detail page can still show rejected status badge if existing detail behavior allows access.
+11. Responsive smoke checks verify desktop table and mobile card layouts both omit rejected jobs.
+
+### 3.5 Regression Tests
+
+Recommended regression scope:
+1. Existing source-delete visibility tests: ensure main-display rejected filtering composes with retained/hidden deleted-source rules.
+2. Existing jobs filters/search/sort tests: update expectations so rejected fixtures are no longer returned by main Jobs display.
+3. Existing dashboard tests: update counts/previews to actionable-only semantics.
+4. Existing classification flow tests: ensure classification still writes `job_decisions` and denormalized latest fields as before; only list visibility changes.
+5. Existing notifications/reminders/digest tests: confirm this feature does not silently alter out-of-scope reminder/tracking surfaces unless they intentionally reuse dashboard/main-display query.
+6. Existing detail route tests: confirm rejected detail access did not regress.
+7. Existing template tests for duplicate paths (`app/templates` and `app/web/templates`) if both are active or covered.
+
+### 3.6 Basic Security, Privacy, and Reliability Checks
+
+1. Confirm this feature is not treated as access control: rejected job detail remains governed by existing source-delete/detail visibility only.
+2. Confirm list/dashboard responses do not leak hidden rejected job titles/descriptions in rendered HTML, JSON payloads, data attributes, or dashboard previews.
+3. Confirm telemetry/log assertions, if implemented, do not log sensitive job title/description content and distinguish visible actionable counts from stored totals.
+4. Confirm no destructive mutation is triggered by list/dashboard access.
+5. Confirm stale query parameters (`bucket=rejected`, invalid bucket values if supported) fail closed for rejected visibility and do not produce stack traces.
+
+## 4. Edge Cases
+
+| Edge Case | Expected Result | Coverage |
+|---|---|---|
+| All jobs are rejected. | `/jobs` empty state; dashboard actionable counts/previews empty/zero; no error language. | API + UI empty-state tests. |
+| Underlying first page or first query batch contains rejected jobs before eligible jobs. | Eligible jobs fill the displayed page/list where pagination exists; no short/empty page due only to UI hiding. | Pagination regression if available; otherwise query-layer predicate unit/integration assertion. |
+| Job has `NULL` classification. | Visible by default per technical design. | Unit + API + UI fixture. |
+| Job has unknown non-`rejected` classification. | Visible by default per technical design/backward compatibility. | Unit + API fixture. |
+| Multiple classification records disagree. | Current/latest display classification (`latest_bucket`) controls visibility. | Integration fixture with historical rejected/current matched and historical matched/current rejected. |
+| Search term matches only rejected jobs. | Empty/no-results state; no rejected data leaked. | API + HTML/UI search tests. |
+| Source/tracking/company/location filters match rejected and non-rejected jobs. | Only eligible non-rejected jobs shown. | API/integration filter matrix. |
+| User manually requests `/jobs?bucket=rejected`. | Empty/no-results; no rejected option selected or exposed in UI. | API + UI bookmarked URL test. |
+| Rejected job is tracked/saved/has reminders. | Hidden from Jobs and dashboard actionable surfaces; out-of-scope reminder/tracking surfaces unchanged unless shared query. | Integration + regression tests. |
+| Rejected job direct detail URL. | Behavior unchanged; accessible if existing source visibility allows, 404 if existing rules hide it. | Detail route tests. |
+| Reclassification while user has page open. | Current page may remain stale; refresh/reload reflects persisted classification. | Integration transition tests. |
+| Duplicate template paths. | Active and tested template variants do not expose `Rejected` option. | HTML/template regression tests. |
+
+## 5. Test Types Covered
+
+- Functional correctness: main Jobs filtering, dashboard filtering, direct detail unchanged, no record mutation.
+- Validation and negative scenarios: stale `bucket=rejected`, rejected-only search/filter results, invalid/stale filters where supported.
+- Edge cases: all-rejected data, `NULL`/unknown buckets, multiple classification records, tracked rejected jobs, deleted-source composition.
+- API/UI consistency: JSON/API and server-rendered Jobs/Dashboard surfaces apply the same visibility rule.
+- Integration/regression: classification transitions, source-delete visibility composition, dashboard previews/counts, template option removal.
+- Basic reliability: query-layer filtering before counts/pagination where applicable; refresh/reload semantics after persisted classification changes.
+- Basic security/privacy: no hidden rejected payloads in main list/dashboard output; no sensitive telemetry/log expansion; no destructive side effects.
+
+Recommended commands once tests are implemented:
+
+```bash
+pytest tests/unit/test_job_visibility.py
+pytest tests/api/test_hide_rejected_job_openings_api.py
+pytest tests/integration/test_hide_rejected_job_openings_surfaces.py
+pytest tests/ui/test_hide_rejected_job_openings_ui.py
+pytest tests/unit tests/api tests/integration tests/ui
+```
+
+QA sign-off gate for this feature:
+- All critical API and UI tests prove rejected jobs are absent from `/jobs`, `/jobs?bucket=rejected`, search/filter results, dashboard counts, and dashboard previews.
+- `matched`, `review`, `NULL`, and unknown non-rejected jobs remain visible where expected and existing filters still work.
+- Direct rejected detail route behavior is unchanged except for pre-existing source-delete visibility rules.
+- Rejected job records and classification data remain persisted and unmodified by list/dashboard access.
+- No blocking regression in source-delete visibility, classification transitions, dashboard rendering, or jobs filter accessibility.
+- Any telemetry/count behavior either uses the filtered actionable set or clearly distinguishes visible actionable counts from total stored jobs.

--- a/docs/qa/hide_rejected_job_openings_test_report.md
+++ b/docs/qa/hide_rejected_job_openings_test_report.md
@@ -1,0 +1,132 @@
+# Test Report
+
+Feature: Hide Rejected Job Openings  
+Branch: `feature/hide_rejected_job_openings`  
+QA date: 2026-04-25
+
+## 1. Execution Summary
+
+### Automated test execution
+
+| Command | Scope | Result |
+|---|---|---|
+| `./.venv/bin/python -m pytest tests/unit/test_job_visibility.py tests/integration/test_hide_rejected_job_openings_surfaces.py tests/ui/test_hide_rejected_job_openings_ui.py -q` | Feature unit, integration, and UI validation | **13 passed / 0 failed** |
+| `./.venv/bin/python -m pytest tests/integration/test_html_views.py tests/integration/test_api_flow.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/api/test_source_delete_job_cleanup_api.py tests/ui/test_source_edit_delete_ui_qa.py -q` | Relevant Jobs/Dashboard/source-delete regression coverage | **17 passed / 0 failed** |
+| `./.venv/bin/python -m pytest -q` | Full repository suite | **49 passed / 5 failed** |
+
+### Summary counts
+
+- Critical feature-targeted tests: **13 total / 13 passed / 0 failed**
+- Relevant regression tests: **17 total / 17 passed / 0 failed**
+- Full suite: **54 total / 49 passed / 5 failed**
+
+The 5 full-suite failures are isolated to `tests/ui/test_saas_dashboard_ui_revamp.py` and are classified as unrelated test harness/data expectation issues, not defects in Hide Rejected Job Openings.
+
+### Acceptance criteria validation
+
+| AC | QA Result | Evidence |
+|---|---|---|
+| AC-01: Rejected jobs hidden from main Jobs display. | Pass | `test_jobs_api_excludes_rejected_and_keeps_null_unknown_visible`; `test_jobs_page_omits_rejected_rows_and_cards`. |
+| AC-02: Review jobs remain visible. | Pass | API and UI tests show review fixtures remain in `/jobs` and dashboard previews. |
+| AC-03: Matched jobs remain visible. | Pass | API and UI tests show matched fixtures remain in `/jobs` and dashboard previews. |
+| AC-04: Counts reflect eligible non-rejected jobs only. | Pass | Dashboard JSON asserts `matched_count == 1`, `review_count == 1`, `rejected_count == 0`; UI asserts `2 actionable job(s) found.` |
+| AC-05: Rejected exclusion applied before count/pagination. | Pass with current architecture note | Current implementation has no pagination. Code inspection confirms `/jobs` starts from `apply_main_display_jobs(select(JobPosting))` before bucket/search/source/sort handling. |
+| AC-06: Search matching only rejected jobs returns empty/no-results. | Pass | `test_jobs_filters_do_not_reintroduce_rejected_jobs` asserts `/jobs?search=Rejected%20Only` returns `[]`. |
+| AC-07: Existing filters do not reintroduce rejected jobs. | Pass | Bucket rejected, shared search, and source filter tests pass; regression suites passed. |
+| AC-08: Review -> rejected disappears after refresh/reload. | Pass | `test_reclassification_transitions_affect_main_display_without_deleting_records`. |
+| AC-09: Rejected -> matched/review appears after refresh/reload when eligible. | Pass | `test_reclassification_transitions_affect_main_display_without_deleting_records` validates rejected -> matched visibility. |
+| AC-10: Rejected jobs are not deleted. | Pass | Tests assert rejected record still exists and remains `latest_bucket == "rejected"` after Jobs access. |
+| AC-11: All-rejected data shows normal empty state. | Pass | `test_all_rejected_jobs_render_normal_empty_state`; `/jobs?bucket=rejected` UI empty state validated. |
+| AC-12: Analytics/telemetry counts based on filtered visible set or distinguished. | Pass / not applicable | No dedicated analytics/telemetry event path found; dashboard count contract uses filtered actionable set. |
+
+### Additional QA validations
+
+- `/jobs` excludes rejected records and includes `matched`, `review`, `NULL`, and unknown non-rejected buckets.
+- `/jobs?bucket=rejected` returns an empty result set and does not reveal rejected payloads.
+- Jobs page bucket selector exposes only `All actionable`, `Matched`, and `Review`; no `Rejected` option is rendered.
+- Dashboard actionable counts/previews exclude rejected jobs and do not render a `/jobs?bucket=rejected` link.
+- Direct rejected job detail route remains unchanged for source-visible rejected jobs; JSON detail returns 200 with `latest_bucket == "rejected"`.
+- Source-delete visibility composition remains covered by passing regression tests.
+- Rejected records are not deleted, archived, or reclassified by list/dashboard access.
+
+## 2. Failed Tests
+
+Full-suite failures from `./.venv/bin/python -m pytest -q`:
+
+1. `tests/ui/test_saas_dashboard_ui_revamp.py::test_dashboard_renders_html_shell`
+   - Error: expected `text/html`, received `application/json`.
+   - Relevant log: response body was JSON dashboard counts: `{"matched_count":0,"review_count":0,"rejected_count":0,...}`.
+
+2. `tests/ui/test_saas_dashboard_ui_revamp.py::test_jobs_index_renders_management_table_ui`
+   - Error: expected `text/html`, received `application/json`.
+   - Relevant log: response body was `[]`.
+
+3. `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view`
+   - Error: expected status `200`, received `404` for `/jobs/1`.
+   - Relevant log: `{"detail":"Job not found."}`.
+
+4. `tests/ui/test_saas_dashboard_ui_revamp.py::test_sources_index_renders_management_table_ui`
+   - Error: expected `text/html`, received `application/json`.
+   - Relevant log: response body was `[]`.
+
+5. `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`
+   - Error: failed to find source detail link in `/sources` response.
+   - Relevant log: `/sources` response body was `[]`.
+
+## 3. Failure Classification
+
+| Failed test | Classification | Feature-related? | Rationale |
+|---|---|---:|---|
+| `test_dashboard_renders_html_shell` | Test Bug / Harness Issue | No | Test requests `/dashboard` without `Accept: text/html` but asserts HTML shell. Existing route returns JSON unless HTML is requested. Feature-specific dashboard HTML tests request `Accept: text/html` and pass. |
+| `test_jobs_index_renders_management_table_ui` | Test Bug / Harness Issue | No | Test requests `/jobs` without `Accept: text/html` but asserts HTML. JSON `[]` is expected for an empty test DB/API request. Feature-specific Jobs UI tests request HTML and pass. |
+| `test_job_detail_renders_html_detail_view` | Test Data Issue | No | Test assumes `/jobs/1` exists without seeding a job. Failure is 404 due to missing fixture, not rejected-job filtering. |
+| `test_sources_index_renders_management_table_ui` | Test Bug / Harness Issue | No | Test requests `/sources` without `Accept: text/html` but asserts HTML. JSON `[]` is expected for an empty source list/API request. |
+| `test_source_detail_renders_html_detail_view` | Test Data / Harness Issue | No | Test expects an HTML source link in a JSON empty response and does not seed source data. |
+
+No failed test shows a rejected job leaking into `/jobs`, `/jobs?bucket=rejected`, dashboard counts/previews, or an unintended mutation/deletion of rejected records.
+
+## 4. Observations
+
+- The implementation uses `apply_main_display_jobs(select(JobPosting))` for `/jobs` and dashboard actionable loading, which supports query-layer filtering rather than UI-only hiding.
+- `actionable_job_status_predicate()` explicitly includes `NULL` buckets and excludes only `latest_bucket == "rejected"`, matching the technical design.
+- Direct job detail uses `apply_visible_jobs()` rather than `apply_main_display_jobs()`, preserving detail access behavior for source-visible rejected jobs.
+- The full-suite failures are stable and reproducible; they are not flaky and are unrelated to the new feature.
+- Current `/jobs` implementation has no pagination, so pagination acceptance was validated by query-layer placement and current architectural constraints rather than page-boundary execution.
+
+## 5. QA Decision
+
+APPROVED
+
+All critical Hide Rejected Job Openings validations passed. Remaining full-suite failures are unrelated/pre-existing UI test harness and fixture assumptions.
+
+[QA SIGN-OFF APPROVED]
+
+---
+
+## 6. Regression Re-check After Source Active Checkbox Fix
+
+Fix commit re-checked: `3b33e28 Fix source active checkbox parsing`  
+Regression QA date: 2026-04-25
+
+### Automated regression execution
+
+| Command | Scope | Result |
+|---|---|---|
+| `./.venv/bin/python -m pytest tests/unit/test_job_visibility.py tests/integration/test_hide_rejected_job_openings_surfaces.py tests/ui/test_hide_rejected_job_openings_ui.py -q` | Hide-rejected targeted unit/integration/UI regression | **13 passed / 0 failed** |
+| `./.venv/bin/python -m pytest tests/integration/test_html_views.py tests/integration/test_api_flow.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/api/test_source_delete_job_cleanup_api.py tests/ui/test_source_edit_delete_ui_qa.py -q` | Related Jobs/Dashboard/source-delete regression | **17 passed / 0 failed** |
+| `./.venv/bin/python -m pytest tests/unit tests/api tests/integration -q` | Backend/API/integration suites | **39 passed / 0 failed** |
+| `./.venv/bin/python -m pytest -q` | Full repository suite | **54 passed / 5 failed** |
+
+### Regression result
+
+Hide Rejected Job Openings remains approved after the source active checkbox/run blocker fix. Targeted tests continue to validate:
+
+- `/jobs` excludes rejected jobs and retains matched/review/null/unknown non-rejected jobs.
+- `/jobs?bucket=rejected` returns no rejected records.
+- Dashboard actionable counts/previews exclude rejected jobs.
+- Jobs UI bucket selector exposes actionable options only.
+- Direct rejected job detail behavior remains unchanged.
+
+The remaining 5 full-suite failures are still isolated to `tests/ui/test_saas_dashboard_ui_revamp.py` and remain classified as unrelated HTML Accept-header/test fixture assumptions.
+
+[QA SIGN-OFF APPROVED]

--- a/docs/qa/source_active_checkbox_run_blocker_qa_report.md
+++ b/docs/qa/source_active_checkbox_run_blocker_qa_report.md
@@ -1,0 +1,82 @@
+# Test Report
+
+Feature/Fix: Source Active Checkbox Run Blocker  
+Branch: `feature/hide_rejected_job_openings`  
+Fix commit: `3b33e28 Fix source active checkbox parsing`  
+QA date: 2026-04-25
+
+## 1. Execution Summary
+
+### Automated test execution
+
+| Command | Scope | Result |
+|---|---|---|
+| `./.venv/bin/python -m pytest tests/integration/test_source_edit_delete_html.py -q` | Source create/edit checkbox parsing and run-blocker regression | **7 passed / 0 failed** |
+| `./.venv/bin/python -m pytest tests/unit/test_job_visibility.py tests/integration/test_hide_rejected_job_openings_surfaces.py tests/ui/test_hide_rejected_job_openings_ui.py -q` | Hide Rejected Job Openings targeted regression | **13 passed / 0 failed** |
+| `./.venv/bin/python -m pytest tests/integration/test_html_views.py tests/integration/test_api_flow.py tests/integration/test_source_delete_job_cleanup_surfaces.py tests/api/test_source_delete_job_cleanup_api.py tests/ui/test_source_edit_delete_ui_qa.py -q` | Related HTML/API/source-delete regression | **17 passed / 0 failed** |
+| `./.venv/bin/python -m pytest tests/unit tests/api tests/integration -q` | Backend/API/integration suites | **39 passed / 0 failed** |
+| `./.venv/bin/python -m pytest -q` | Full repository suite | **54 passed / 5 failed** |
+
+### Validation requirements status
+
+| Requirement | QA Result | Evidence |
+|---|---|---|
+| Source creation with checked checkbox value `true` persists active. | Pass | `test_source_create_form_accepts_true_checkbox_value` passed; DB assertion verifies `source.is_active is True`. |
+| Source creation with checked checkbox value `on` persists active. | Pass | `test_source_create_form_accepts_on_checkbox_value` passed; DB assertion verifies `source.is_active is True`. |
+| Omitted checkbox persists inactive if intended. | Pass | `test_source_create_form_omitted_checkbox_persists_inactive` passed; aligns with implementation assumption that missing checkbox means unchecked/inactive. |
+| Edit flow uses corrected active-state parsing. | Pass | `test_source_edit_form_accepts_true_checkbox_value` passed; inactive source updated to active via HTML edit form with `is_active=true`. |
+| Active source does not fail immediately with inactive-source 409 on `Run now`. | Pass | `test_source_created_with_true_checkbox_can_run_without_inactive_conflict` passed using mocked Greenhouse HTTP response; run returned 200 with expected `source_id`, not inactive-source 409. |
+| Hide-rejected-jobs feature remains valid. | Pass | Targeted hide-rejected unit/integration/UI suite passed 13/13. |
+| Remaining full-suite failures inspected/classified. | Pass | All 5 failures remain isolated to `tests/ui/test_saas_dashboard_ui_revamp.py`; see classification below. |
+
+## 2. Failed Tests
+
+Full-suite failures from `./.venv/bin/python -m pytest -q`:
+
+1. `tests/ui/test_saas_dashboard_ui_revamp.py::test_dashboard_renders_html_shell`
+   - Error: expected `text/html`, received `application/json`.
+   - Relevant log: response body was JSON dashboard counts: `{"matched_count":0,"review_count":0,"rejected_count":0,...,"source_count":1}`.
+
+2. `tests/ui/test_saas_dashboard_ui_revamp.py::test_jobs_index_renders_management_table_ui`
+   - Error: expected `text/html`, received `application/json`.
+   - Relevant log: response body was `[]`.
+
+3. `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view`
+   - Error: expected status `200`, received `404` for `/jobs/1`.
+   - Relevant log: `{"detail":"Job not found."}`.
+
+4. `tests/ui/test_saas_dashboard_ui_revamp.py::test_sources_index_renders_management_table_ui`
+   - Error: expected `text/html`, received `application/json`.
+   - Relevant log: response body was JSON source data from the non-isolated app database, not an HTML shell.
+
+5. `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`
+   - Error: failed to find an HTML source link in `/sources` response.
+   - Relevant log: `/sources` returned JSON source data, so the HTML-link regex could not match.
+
+## 3. Failure Classification
+
+| Failed test | Classification | Related to checkbox fix? | Related to hide-rejected feature? | Rationale |
+|---|---|---:|---:|---|
+| `test_dashboard_renders_html_shell` | Test Bug / Harness Issue | No | No | Test requests `/dashboard` without `Accept: text/html` while route returns JSON by default. HTML-specific tests using the correct Accept header pass. |
+| `test_jobs_index_renders_management_table_ui` | Test Bug / Harness Issue | No | No | Test requests `/jobs` without `Accept: text/html` while route returns JSON by default. Hide-rejected HTML UI tests use the correct Accept header and pass. |
+| `test_job_detail_renders_html_detail_view` | Test Data Issue | No | No | Test assumes `/jobs/1` exists without creating a job fixture; 404 is expected when no such job exists. |
+| `test_sources_index_renders_management_table_ui` | Test Bug / Environment Data Issue | No | No | Test requests `/sources` without `Accept: text/html` and uses the global app client outside isolated DB fixtures; JSON response is not evidence of source active parsing failure. |
+| `test_source_detail_renders_html_detail_view` | Test Bug / Environment Data Issue | No | No | Test parses an HTML link from a JSON response and does not use isolated seeded HTML fixture flow. |
+
+No failed full-suite test demonstrates that a checked `true`/`on` checkbox persists inactive, that active source run flow is blocked with inactive-source 409, or that rejected jobs leak into Jobs/Dashboard surfaces.
+
+## 4. Observations
+
+- Code inspection confirms `parse_form_checkbox()` treats `None` as `False` and accepts `on`, `true`, `1`, and `yes` as truthy.
+- `parse_source_form()` now uses `parse_form_checkbox(form.get("is_active"))`; source create and edit flows share this parser.
+- Run validation used a mocked Greenhouse adapter HTTP response (`{"jobs": []}`) to avoid live network dependency and isolate the inactive-source blocker behavior.
+- Hide-rejected regression remains stable after commit `3b33e28`: `/jobs`, `/jobs?bucket=rejected`, dashboard actionable counts/previews, direct detail behavior, null/unknown visibility, and UI filter behavior remain covered by passing targeted tests.
+- Existing full-suite UI revamp failures remain stable and unrelated to both this fix and hide-rejected job visibility.
+
+## 5. QA Decision
+
+APPROVED
+
+The source active checkbox/run blocker fix meets validation requirements, and the Hide Rejected Job Openings feature remains valid after regression testing. Remaining full-suite failures are unrelated test harness/data issues.
+
+[QA SIGN-OFF APPROVED]

--- a/docs/release/hide_rejected_job_openings_issue.md
+++ b/docs/release/hide_rejected_job_openings_issue.md
@@ -1,0 +1,85 @@
+# GitHub Issue
+
+## 1. Feature Name
+Hide Rejected Job Openings
+
+## 2. Problem Summary
+The main job openings display currently includes jobs classified as `rejected`, creating clutter and inflating the active review surface with non-actionable opportunities. The feature should hide explicitly rejected jobs from the primary Jobs list and dashboard actionable summaries while continuing to show `matched`, `review`, and non-rejected/null/unknown jobs according to existing visibility rules.
+
+## 3. Linked Planning Documents
+- Product Spec: `docs/product/hide_rejected_job_openings_product_spec.md`
+- Technical Design: `docs/architecture/hide_rejected_job_openings_technical_design.md`
+- UI/UX Spec: `docs/uiux/hide_rejected_job_openings_uiux_spec.md`
+- QA Test Plan: `docs/qa/hide_rejected_job_openings_test_plan.md`
+
+## 4. Scope Summary
+- in scope
+  - Exclude jobs with current/latest classification `rejected` from `/jobs` HTML and JSON/API-equivalent results by default.
+  - Keep `matched`, `review`, `NULL`, and unknown non-`rejected` jobs visible when they satisfy existing filters and source visibility rules.
+  - Apply filtering at the backend/query layer before counts and any current or future pagination semantics.
+  - Update dashboard actionable counts/previews to exclude rejected jobs.
+  - Remove or suppress the `Rejected` option from the main Jobs bucket selector.
+  - Preserve direct rejected job detail behavior under existing source-delete visibility rules.
+- out of scope
+  - Deleting, archiving, restoring, exporting, or reclassifying rejected jobs.
+  - Adding a rejected-jobs management page or “show rejected” toggle.
+  - Changing ingestion or classification algorithms.
+  - Hiding rejected jobs from every admin, debug, audit, reminder, tracking, or historical surface unless it intentionally uses the main display query.
+
+## 5. Implementation Notes
+- frontend expectations
+  - Jobs bucket selector should expose only `All actionable` or equivalent default, `Matched`, and `Review`.
+  - Jobs rows/cards and dashboard actionable previews must not render rejected jobs.
+  - Empty states should use normal no-results language and must not imply an error or deletion.
+  - Duplicate template paths should be checked and kept consistent where active/tested.
+- backend expectations
+  - Add a reusable main-display/actionable visibility helper composed with existing source-delete visibility.
+  - Use `JobPosting.latest_bucket` as the current display classification source for MVP.
+  - Exclude only explicit `latest_bucket == "rejected"`; include `NULL` and unknown non-rejected values for backward compatibility.
+  - Apply the helper to `/jobs` query construction and dashboard actionable summaries/previews.
+  - Keep `/jobs/{job_id}` and mutation routes on existing visibility behavior unless product later changes detail access rules.
+- dependencies or blockers
+  - Depends on existing `latest_bucket` denormalization and source-delete visibility helpers.
+  - No schema migration is expected.
+  - Open product question remains whether null/unknown classifications should eventually be hidden instead of shown.
+  - Dashboard `rejected_count` contract may need backward-compatible handling as `0` or omission.
+
+## 6. QA Section
+- planned test coverage
+  - Unit tests for composed visibility predicates, explicit rejected exclusion, null/unknown inclusion, and source-delete compatibility.
+  - API/integration tests for `/jobs`, bucket filters, search, source/tracking filters, dashboard summaries/previews, direct detail behavior, and classification transitions.
+  - UI/template tests for absence of rejected rows/cards/options, accessible bucket selector behavior, empty states, and responsive rendering.
+  - Regression tests for source-delete, classification flow, dashboard, detail routes, notifications/reminders where applicable, and duplicate templates.
+- acceptance criteria mapping
+  - AC-01 through AC-03: rejected hidden; review and matched visible.
+  - AC-04 through AC-07: counts, search, filters, and pagination semantics operate on eligible non-rejected jobs.
+  - AC-08 through AC-09: reclassification changes are reflected after persistence and reload.
+  - AC-10: rejected records remain persisted and unmodified.
+  - AC-11: all-rejected datasets show normal empty states.
+  - AC-12: telemetry/count behavior uses or clearly distinguishes the filtered visible set.
+- key edge cases
+  - All jobs rejected.
+  - Search/filter matches only rejected jobs.
+  - `bucket=rejected` supplied manually.
+  - `NULL` or unknown non-rejected bucket values.
+  - Multiple classification records where latest/current status controls visibility.
+  - Rejected tracked jobs, source-deleted jobs, and direct rejected detail URLs.
+  - Classification changes while the user is viewing the list.
+- test types expected
+  - Unit, API, integration, server-rendered HTML/UI, regression, accessibility smoke, reliability, and basic security/privacy checks.
+
+## 7. Risks / Open Questions
+- Filtering only in the UI would cause inconsistent counts and future pagination issues; backend/query-layer filtering is required.
+- Product may prefer strict `matched`/`review` inclusion later, which would change current null/unknown handling.
+- Dashboard clients may depend on a `rejected_count` field; implementation should preserve or intentionally revise the contract.
+- Tracking/reminder surfaces may still expose rejected jobs if outside the main display; confirm whether this is acceptable.
+- Duplicate template paths may drift if only one path is updated.
+
+## 8. Definition of Done
+- `/jobs` default, search, sort, source, tracking, and bucket filters exclude explicit rejected jobs and retain eligible non-rejected jobs.
+- Dashboard actionable counts and previews exclude rejected jobs.
+- Jobs bucket selector no longer exposes `Rejected`.
+- Rejected jobs are not deleted, archived, or reclassified by list/dashboard access.
+- Direct rejected job detail behavior remains unchanged under existing visibility rules.
+- Tests cover planned unit, API/integration, UI, regression, and edge-case scenarios from the QA test plan.
+- All documented acceptance criteria are satisfied or explicitly dispositioned.

--- a/docs/release/hide_rejected_job_openings_pr.md
+++ b/docs/release/hide_rejected_job_openings_pr.md
@@ -1,0 +1,40 @@
+# Pull Request
+
+## 1. Feature Name
+Hide Rejected Job Openings
+
+## 2. Summary
+Hide outright rejected job openings from the main actionable Jobs and Dashboard views while preserving matched, review, null, and unknown non-rejected jobs under existing visibility rules. This branch also fixes the source active checkbox parsing blocker that caused checked sources to persist inactive and block Run now.
+
+## 3. Related Documents
+- Product Spec: docs/product/hide_rejected_job_openings_product_spec.md
+- Technical Design: docs/architecture/hide_rejected_job_openings_technical_design.md
+- UI/UX Spec: docs/uiux/hide_rejected_job_openings_uiux_spec.md
+- QA Report: docs/qa/hide_rejected_job_openings_test_report.md
+- QA Report: docs/qa/source_active_checkbox_run_blocker_qa_report.md
+- Planning Issue: https://github.com/michaelseno/job-intelligence-platform/issues/8
+
+## 4. Changes Included
+- Adds reusable main-display visibility filtering so explicit `rejected` jobs are excluded from actionable job surfaces.
+- Updates Jobs and Dashboard routes/templates so rejected jobs are hidden from lists, counts, previews, and the primary bucket selector.
+- Adds backend, integration, and UI regression coverage for rejected-job filtering behavior.
+- Fixes source active checkbox parsing so checked sources persist active and no longer block Run now validation.
+- Includes product, architecture, UI/UX, QA, backend/frontend implementation, bug, issue, and release documentation artifacts.
+
+## 5. QA Status
+- Approved: YES
+- [QA SIGN-OFF APPROVED]
+
+## 6. Test Coverage
+- Source checkbox/run blocker tests: 7 passed / 0 failed.
+- Hide-rejected targeted regression: 13 passed / 0 failed.
+- Related regression suites: 17 passed / 0 failed.
+- Backend/API/integration suites: 39 passed / 0 failed.
+- Full suite: 54 passed / 5 failed.
+- Remaining full-suite failures are isolated to `tests/ui/test_saas_dashboard_ui_revamp.py` and classified as unrelated HTML Accept-header/test fixture issues.
+
+## 7. Risks / Notes
+- Rejected jobs are hidden from main actionable displays only; records are not deleted or reclassified.
+- Direct rejected job detail behavior remains governed by existing source-delete visibility rules.
+- Null and unknown non-rejected bucket values remain visible for MVP per the technical design.
+- Dashboard rejected-count contract may require future cleanup if product chooses to remove the field entirely.

--- a/docs/uiux/hide_rejected_job_openings_uiux_spec.md
+++ b/docs/uiux/hide_rejected_job_openings_uiux_spec.md
@@ -1,0 +1,319 @@
+# Design Specification
+
+## 1. Feature Overview
+
+Feature: Hide Rejected Job Openings
+
+The main user-facing Jobs display must become an actionable queue that shows jobs whose current display classification is `matched`, `review`, or otherwise not explicitly `rejected`. Jobs classified as `rejected` are hidden from the Jobs list, Jobs filter options, dashboard actionable summaries, and dashboard job preview cards.
+
+Rejected jobs are not deleted, archived, or reclassified by this feature. Direct access to a rejected job detail URL is unchanged: if the job is otherwise visible under existing source-delete rules, `/jobs/{job_id}` may still render the detail page.
+
+Primary affected surfaces:
+- `/jobs` HTML Jobs list and its JSON/API equivalent
+- Jobs list bucket filter
+- Dashboard actionable job summary counts and matched/review preview cards
+- Duplicate template paths currently present in the repository:
+  - `app/web/templates/jobs/list.html`
+  - `app/templates/jobs/list.html`
+  - `app/web/templates/dashboard/index.html`
+  - `app/templates/dashboard/index.html`
+
+Out of scope:
+- A rejected-jobs management page
+- A “show rejected” toggle
+- Any deletion, archive, restore, or export flow
+- Changing classification logic or detail-page access control
+
+## 2. User Goal
+
+As a job seeker reviewing opportunities, I want the main Jobs page and dashboard to show only actionable jobs, so I can focus on matches and jobs that still need review without repeatedly scanning opportunities the system has already rejected.
+
+## 3. UX Rationale
+
+- The main Jobs list is a triage workspace. Rejected jobs are non-actionable in this workflow and should not compete visually with matched or review jobs.
+- Hiding rejected jobs at the query/data layer keeps counts, search results, and future pagination consistent with what the user sees.
+- Removing the visible `Rejected` bucket option avoids suggesting that rejected jobs are available as a normal main-page filter.
+- Existing UI patterns should remain stable: this feature is a visibility and copy change, not a redesign of job cards, tables, badges, or tracking controls.
+
+## 4. Information Hierarchy
+
+### Jobs page
+1. Page header: “Jobs” with existing triage description.
+2. Filter form:
+   - Search jobs
+   - Automated bucket / classification filter with actionable options only
+   - Tracking status
+   - Source
+   - Sort
+   - Apply and reset controls
+3. Results summary count based only on visible actionable jobs.
+4. Job table on desktop and job cards on mobile.
+5. Empty state when no visible actionable jobs match the current view.
+
+### Dashboard
+1. Page header and primary actions remain unchanged.
+2. Actionable summary cards/counts:
+   - Matched
+   - Review / Needs review
+   - Other non-job cards such as reminders and sources remain unchanged.
+3. Recent matched jobs preview.
+4. Recent review jobs / jobs needing attention preview.
+5. Existing reminders/source health sections remain outside this feature unless they intentionally reuse the main display query.
+
+## 5. Layout Structure
+
+### Jobs filter panel
+
+Keep the existing form layout and responsive behavior. Only update bucket filter options/copy.
+
+Recommended desktop/web-template structure:
+
+```text
+Panel
+└─ Filters form
+   ├─ Search jobs input
+   ├─ Automated bucket select
+   │  ├─ All actionable
+   │  ├─ Matched
+   │  └─ Review
+   ├─ Tracking status select
+   ├─ Source select
+   ├─ Sort select
+   └─ Apply filters / Reset filters
+```
+
+If minimal copy change is preferred, `All buckets` may remain, but `All actionable` is recommended because the default no longer represents all stored job buckets.
+
+### Jobs results
+
+Keep the existing table/card layouts. Rejected rows/cards should not be rendered in the Jobs list at all, so rejected-specific muted row/card styling should not be observable on this surface after implementation.
+
+Desktop table columns remain unchanged unless the active template differs:
+- Role
+- Automated bucket / Status
+- Tracking
+- Score or last updated depending on template
+- Reason/source metadata as currently implemented
+- Actions
+
+Mobile cards remain unchanged in structure and should show only non-rejected jobs.
+
+### Dashboard summaries
+
+Preferred dashboard structure:
+- Do not show a visible `Rejected` stat card in the user-facing dashboard if the card represents the actionable Jobs surface.
+- Keep Matched and Review/Needs review cards and link them to `/jobs?bucket=matched` and `/jobs?bucket=review`.
+- Existing non-actionable operational cards such as Pending reminders, Active sources, Saved needing action, and Applied follow-up may remain if already present.
+
+Backward-compatible fallback if the API/template contract requires `summary.rejected` temporarily:
+- The value must be `0` after main-display filtering.
+- Avoid linking users to `/jobs?bucket=rejected` from normal dashboard UI.
+- If the card cannot be removed immediately, label it in a way that does not imply a browsable queue, but removal is strongly preferred for this feature.
+
+## 6. Components
+
+### Bucket select
+
+Component: existing native `<select>`.
+
+Required options on main Jobs page:
+- `value=""`: “All actionable”
+- `value="matched"`: “Matched”
+- `value="review"`: “Review”
+
+Do not include:
+- `value="rejected"`: “Rejected”
+
+If a bookmarked URL contains `?bucket=rejected`, the select should not display a selected rejected option. Preferred UI state is defaulting the select visually to “All actionable” while the result set remains empty due to backend compatibility behavior. Do not add a hidden or disabled rejected option.
+
+### Results summary
+
+Component: existing `.results-summary` paragraph when present.
+
+Recommended copy:
+- `{{ jobs|length }} actionable job(s) found.`
+
+Acceptable existing copy may remain if it does not imply rejected jobs are included. Avoid “all jobs found” wording.
+
+### Job rows/cards
+
+Component: existing table rows and `.job-card` mobile cards.
+
+Behavior:
+- Render matched, review, null, and unknown non-rejected jobs according to backend eligibility rules.
+- Do not render rejected rows/cards on the main Jobs page.
+- Existing rejected badge tone may remain available for detail/admin/debug surfaces; do not remove global badge styling.
+
+### Dashboard stat cards
+
+Component: existing `ui.stat_card` or `.stat-card`.
+
+Expected user-facing cards:
+- Matched: count of visible actionable matched jobs.
+- Review / Needs review: count of visible actionable review jobs.
+- Non-job workflow cards unchanged.
+
+Do not present a clickable Rejected dashboard card that routes to `/jobs?bucket=rejected`.
+
+### Empty state
+
+Component: existing `ui.empty_state`.
+
+Jobs page preferred copy:
+- Title: “No actionable jobs found”
+- Body: “Matched and review jobs that meet your filters will appear here. Rejected jobs are hidden from this main view.”
+- CTA: existing `/sources` action such as “Open Sources” or “Manage sources” when appropriate.
+
+If product prefers not to mention rejected jobs in empty states, the existing copy is acceptable:
+- “No jobs match the current view”
+- “Either ingestion has not produced jobs yet, or the current filters narrow the list to zero results.”
+
+Dashboard all-hidden/no-actionable state preferred copy:
+- Title: “No actionable jobs yet”
+- Body: “Matched and review jobs will appear here after ingestion. Rejected jobs are hidden from the dashboard queue.”
+
+## 7. Interaction Behavior
+
+### Default Jobs page load
+1. User opens `/jobs`.
+2. Bucket select defaults to “All actionable”.
+3. List contains eligible non-rejected jobs only.
+4. Results summary count equals the number of rendered jobs.
+5. Rejected jobs are not visible and cannot be selected through the bucket filter.
+
+### Filtering
+- Search, tracking status, source, and sort operate only within the non-rejected main-display set.
+- Selecting “Matched” shows matched jobs only, excluding rejected jobs regardless of other filters.
+- Selecting “Review” shows review jobs only, excluding rejected jobs regardless of other filters.
+- Reset filters returns to `/jobs` with “All actionable”.
+- A manually entered `/jobs?bucket=rejected` URL returns an empty list/no-results state and should not reveal rejected jobs.
+
+### Dashboard summaries and previews
+- Matched and review counts use the same actionable main-display eligibility as `/jobs`.
+- Recent matched/review preview cards must not include rejected jobs.
+- Links from dashboard should target only supported visible filters: `/jobs`, `/jobs?bucket=matched`, `/jobs?bucket=review`, and existing tracking/source routes.
+
+### Classification changes
+- If a visible review or matched job is reclassified as rejected, it remains on a currently loaded server-rendered page until refresh/reload unless an existing real-time mechanism already updates it.
+- After refresh/reload, the job disappears from Jobs list and dashboard actionable summaries.
+- If a rejected job is later reclassified as review or matched, it appears after refresh/reload when it satisfies other active filters.
+
+### Detail access
+- Clicking from the main list cannot navigate to a rejected job because rejected jobs are absent.
+- Direct navigation to `/jobs/{job_id}` for a rejected job is unchanged by this feature. If the detail route currently allows the job under source-delete visibility rules, show the detail page as before.
+- The detail page may continue to show a Rejected badge/status for that job. This is not a main-page filter option.
+
+## 8. Component States
+
+### Bucket select
+- Default: “All actionable” selected; Matched and Review available.
+- Hover: native browser hover behavior; no custom visual change required.
+- Focus: visible focus ring using existing form control focus styles; label must remain associated with select.
+- Active/open: native select menu displays only actionable options.
+- Disabled: not disabled under normal conditions.
+- Loading: no special loading state for server-rendered form; page reload is acceptable.
+- Error: if backend rejects an invalid bucket in the future, display normal form/list error handling. Current technical design prefers empty results for `bucket=rejected`, not a 400.
+
+### Jobs list
+- Default: renders eligible non-rejected jobs.
+- Empty: use empty state; do not show an error when all stored jobs are rejected.
+- Loading: full page reload only; no skeleton required.
+- Success: results and counts match current filters after refresh.
+- Error: use existing page-level error handling; do not expose query internals.
+
+### Job row/card
+- Default: normal row/card styling for matched/review/non-rejected jobs.
+- Hover/focus: existing link/button hover and focus states.
+- Active: existing button/form active states.
+- Disabled: existing disabled state for form actions if present.
+- Rejected state: not rendered in the main list. Rejected muted row/card styling may remain dead code or be used elsewhere, but visual regression tests should expect no rejected row/card on `/jobs`.
+
+### Dashboard cards
+- Default: matched/review counts exclude rejected jobs.
+- Empty: matched/review cards may display `0`; preview sections show existing muted/empty messages.
+- Hover/focus: stat card links follow existing link focus/hover behavior.
+- Error/loading: no new state required.
+
+## 9. Responsive Design Rules
+
+- Preserve existing breakpoints and server-rendered behavior.
+- Desktop Jobs page continues to use table layout where currently implemented.
+- Mobile Jobs page continues to use card layout where currently implemented.
+- Removing the Rejected option must not change filter wrapping behavior; the filter row should simply have a shorter select menu.
+- Empty-state copy must wrap cleanly within the existing panel/surface width.
+- Dashboard stat grid should reflow using existing grid behavior. If removing the Rejected card creates an uneven row, do not add placeholder cards; allow the grid to naturally reflow.
+
+## 10. Visual Design Tokens
+
+Use existing design tokens and component styles. No new colors, spacing scales, or typography are required.
+
+Known existing token guidance from current UI specs/styles:
+- Background: `--bg #f5f7fb`
+- Surface: `--surface #ffffff`
+- Muted surface: `--surface-muted #eef2f7`
+- Text: `--text #162032`
+- Muted text: `--text-muted #5d6b82`
+- Border: `--border #d7dfeb`
+- Primary/info: `--primary #3157d5`
+- Matched/success: `--matched #1f8f5f`
+- Review/warning: `--review #a66a00`
+- Rejected/danger: `--rejected #b53737`
+- Radius: `--radius 14px`
+- Shadow: `--shadow 0 10px 28px rgba(15, 23, 42, 0.06)`
+
+Rejected/danger styling may continue to exist for detail pages and non-main surfaces, but it should not appear in the main Jobs list or dashboard actionable summaries as part of this feature.
+
+## 11. Accessibility Requirements
+
+- The bucket select must retain an accessible label:
+  - Visible label `Automated bucket` in `app/web/templates/jobs/list.html`, or
+  - `.sr-only` label in `app/templates/jobs/list.html`.
+- Do not rely on color alone to communicate status; matched/review badges must retain text labels.
+- Removing Rejected from the select must not leave an orphaned selected value or blank unlabeled control for screen reader users.
+- Empty states must use plain, non-alarming language. All-rejected data is a valid no-results condition, not an error.
+- Keyboard users must be able to tab through search, bucket, tracking, source, sort, Apply, and Reset in the existing logical order.
+- Dashboard stat card links must remain keyboard focusable and have descriptive text, e.g., “Matched” and “Review”.
+- If a rejected job detail page is directly accessed, its status badge should remain text-based so assistive technology can identify the job state.
+
+## 12. Edge Cases
+
+- All stored jobs are rejected: Jobs page shows empty state; dashboard matched/review counts are `0`; no error language.
+- Search term matches only rejected jobs: Jobs page shows empty state; rejected matches remain hidden.
+- Active source/company/location/tracking filters match only rejected jobs: empty state; do not reveal rejected jobs.
+- User manually enters `/jobs?bucket=rejected`: rejected jobs remain hidden; UI does not show Rejected as a selectable option.
+- Null/missing classification: per technical design, remains visible for MVP unless product later decides strict matched/review-only display.
+- Unknown non-`rejected` classification: remains visible for backward compatibility per technical design; badge rendering should use existing fallback tone.
+- Multiple classification records: UI uses the backend-provided current/latest display classification; do not infer status client-side.
+- Classification changes while viewing list: server-rendered UI may remain stale until refresh/reload.
+- Rejected tracked jobs or reminders: outside this feature unless they are rendered through the main Jobs display/dashboard actionable query. Do not silently change reminder/tracking-specific surfaces without product confirmation.
+- Rejected job detail URL: direct access unchanged if existing detail visibility permits it.
+
+## 13. Developer Handoff Notes
+
+- Do not implement client-side hiding as the primary behavior. The backend/query layer must exclude rejected jobs before counts and any future pagination.
+- Update both Jobs list template paths if both remain in use or tests cover both:
+  - `app/web/templates/jobs/list.html`
+  - `app/templates/jobs/list.html`
+- Remove/suppress `Rejected` from the main Jobs bucket selector in both template variants.
+- Prefer changing the all-option label from “All buckets” to “All actionable”. If this is too broad for the current release, keep “All buckets” only if tests/product accept that wording.
+- Dashboard actionable summaries/previews should use the same non-rejected eligibility as `/jobs`.
+- Remove the clickable dashboard Rejected stat card from user-facing UI where feasible. If retained for contract compatibility, it must show `0` and should not link to `/jobs?bucket=rejected`.
+- Do not remove global rejected badge styles because rejected status may still appear on detail, admin, debug, audit, or historical surfaces.
+- Visual regression expectations:
+  - Jobs filter menu contains All actionable/Matched/Review only.
+  - No row/card with rejected badge, `.row-muted`, or `.job-card-muted` appears on `/jobs` for rejected data.
+  - Jobs empty state appears when fixtures contain only rejected jobs.
+  - Dashboard matched/review counts exclude rejected fixtures.
+  - Dashboard previews contain no rejected cards.
+  - Direct rejected job detail, if tested, still renders according to existing detail behavior.
+- Content regression expectations:
+  - Counts should describe visible/actionable jobs, not total stored jobs.
+  - Empty states should not imply records were deleted or that an error occurred.
+  - Avoid adding “deleted” language for rejected jobs; they are hidden from the main display only.
+
+### Explicit assumptions
+
+- `JobPosting.latest_bucket` or equivalent backend-provided current/latest classification is the source of truth for display status.
+- Null/unknown non-rejected jobs remain visible for MVP, matching the technical design.
+- Main display means `/jobs` and dashboard actionable job summaries/previews, not every route that can show a job.
+- Direct detail access for rejected jobs is unchanged by this feature.

--- a/tests/integration/test_hide_rejected_job_openings_surfaces.py
+++ b/tests/integration/test_hide_rejected_job_openings_surfaces.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.persistence.models import JobPosting, JobSourceLink, Source, SourceRun
+
+
+def seed_visibility_jobs(session):
+    source = Source(
+        name="Visibility Source",
+        source_type="greenhouse",
+        base_url="https://boards.greenhouse.io/visibility",
+        external_identifier="visibility",
+        dedupe_key="visibility",
+        is_active=True,
+    )
+    session.add(source)
+    session.commit()
+    run = SourceRun(source_id=source.id, trigger_type="manual", status="success")
+    session.add(run)
+    session.commit()
+    jobs = [
+        JobPosting(canonical_key="qa-matched", primary_source_id=source.id, title="QA Matched Unique", company_name="VisibilityCo", job_url="https://example.com/matched", latest_bucket="matched", current_state="active"),
+        JobPosting(canonical_key="qa-review", primary_source_id=source.id, title="QA Review Shared", company_name="VisibilityCo", job_url="https://example.com/review", latest_bucket="review", current_state="active"),
+        JobPosting(canonical_key="qa-rejected", primary_source_id=source.id, title="QA Rejected Only", company_name="VisibilityCo", job_url="https://example.com/rejected", latest_bucket="rejected", current_state="active", tracking_status="saved"),
+        JobPosting(canonical_key="qa-null", primary_source_id=source.id, title="QA Null Shared", company_name="VisibilityCo", job_url="https://example.com/null", latest_bucket=None, current_state="active"),
+        JobPosting(canonical_key="qa-unknown", primary_source_id=source.id, title="QA Unknown Shared", company_name="VisibilityCo", job_url="https://example.com/unknown", latest_bucket="unknown", current_state="active"),
+    ]
+    session.add_all(jobs)
+    session.flush()
+    for job in jobs:
+        session.add(
+            JobSourceLink(
+                job_posting_id=job.id,
+                source_id=source.id,
+                source_run_id=run.id,
+                source_job_url=job.job_url,
+                content_hash=f"hash-{job.canonical_key}",
+                is_primary=True,
+            )
+        )
+    session.commit()
+    return source, {job.canonical_key: job.id for job in jobs}
+
+
+def response_titles(response):
+    return {job["title"] for job in response.json()}
+
+
+def test_jobs_api_excludes_rejected_and_keeps_null_unknown_visible(client, session):
+    _, job_ids = seed_visibility_jobs(session)
+
+    response = client.get("/jobs")
+
+    assert response.status_code == 200
+    assert response_titles(response) == {"QA Matched Unique", "QA Review Shared", "QA Null Shared", "QA Unknown Shared"}
+    assert session.get(JobPosting, job_ids["qa-rejected"]) is not None
+    assert session.get(JobPosting, job_ids["qa-rejected"]).latest_bucket == "rejected"
+
+
+def test_jobs_filters_do_not_reintroduce_rejected_jobs(client, session):
+    source, _ = seed_visibility_jobs(session)
+
+    rejected_bucket_response = client.get("/jobs?bucket=rejected")
+    rejected_search_response = client.get("/jobs?search=Rejected%20Only")
+    shared_search_response = client.get("/jobs?search=Shared")
+    source_response = client.get(f"/jobs?source_id={source.id}")
+
+    assert rejected_bucket_response.status_code == 200
+    assert rejected_bucket_response.json() == []
+    assert rejected_search_response.status_code == 200
+    assert rejected_search_response.json() == []
+    assert shared_search_response.status_code == 200
+    assert response_titles(shared_search_response) == {"QA Review Shared", "QA Null Shared", "QA Unknown Shared"}
+    assert source_response.status_code == 200
+    assert "QA Rejected Only" not in response_titles(source_response)
+
+
+def test_dashboard_counts_and_previews_use_actionable_jobs(client, session):
+    seed_visibility_jobs(session)
+
+    json_response = client.get("/dashboard")
+    html_response = client.get("/dashboard", headers={"accept": "text/html"})
+
+    assert json_response.status_code == 200
+    assert json_response.json()["matched_count"] == 1
+    assert json_response.json()["review_count"] == 1
+    assert json_response.json()["rejected_count"] == 0
+    assert json_response.json()["saved_needing_action"] == 0
+    assert html_response.status_code == 200
+    assert "QA Matched Unique" in html_response.text
+    assert "QA Review Shared" in html_response.text
+    assert "QA Rejected Only" not in html_response.text
+
+
+def test_direct_rejected_job_detail_remains_accessible(client, session):
+    _, job_ids = seed_visibility_jobs(session)
+
+    response = client.get(f"/jobs/{job_ids['qa-rejected']}")
+
+    assert response.status_code == 200
+    assert response.json()["latest_bucket"] == "rejected"
+
+
+def test_reclassification_transitions_affect_main_display_without_deleting_records(client, session):
+    _, job_ids = seed_visibility_jobs(session)
+    review_job = session.get(JobPosting, job_ids["qa-review"])
+    rejected_job = session.get(JobPosting, job_ids["qa-rejected"])
+    review_job.latest_bucket = "rejected"
+    rejected_job.latest_bucket = "matched"
+    session.add_all([review_job, rejected_job])
+    session.commit()
+
+    response = client.get("/jobs")
+    titles = response_titles(response)
+
+    assert response.status_code == 200
+    assert "QA Review Shared" not in titles
+    assert "QA Rejected Only" in titles
+    assert session.scalar(select(JobPosting).where(JobPosting.id == job_ids["qa-review"])) is not None

--- a/tests/integration/test_html_views.py
+++ b/tests/integration/test_html_views.py
@@ -20,7 +20,7 @@ def seed_job(client, monkeypatch):
                 "title": "QA Automation Engineer",
                 "absolute_url": "https://example.com/jobs/99",
                 "location": {"name": "Remote, Spain"},
-                "content": "<p>QA automation role. Sponsorship unclear.</p>",
+                "content": "<p>QA automation role with Python testing ownership. Sponsorship is unclear for this role.</p>",
                 "updated_at": "2026-04-23T10:00:00Z",
             }
         ]
@@ -45,10 +45,10 @@ def seed_job_with_source(client, monkeypatch):
         "jobs": [
             {
                 "id": 100,
-                "title": "Backend Platform Engineer",
+                "title": "Python Backend Engineer",
                 "absolute_url": "https://example.com/jobs/100",
                 "location": {"name": "Remote"},
-                "content": "<p>Platform engineering role with Python and backend ownership.</p>",
+                "content": "<p>Platform engineering role with Python and backend ownership. Visa sponsorship available.</p>",
                 "updated_at": "2026-04-23T11:00:00Z",
             }
         ]
@@ -75,12 +75,12 @@ def test_dashboard_and_jobs_html_render(client, monkeypatch):
     dashboard_response = client.get("/dashboard", headers={"accept": "text/html"})
     assert dashboard_response.status_code == 200
     assert "Dashboard" in dashboard_response.text
-    assert "Rejected" in dashboard_response.text
-    assert "Recent review jobs" in dashboard_response.text
+    assert "Rejected" not in dashboard_response.text
+    assert "Jobs needing attention" in dashboard_response.text
 
     jobs_response = client.get("/jobs", headers={"accept": "text/html"})
     assert jobs_response.status_code == 200
-    assert "Automated bucket" in jobs_response.text
+    assert "Bucket" in jobs_response.text
     assert "Tracking" in jobs_response.text
     assert "QA Automation Engineer" in jobs_response.text
 

--- a/tests/integration/test_source_edit_delete_html.py
+++ b/tests/integration/test_source_edit_delete_html.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+from app.persistence.models import Source
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
 
 def create_source(client, *, name: str = "Editable Source", is_active: bool = True):
     response = client.post(
@@ -51,6 +64,86 @@ def test_source_edit_html_flow_updates_values_and_shows_inactive_state(client):
     assert "Updated note" in detail_page.text
     assert "Inactive" in detail_page.text
     assert "cannot be run" in detail_page.text
+
+
+def post_source_form(client, *, name: str, is_active_value=...):
+    data = {
+        "name": name,
+        "source_type": "greenhouse",
+        "company_name": "Checkbox Co",
+        "base_url": f"https://boards.greenhouse.io/{name.lower().replace(' ', '-')}",
+        "external_identifier": name.lower().replace(" ", "-"),
+        "adapter_key": "",
+        "notes": "",
+    }
+    if is_active_value is not ...:
+        data["is_active"] = is_active_value
+    return client.post(
+        "/sources",
+        headers={"content-type": "application/x-www-form-urlencoded", "accept": "text/html"},
+        data=data,
+        follow_redirects=False,
+    )
+
+
+def test_source_create_form_accepts_true_checkbox_value(client, session):
+    response = post_source_form(client, name="True Active Source", is_active_value="true")
+
+    assert response.status_code == 303
+    source = session.query(Source).filter_by(name="True Active Source").one()
+    assert source.is_active is True
+
+
+def test_source_create_form_accepts_on_checkbox_value(client, session):
+    response = post_source_form(client, name="On Active Source", is_active_value="on")
+
+    assert response.status_code == 303
+    source = session.query(Source).filter_by(name="On Active Source").one()
+    assert source.is_active is True
+
+
+def test_source_create_form_omitted_checkbox_persists_inactive(client, session):
+    response = post_source_form(client, name="Omitted Inactive Source")
+
+    assert response.status_code == 303
+    source = session.query(Source).filter_by(name="Omitted Inactive Source").one()
+    assert source.is_active is False
+
+
+def test_source_edit_form_accepts_true_checkbox_value(client, session):
+    source = create_source(client, name="Edit True Source", is_active=False)
+
+    response = client.post(
+        f"/sources/{source['id']}/edit",
+        headers={"content-type": "application/x-www-form-urlencoded", "accept": "text/html"},
+        data={
+            "name": "Edit True Source",
+            "source_type": "greenhouse",
+            "company_name": "Checkbox Co",
+            "base_url": "https://boards.greenhouse.io/edit-true-source",
+            "external_identifier": "edit-true-source",
+            "adapter_key": "",
+            "notes": "Updated active state",
+            "is_active": "true",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    session.expire_all()
+    assert session.get(Source, source["id"]).is_active is True
+
+
+def test_source_created_with_true_checkbox_can_run_without_inactive_conflict(client, session, monkeypatch):
+    monkeypatch.setattr("app.adapters.greenhouse.adapter.httpx.get", lambda *args, **kwargs: DummyResponse({"jobs": []}))
+    create_response = post_source_form(client, name="Runnable True Source", is_active_value="true")
+    assert create_response.status_code == 303
+    source = session.query(Source).filter_by(name="Runnable True Source").one()
+
+    run_response = client.post(f"/sources/{source.id}/run?next=/sources")
+
+    assert run_response.status_code == 200
+    assert run_response.json()["source_id"] == source.id
 
 
 def test_source_delete_html_flow_hides_deleted_source_from_management_surfaces(client):

--- a/tests/ui/test_hide_rejected_job_openings_ui.py
+++ b/tests/ui/test_hide_rejected_job_openings_ui.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+from app.persistence.models import JobPosting, JobSourceLink, Source, SourceRun
+
+
+def seed_ui_jobs(session):
+    source = Source(
+        name="UI Visibility Source",
+        source_type="greenhouse",
+        base_url="https://boards.greenhouse.io/ui-visibility",
+        external_identifier="ui-visibility",
+        dedupe_key="ui-visibility",
+        is_active=True,
+    )
+    session.add(source)
+    session.commit()
+    run = SourceRun(source_id=source.id, trigger_type="manual", status="success")
+    session.add(run)
+    session.commit()
+    jobs = [
+        JobPosting(
+            canonical_key="ui-matched-actionable",
+            primary_source_id=source.id,
+            title="UI Matched Actionable",
+            company_name="ActionableCo",
+            job_url="https://example.com/ui-matched",
+            latest_bucket="matched",
+            current_state="active",
+        ),
+        JobPosting(
+            canonical_key="ui-review-actionable",
+            primary_source_id=source.id,
+            title="UI Review Actionable",
+            company_name="ActionableCo",
+            job_url="https://example.com/ui-review",
+            latest_bucket="review",
+            current_state="active",
+        ),
+        JobPosting(
+            canonical_key="ui-rejected-hidden",
+            primary_source_id=source.id,
+            title="UI Rejected Hidden",
+            company_name="HiddenCo",
+            job_url="https://example.com/ui-rejected",
+            latest_bucket="rejected",
+            current_state="active",
+        ),
+    ]
+    session.add_all(jobs)
+    session.flush()
+    for job in jobs:
+        session.add(
+            JobSourceLink(
+                job_posting_id=job.id,
+                source_id=source.id,
+                source_run_id=run.id,
+                source_job_url=job.job_url,
+                content_hash=f"hash-{job.canonical_key}",
+                is_primary=True,
+            )
+        )
+    session.commit()
+    return jobs
+
+
+def parse_html(response):
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    return BeautifulSoup(response.text, "html.parser")
+
+
+def test_jobs_bucket_select_exposes_only_actionable_options(client, session):
+    seed_ui_jobs(session)
+
+    response = client.get("/jobs", headers={"accept": "text/html"})
+    soup = parse_html(response)
+    bucket_select = soup.find("select", {"name": "bucket"})
+
+    assert bucket_select is not None
+    options = [(option.get("value", ""), option.get_text(strip=True)) for option in bucket_select.find_all("option")]
+    assert options == [("", "All actionable"), ("matched", "Matched"), ("review", "Review")]
+    assert all(label != "Rejected" for _, label in options)
+    assert all(value != "rejected" for value, _ in options)
+
+
+def test_jobs_page_omits_rejected_rows_and_cards(client, session):
+    seed_ui_jobs(session)
+
+    response = client.get("/jobs", headers={"accept": "text/html"})
+
+    assert response.status_code == 200
+    assert "UI Matched Actionable" in response.text
+    assert "UI Review Actionable" in response.text
+    assert "UI Rejected Hidden" not in response.text
+    assert "row-muted" not in response.text
+    assert "job-card-muted" not in response.text
+    assert "2 actionable job(s) found." in response.text
+
+
+def test_manual_rejected_bucket_query_shows_actionable_empty_state(client, session):
+    seed_ui_jobs(session)
+
+    response = client.get("/jobs?bucket=rejected", headers={"accept": "text/html"})
+    soup = parse_html(response)
+    bucket_select = soup.find("select", {"name": "bucket"})
+
+    assert "UI Rejected Hidden" not in response.text
+    assert "No actionable jobs found" in response.text
+    assert "Rejected jobs are hidden from this main view." in response.text
+    assert bucket_select is not None
+    assert bucket_select.find("option", {"value": "rejected"}) is None
+    assert bucket_select.find("option", {"value": ""}).get_text(strip=True) == "All actionable"
+
+
+def test_all_rejected_jobs_render_normal_empty_state(client, session):
+    seed_ui_jobs(session)
+    for job in session.query(JobPosting).all():
+        job.latest_bucket = "rejected"
+    session.commit()
+
+    response = client.get("/jobs", headers={"accept": "text/html"})
+
+    assert response.status_code == 200
+    assert "No actionable jobs found" in response.text
+    assert "UI Matched Actionable" not in response.text
+    assert "UI Review Actionable" not in response.text
+    assert "UI Rejected Hidden" not in response.text
+
+
+def test_dashboard_does_not_render_rejected_actionable_card(client, session):
+    seed_ui_jobs(session)
+
+    response = client.get("/dashboard", headers={"accept": "text/html"})
+
+    assert response.status_code == 200
+    assert "UI Matched Actionable" in response.text
+    assert "UI Review Actionable" in response.text
+    assert "UI Rejected Hidden" not in response.text
+    assert "/jobs?bucket=rejected" not in response.text
+    assert "Rejected" not in response.text

--- a/tests/ui/test_source_edit_delete_ui_qa.py
+++ b/tests/ui/test_source_edit_delete_ui_qa.py
@@ -49,10 +49,10 @@ def test_source_delete_confirmation_explains_async_cleanup_and_retention(client,
         "jobs": [
             {
                 "id": 501,
-                "title": "Historical Safety Engineer",
+                "title": "Historical QA Automation Engineer",
                 "absolute_url": "https://example.com/jobs/501",
                 "location": {"name": "Remote"},
-                "content": "<p>Historical safety regression role.</p>",
+                "content": "<p>QA automation regression role. Sponsorship is mentioned but remains unclear.</p>",
                 "updated_at": "2026-04-23T10:00:00Z",
             }
         ]
@@ -170,10 +170,10 @@ def test_deleted_source_non_retained_job_uses_normal_not_found(client, monkeypat
         "jobs": [
             {
                 "id": 501,
-                "title": "Deleted Cleanup Engineer",
+                "title": "Deleted Cleanup QA Automation Engineer",
                 "absolute_url": "https://example.com/jobs/501",
                 "location": {"name": "Remote"},
-                "content": "<p>Deleted cleanup regression role.</p>",
+                "content": "<p>QA automation cleanup regression role. Sponsorship is mentioned but remains unclear.</p>",
                 "updated_at": "2026-04-23T10:00:00Z",
             }
         ]

--- a/tests/unit/test_job_visibility.py
+++ b/tests/unit/test_job_visibility.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy import select
 
-from app.domain.job_visibility import apply_visible_jobs
+from app.domain.job_visibility import apply_main_display_jobs, apply_visible_jobs
 from app.persistence.models import JobPosting, JobSourceLink, Source, SourceRun, utcnow
 
 
@@ -25,3 +25,41 @@ def test_visible_jobs_hide_non_retained_deleted_source_jobs_immediately(session)
     visible_jobs = list(session.scalars(apply_visible_jobs(select(JobPosting)).order_by(JobPosting.canonical_key)))
 
     assert [job.canonical_key for job in visible_jobs] == ["retained", "visible"]
+
+
+def test_main_display_jobs_hide_only_explicit_rejected_buckets(session):
+    source = Source(name="Active", source_type="greenhouse", base_url="https://boards.greenhouse.io/active", external_identifier="active", dedupe_key="active", is_active=True)
+    session.add(source)
+    session.commit()
+    jobs = [
+        JobPosting(canonical_key="matched", primary_source_id=source.id, title="Matched", job_url="https://example.com/matched", latest_bucket="matched", current_state="active"),
+        JobPosting(canonical_key="review", primary_source_id=source.id, title="Review", job_url="https://example.com/review", latest_bucket="review", current_state="active"),
+        JobPosting(canonical_key="null", primary_source_id=source.id, title="Null", job_url="https://example.com/null", latest_bucket=None, current_state="active"),
+        JobPosting(canonical_key="unknown", primary_source_id=source.id, title="Unknown", job_url="https://example.com/unknown", latest_bucket="unknown", current_state="active"),
+        JobPosting(canonical_key="rejected", primary_source_id=source.id, title="Rejected", job_url="https://example.com/rejected", latest_bucket="rejected", current_state="active"),
+    ]
+    session.add_all(jobs)
+    session.commit()
+
+    visible_jobs = list(session.scalars(apply_main_display_jobs(select(JobPosting)).order_by(JobPosting.canonical_key)))
+
+    assert [job.canonical_key for job in visible_jobs] == ["matched", "null", "review", "unknown"]
+
+
+def test_main_display_jobs_compose_rejected_and_deleted_source_visibility(session):
+    source = Source(name="Deleted", source_type="greenhouse", base_url="https://boards.greenhouse.io/deleted", external_identifier="deleted", dedupe_key="deleted", is_active=False, deleted_at=utcnow())
+    active_source = Source(name="Active", source_type="greenhouse", base_url="https://boards.greenhouse.io/active", external_identifier="active", dedupe_key="active", is_active=True)
+    session.add_all([source, active_source])
+    session.commit()
+    jobs = [
+        JobPosting(canonical_key="retained-matched", primary_source_id=source.id, title="Retained", job_url="https://example.com/retained", latest_bucket="matched", current_state="active"),
+        JobPosting(canonical_key="deleted-review", primary_source_id=source.id, title="Deleted Review", job_url="https://example.com/deleted-review", latest_bucket="review", current_state="active"),
+        JobPosting(canonical_key="active-rejected", primary_source_id=active_source.id, title="Rejected", job_url="https://example.com/rejected", latest_bucket="rejected", current_state="active"),
+        JobPosting(canonical_key="active-review", primary_source_id=active_source.id, title="Review", job_url="https://example.com/review", latest_bucket="review", current_state="active"),
+    ]
+    session.add_all(jobs)
+    session.commit()
+
+    visible_jobs = list(session.scalars(apply_main_display_jobs(select(JobPosting)).order_by(JobPosting.canonical_key)))
+
+    assert [job.canonical_key for job in visible_jobs] == ["active-review", "retained-matched"]


### PR DESCRIPTION
## Summary
- Hides explicitly `rejected` job openings from the main actionable Jobs and Dashboard views while preserving matched, review, null, and unknown non-rejected jobs under existing visibility rules.
- Updates Jobs/Dashboard UI so rejected jobs are absent from lists, previews, counts, and the primary bucket selector.
- Fixes the source active checkbox parsing blocker that caused checked sources to persist inactive and block Run now.
- Adds release/planning, implementation, bug, and QA artifacts for the feature and validation blocker.

## QA Results
- [QA SIGN-OFF APPROVED]
- Source checkbox/run blocker tests: 7 passed / 0 failed.
- Hide-rejected targeted regression: 13 passed / 0 failed.
- Related regression suites: 17 passed / 0 failed.
- Backend/API/integration suites: 39 passed / 0 failed.
- Full suite: 54 passed / 5 failed.

## Notes on Remaining Failures
- The 5 full-suite failures are isolated to `tests/ui/test_saas_dashboard_ui_revamp.py`.
- QA classified these as unrelated HTML Accept-header/test fixture issues, not regressions from this feature branch.

## Linked Planning Issue
- https://github.com/michaelseno/job-intelligence-platform/issues/8

## Release Notes
- Rejected jobs are hidden from actionable views only; records are not deleted or reclassified.
- Direct rejected job detail behavior remains governed by existing source-delete visibility rules.
- Source active checkbox parsing was fixed in this branch to unblock Run now validation.

Closes #8 