### PR TITLE
Bugfix: CSV source import zero imported

### DIFF
--- a/app/domain/sources.py
+++ b/app/domain/sources.py
@@ -187,16 +187,21 @@ class SourceService:
         rows: list[SourceImportRowResult] = []
         created = skipped_duplicate = invalid = 0
         for idx, row in enumerate(reader, start=2):
+            row_errors = validate_csv_row_shape(row)
+            if row_errors:
+                invalid += 1
+                rows.append(SourceImportRowResult(row_number=idx, status="invalid", message="; ".join(row_errors)))
+                continue
             try:
                 payload = SourceCreateRequest(
-                    name=row.get("name", ""),
-                    source_type=row.get("source_type", ""),
-                    base_url=row.get("base_url", ""),
-                    external_identifier=row.get("external_identifier") or None,
-                    adapter_key=row.get("adapter_key") or None,
-                    company_name=row.get("company_name") or None,
-                    is_active=(row.get("is_active", "true").strip().lower() not in {"false", "0", "no"}),
-                    notes=row.get("notes") or None,
+                    name=clean_csv_value(row.get("name")),
+                    source_type=clean_csv_value(row.get("source_type")).lower(),
+                    base_url=clean_csv_value(row.get("base_url")),
+                    external_identifier=clean_csv_optional_value(row.get("external_identifier")),
+                    adapter_key=clean_csv_optional_value(row.get("adapter_key")),
+                    company_name=clean_csv_optional_value(row.get("company_name")),
+                    is_active=parse_csv_is_active(row.get("is_active")),
+                    notes=clean_csv_optional_value(row.get("notes")),
                 )
             except Exception as exc:
                 invalid += 1
@@ -221,3 +226,31 @@ def build_source_dedupe_key(source_type: str, base_url: str, external_identifier
     return "|".join(
         [slugify(source_type), slugify(adapter_key), normalize_url(base_url), slugify(external_identifier)]
     )
+
+
+def validate_csv_row_shape(row: dict[str | None, str | list[str] | None]) -> list[str]:
+    errors: list[str] = []
+    extra_fields = row.get(None)
+    if extra_fields:
+        errors.append("Malformed CSV row: unexpected extra fields found. Quote values that contain commas.")
+    return errors
+
+
+def clean_csv_value(value: str | list[str] | None) -> str:
+    if isinstance(value, list):
+        return " ".join(str(item).strip() for item in value if item is not None).strip()
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def clean_csv_optional_value(value: str | list[str] | None) -> str | None:
+    cleaned = clean_csv_value(value)
+    return cleaned or None
+
+
+def parse_csv_is_active(value: str | list[str] | None) -> bool:
+    cleaned = clean_csv_value(value)
+    if not cleaned:
+        cleaned = "true"
+    return cleaned.lower() not in {"false", "0", "no"}

--- a/app/templates/sources/index.html
+++ b/app/templates/sources/index.html
@@ -88,10 +88,60 @@
 
     <article class="surface" id="import-panel">
       <div class="section-heading"><h3>Import CSV</h3></div>
-      {% if import_result %}<div class="alert alert--success">Imported {{ import_result.created_count|default(0) }} sources.</div>{% endif %}
+      {% if import_result %}
+        {% set created_count = import_result.created|default(0) %}
+        {% set skipped_count = import_result.skipped_duplicate|default(0) %}
+        {% set invalid_count = import_result.invalid|default(0) %}
+        {% if invalid_count > 0 and created_count == 0 %}
+          {% set alert_tone = 'danger' %}
+          {% set alert_title = 'Import completed with validation errors' %}
+          {% set alert_body = 'No sources were imported. Review the invalid rows below and update the CSV before retrying.' %}
+        {% elif invalid_count > 0 %}
+          {% set alert_tone = 'warning' %}
+          {% set alert_title = 'Import partially completed' %}
+          {% set alert_body = 'Some sources were imported, but one or more rows need attention.' %}
+        {% elif created_count > 0 %}
+          {% set alert_tone = 'success' %}
+          {% set alert_title = 'Import completed' %}
+          {% set alert_body = created_count ~ ' source' ~ ('' if created_count == 1 else 's') ~ ' imported.' %}
+        {% else %}
+          {% set alert_tone = 'warning' %}
+          {% set alert_title = 'No new sources imported' %}
+          {% set alert_body = 'No new sources were created. Review skipped duplicate rows below.' %}
+        {% endif %}
+        <section class="alert alert--{{ alert_tone }}" role="{{ 'alert' if invalid_count > 0 else 'status' }}" aria-labelledby="import-result-title">
+          <div class="alert__title" id="import-result-title">{{ alert_title }}</div>
+          <p>{{ alert_body }}</p>
+          <dl class="detail-list" aria-label="CSV import summary">
+            <div><dt>Created</dt><dd>{{ created_count }}</dd></div>
+            <div><dt>Skipped duplicates</dt><dd>{{ skipped_count }}</dd></div>
+            <div><dt>Invalid rows</dt><dd>{{ invalid_count }}</dd></div>
+          </dl>
+        </section>
+        {% if import_result.rows %}
+          <div class="table-wrap" aria-labelledby="import-rows-title">
+            <table>
+              <caption id="import-rows-title">CSV import row results</caption>
+              <thead><tr><th scope="col">Row</th><th scope="col">Status</th><th scope="col">Message</th></tr></thead>
+              <tbody>
+                {% for row in import_result.rows %}
+                  {% set status_label = row.status|replace('_', ' ')|title %}
+                  {% set status_tone = 'success' if row.status == 'created' else ('warning' if row.status == 'skipped_duplicate' else ('danger' if row.status == 'invalid' else 'neutral')) %}
+                  <tr>
+                    <td>{{ row.row_number }}</td>
+                    <td>{{ ui.badge(status_label, status_tone) }}</td>
+                    <td>{{ row.message }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% endif %}
+      {% endif %}
       <form method="post" action="/sources/import" enctype="multipart/form-data" class="stack-form">
-        <label>CSV file</label>
-        <input type="file" name="file" accept=".csv,text/csv" required>
+        <label for="source-import-file">CSV file</label>
+        <input id="source-import-file" type="file" name="file" accept=".csv,text/csv" required aria-describedby="source-import-help">
+        <p class="helper-text" id="source-import-help">Expected columns: name, source_type, base_url, external_identifier, adapter_key, company_name, is_active, notes.</p>
         <button class="btn btn--secondary" type="submit">Import sources</button>
       </form>
     </article>

--- a/docs/backend/csv_import_sources_zero_imported_implementation_plan.md
+++ b/docs/backend/csv_import_sources_zero_imported_implementation_plan.md
@@ -1,0 +1,50 @@
+# Implementation Plan
+
+## 1. Feature Overview
+Fix the backend CSV source import path so valid source rows using common CSV enum casing import successfully and invalid CSV rows return actionable row-level validation results.
+
+## 2. Technical Scope
+- Normalize CSV string fields during source import before validation.
+- Normalize `source_type` casing for common enum values while preserving existing lowercase behavior.
+- Detect malformed rows with extra CSV fields and return row-level invalid results.
+- Preserve existing duplicate-skip import behavior.
+- Add backend integration test coverage for title-cased source types, duplicate skips, malformed row errors, and the user's CSV column shape.
+
+## 3. Source Inputs
+- `docs/bugs/csv_import_sources_zero_imported_bug_report.md`
+- `docs/product/job_intelligence_platform_mvp_product_spec.md` CSV import assumptions and acceptance criteria
+- Existing backend implementation in `app/domain/sources.py`
+- Existing API test conventions in `tests/integration/test_api_flow.py`
+
+## 4. API Contracts Affected
+Endpoint: `POST /sources/import`
+
+- Request: multipart upload with `file` CSV, unchanged.
+- Response: existing `SourceImportResponse` contract unchanged: `created`, `skipped_duplicate`, `invalid`, `rows`.
+- Row-level statuses remain `created`, `skipped_duplicate`, and `invalid`.
+- HTTP success status remains `200` for mixed valid/invalid CSV imports.
+
+## 5. Data Models / Storage Affected
+No data model or storage schema changes.
+
+Imported sources will continue to persist to the existing `Source` model using normalized/cleaned values already used by source creation.
+
+## 6. Files Expected to Change
+- `app/domain/sources.py`
+- `tests/integration/test_api_flow.py`
+- `docs/backend/csv_import_sources_zero_imported_implementation_plan.md`
+- `docs/backend/csv_import_sources_zero_imported_implementation_report.md`
+
+## 7. Security / Authorization Considerations
+No authentication or authorization behavior changes are in scope. Uploaded CSV values remain validated by existing source validation before persistence. Error messages will be row-specific and must not expose stack traces for expected malformed CSV rows.
+
+## 8. Dependencies / Constraints
+No new dependencies. Use Python standard library `csv.DictReader` and existing validation/service patterns.
+
+## 9. Assumptions
+- CSV imports may accept common whitespace/casing variants for `source_type` by normalizing with `strip().lower()` before validation.
+- Rows with extra CSV fields from unquoted delimiters are considered malformed and should be returned as row-level invalid results instead of silently truncating or importing partial data.
+
+## 10. Validation Plan
+- Run targeted integration tests: `pytest tests/integration/test_api_flow.py -q`.
+- Run broader test suite if targeted tests pass and runtime is reasonable: `pytest -q`.

--- a/docs/backend/csv_import_sources_zero_imported_implementation_report.md
+++ b/docs/backend/csv_import_sources_zero_imported_implementation_report.md
@@ -1,0 +1,55 @@
+# Implementation Report
+
+## 1. Summary of Changes
+Fixed CSV source import normalization so title-cased `source_type` values such as `Greenhouse` and `Lever` are accepted through the existing import endpoint. Added row-level malformed CSV detection for extra fields caused by unquoted commas and expanded backend tests for normalized imports, duplicate skips, malformed rows, and the user's CSV column shape.
+
+## 2. Files Modified
+- `app/domain/sources.py` — normalizes CSV import fields before validation and reports malformed rows with extra CSV fields as row-level invalid results.
+- `tests/integration/test_api_flow.py` — adds CSV import integration coverage for title-cased source types, duplicate behavior, malformed rows, and valid user-shaped CSV rows.
+- `docs/backend/csv_import_sources_zero_imported_implementation_plan.md` — backend implementation plan.
+- `docs/backend/csv_import_sources_zero_imported_implementation_report.md` — this implementation report.
+
+## 3. API Contract Implementation
+`POST /sources/import` continues to accept multipart CSV uploads and return the existing `SourceImportResponse` shape: `created`, `skipped_duplicate`, `invalid`, and `rows`.
+
+No response contract fields were added or removed. Mixed valid/invalid imports still return HTTP `200` with row-level statuses.
+
+## 4. Data / Persistence Implementation
+No schema or migration changes were made. Created source records continue to use the existing `Source` persistence model and dedupe key behavior.
+
+## 5. Key Logic Implemented
+- CSV string values are stripped before constructing `SourceCreateRequest`.
+- CSV `source_type` is normalized with `strip().lower()` before validation.
+- Optional CSV fields are stripped and converted to `None` when blank.
+- `is_active` parsing preserves existing behavior: blank/missing values default active, and `false`, `0`, or `no` are inactive.
+- Rows with extra fields from malformed CSV input are marked invalid with: `Malformed CSV row: unexpected extra fields found. Quote values that contain commas.`
+- Duplicate-skip behavior is preserved through the existing validation path.
+
+## 6. Security / Authorization Implemented
+No authentication or authorization behavior was changed. Uploaded values remain validated before persistence. Expected malformed CSV errors return controlled row-level messages instead of internal stack traces.
+
+## 7. Error Handling Implemented
+- Malformed rows with unexpected extra fields are handled explicitly as row-level invalid results.
+- Existing row-specific validation remains in place for missing required fields, unsupported source types, adapter validation, and duplicates.
+
+## 8. Observability / Logging
+No logging changes were required for this scoped backend fix.
+
+## 9. Assumptions Made
+- Common CSV enum casing variants for `source_type` are safe to normalize to lowercase before validation.
+- Rows with unquoted commas that create extra CSV fields should be treated as malformed and returned as invalid row-level results rather than silently ignoring the extra fields.
+
+## 10. Validation Performed
+- `pytest tests/integration/test_api_flow.py -q` — failed because `pytest` was not available on PATH.
+- `python -m pytest tests/integration/test_api_flow.py -q` — failed because `python` was not available on PATH.
+- `python3 -m pytest tests/integration/test_api_flow.py -q` — failed because the system Python does not have `pytest` installed.
+- `PYTHONPATH=. uv run pytest tests/integration/test_api_flow.py -q` — passed: `9 passed`.
+- `PYTHONPATH=. uv run python -m py_compile app/domain/sources.py tests/integration/test_api_flow.py` — passed.
+- `PYTHONPATH=. uv run pytest -q` — ran full suite; `84 passed`, `2 failed`. Failures were existing UI tests expecting seeded jobs/sources: `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view` and `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`.
+
+## 11. Known Limitations / Follow-Ups
+- Frontend/template work is still required per the bug report because the active Sources template displays `import_result.created_count` and hides row-level invalid results.
+- Full-suite UI failures remain outside this backend scope and appear unrelated to the CSV import changes.
+
+## 12. Commit Status
+Commit pending at report creation time; final orchestration response will include the commit hash after commit creation.

--- a/docs/bugs/csv_import_sources_zero_imported_bug_report.md
+++ b/docs/bugs/csv_import_sources_zero_imported_bug_report.md
@@ -1,0 +1,114 @@
+# Bug Report
+
+## 1. Summary
+CSV upload from the Sources UI reports `0 imported` for `/Users/mjseno/Downloads/job_board.csv` with no backend error. The provided CSV uses the documented header names and has unique rows, but all `source_type` values are title-cased (`Greenhouse`, `Lever`) while backend validation only accepts lowercase (`greenhouse`, `lever`). The active UI template also hides row-level invalid results and reads a non-existent result field, so invalid imports are surfaced as a misleading success-style `0 imported` message.
+
+## 2. Investigation Context
+- Source of report: user/HITL-style validation on branch `bugfix/csv_import_sources_zero_imported`.
+- Related feature/workflow: Sources page CSV upload, button labeled `Import sources`.
+- User action: upload `/Users/mjseno/Downloads/job_board.csv` through the UI Import CSV form.
+- Backend endpoint: `POST /sources/import` in `app/web/routes.py`.
+- Backend service: `SourceService.import_csv()` in `app/domain/sources.py`.
+- Acceptance criterion: valid unique CSV rows import as sources; duplicates are skipped. If the CSV format is invalid, provide/fix a valid format so it can import.
+
+## 3. Observed Symptoms
+- UI/import response says `0 imported`.
+- No backend exception or HTTP error was reported.
+- Expected behavior: valid unique rows should create source records; duplicate rows should be skipped with row-level status.
+- CSV structure inspection:
+  - Header: `name, source_type, base_url, external_identifier, adapter_key, company_name, is_active, notes`.
+  - Row count: 47 data rows.
+  - Source type values: 21 `Greenhouse`, 26 `Lever`.
+  - Missing required `name`, `source_type`, `base_url`, or `external_identifier`: 0 rows.
+  - Duplicate normalized source keys: 0 rows.
+  - One row has unquoted commas in the notes field, producing extra CSV fields. The current importer ignores extra fields, but the CSV is not strictly valid RFC-style CSV for that row unless the notes value is quoted.
+
+## 4. Evidence Collected
+- `docs/product/job_intelligence_platform_mvp_product_spec.md:118-127` documents the baseline CSV columns and row-specific validation requirement.
+- `docs/product/job_intelligence_platform_mvp_product_spec.md:129-132` requires valid CSV uploads to create sources and invalid/incomplete input to be flagged clearly.
+- `app/domain/sources.py:16` defines accepted source types as lowercase only: `greenhouse`, `lever`, `common_pattern`, `custom_adapter`.
+- `app/domain/sources.py:56-57` appends `Unsupported source_type.` when `payload.source_type` is not exactly in `VALID_SOURCE_TYPES`.
+- `app/domain/sources.py:191-199` maps CSV row values directly into `SourceCreateRequest`; it does not normalize `source_type` case.
+- `app/domain/sources.py:205-213` marks non-duplicate validation failures as `invalid`, so title-cased `Greenhouse`/`Lever` rows become invalid rather than created.
+- `app/web/routes.py:586-602` handles `POST /sources/import`, calls `SourceService.import_csv(payload)`, and renders the Sources page for HTML requests.
+- `app/web/routes.py:51-54` configures Jinja search order with `app/templates` before `app/web/templates`, so `app/templates/sources/index.html` is the active `sources/index.html` template when both exist.
+- `app/templates/sources/index.html:91-95` shows `{% if import_result %}<div class="alert alert--success">Imported {{ import_result.created_count|default(0) }} sources.</div>{% endif %}` and button text `Import sources`.
+- `SourceImportResponse` in `app/schemas.py:59-63` exposes `created`, `skipped_duplicate`, `invalid`, and `rows`; it does not expose `created_count`.
+- `app/web/templates/sources/index.html:88-107` contains a more complete import summary/table using `import_result.created`, `import_result.skipped_duplicate`, `import_result.invalid`, and row messages, but that template is shadowed by `app/templates/sources/index.html`.
+- `tests/integration/test_api_flow.py:95-106` validates API JSON behavior for lowercase `greenhouse` rows, an invalid row, and a duplicate row; it does not cover title-cased source types or the active HTML template behavior.
+
+## 5. Execution Path / Failure Trace
+1. User submits the CSV through the Sources UI form in `app/templates/sources/index.html`.
+2. `POST /sources/import` reads the uploaded bytes in `app/web/routes.py:586-594`.
+3. `SourceService.import_csv()` parses rows with `csv.DictReader` in `app/domain/sources.py:185-199`.
+4. For each row, the CSV `source_type` value is passed through unchanged (`Greenhouse` or `Lever`).
+5. `SourceService.validate()` checks exact membership in lowercase `VALID_SOURCE_TYPES` at `app/domain/sources.py:56`.
+6. Each row fails validation with `Unsupported source_type.` and is counted as invalid, not created.
+7. For an HTML request, the route renders `sources/index.html` with `import_result`.
+8. Because Jinja searches `app/templates` before `app/web/templates`, the active template is `app/templates/sources/index.html`, which displays `import_result.created_count|default(0)` instead of `import_result.created` and does not display invalid row details. The user sees a misleading `Imported 0 sources.` message rather than actionable validation failures.
+
+## 6. Failure Classification
+- Primary classification: Application Bug.
+- Contributing classification: Contract Mismatch / CSV format ambiguity.
+- Severity: High.
+
+Severity justification: The CSV import workflow fails for a plausible user-provided CSV that otherwise matches the documented column schema and has unique, complete source rows. The UI masks the validation errors, preventing the user from correcting the issue and blocking CSV-based source onboarding.
+
+## 7. Root Cause Analysis
+- Immediate failure point: `SourceService.validate()` rejects every row because `source_type` is title-cased in the CSV and backend validation is case-sensitive.
+- Underlying root cause: The importer does not normalize or clearly validate CSV enum values before applying the source contract, while the active UI template hides `SourceImportResponse.rows` and displays a wrong/non-existent `created_count` field.
+- Supporting evidence:
+  - CSV has `source_type` values `Greenhouse` and `Lever` only.
+  - Backend accepts only lowercase source types at `app/domain/sources.py:16` and checks exact membership at `app/domain/sources.py:56`.
+  - Import mapping uses `row.get("source_type", "")` without `.strip().lower()` at `app/domain/sources.py:193`.
+  - Active template uses `created_count`, which is not part of `SourceImportResponse`, at `app/templates/sources/index.html:91`; schema uses `created` at `app/schemas.py:59-63`.
+
+Confidence label: Confirmed Root Cause for title-case `source_type` rejection and misleading UI result display.
+
+## 8. Confidence Level
+High.
+
+The CSV schema and source type values were inspected directly, and the backend validation path deterministically rejects title-cased enum values. The active template mismatch is directly evidenced by template search order and the `created_count`/`created` field mismatch.
+
+## 9. Recommended Fix
+- Likely owner: full-stack.
+- Backend fix scope:
+  - File: `app/domain/sources.py`.
+  - Function: `SourceService.import_csv()`.
+  - Normalize CSV fields before validation, at minimum `source_type=row.get("source_type", "").strip().lower()` and trim string fields such as `name`, `base_url`, `external_identifier`, `adapter_key`, `company_name`, and `notes`.
+  - Preserve duplicate detection behavior after normalization.
+  - Decide whether extra CSV fields should produce a row-level invalid result. If strict CSV format is required, rows with `None in row` from `csv.DictReader` should be reported invalid with a clear message about quoting fields containing commas. If not strict, document that extra fields are ignored and still create the source.
+- Frontend/template fix scope:
+  - File: `app/templates/sources/index.html` or template resolution cleanup in `app/web/routes.py`.
+  - Replace `import_result.created_count|default(0)` with `import_result.created`.
+  - Display skipped duplicate and invalid counts plus row-level messages, equivalent to `app/web/templates/sources/index.html:88-107`.
+  - Avoid success styling when `created == 0` and `invalid > 0`; show an error/warning summary.
+  - Consider removing or reconciling the duplicate `app/templates/sources/index.html` and `app/web/templates/sources/index.html` templates so the intended UI is not shadowed.
+- CSV correction if no backend normalization is desired:
+  - Change `source_type` values to lowercase `greenhouse` and `lever`.
+  - Quote any `notes` field containing commas.
+
+## 10. Suggested Validation Steps
+- API-level validation:
+  - Upload a CSV with title-cased `Greenhouse` and `Lever` source types and unique source keys; expected: rows are created or clear row-level validation explains the required lowercase format.
+  - Upload the corrected lowercase CSV; expected: 47 rows created if no duplicates already exist.
+  - Re-upload the same corrected CSV; expected: `created == 0`, `skipped_duplicate == 47`, `invalid == 0`.
+  - Include a row with a comma in `notes`; expected behavior should match the chosen strictness decision (quoted field succeeds; unquoted extra fields either clearly invalid or documented/handled safely).
+- UI validation:
+  - Use the `Import sources` button in the active Sources page.
+  - Confirm the UI shows created, skipped duplicate, and invalid counts using actual `SourceImportResponse` fields.
+  - Confirm row-level invalid messages are visible when rows fail validation.
+  - Confirm no success-only `Imported 0 sources.` message is shown when all rows are invalid.
+- Regression checks:
+  - Existing mixed valid/invalid/duplicate import test behavior in `tests/integration/test_api_flow.py` should remain intact.
+  - Add coverage for title-cased source types and HTML import summary rendering.
+
+## 11. Open Questions / Missing Evidence
+- The existing database state at the time of the user import was not inspected. However, CSV duplicate analysis found no duplicate keys within the CSV itself, and duplicate-only behavior would produce `skipped_duplicate`, not row-level `invalid`.
+- Product decision needed: should CSV enum values be case-insensitive, or should the UI provide/download an exact valid template and clearly reject non-lowercase values? The recommended product-friendly behavior is to accept common case variants by normalizing.
+- Product decision needed: should unquoted commas in optional notes invalidate the row, or should extra fields be ignored/truncated? Current importer ignores extra fields silently.
+
+## 12. Final Investigator Decision
+Ready for developer fix.
+
+The CSV is partially invalid relative to the current strict backend contract because `source_type` values are title-cased, and one notes field contains unquoted commas. The feature also has defects: the importer is unnecessarily case-sensitive without actionable UI feedback, and the active UI template displays a non-existent response field while hiding row-level import errors.

--- a/docs/frontend/csv_import_sources_zero_imported_implementation_plan.md
+++ b/docs/frontend/csv_import_sources_zero_imported_implementation_plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan
+
+## 1. Feature Overview
+Fix the active Sources CSV import result UI so HTML imports report the backend `SourceImportResponse` accurately and expose row-level validation feedback.
+
+## 2. Technical Scope
+- Update `app/templates/sources/index.html`, which is the active `sources/index.html` template.
+- Render `created`, `skipped_duplicate`, `invalid`, and `rows` from the backend response contract.
+- Use warning/error styling when validation errors prevent imports instead of showing a success-only `0 imported` message.
+- Add HTML rendering coverage for created, skipped duplicate, and invalid row results.
+
+## 3. UI/UX Inputs
+- Bug report: `docs/bugs/csv_import_sources_zero_imported_bug_report.md`.
+- Backend report: `docs/backend/csv_import_sources_zero_imported_implementation_report.md`.
+- Existing template conventions in `app/templates/sources/index.html` and `app/templates/macros/ui.html`.
+
+## 4. Files Expected to Change
+- `app/templates/sources/index.html`
+- `tests/integration/test_html_views.py`
+- `docs/frontend/csv_import_sources_zero_imported_implementation_plan.md`
+- `docs/frontend/csv_import_sources_zero_imported_implementation_report.md`
+
+## 5. Dependencies / Constraints
+- Backend contract remains unchanged: `created`, `skipped_duplicate`, `invalid`, `rows`.
+- Do not modify backend logic unless a contract defect is found.
+- Keep markup accessible with semantic headings, table headers, live/status alert roles, and visible row messages.
+
+## 6. Assumptions
+- The active template should remain under `app/templates/` because route template search order prioritizes that directory.
+- Row-level import details can be shown in a compact table within the existing import panel.
+
+## 7. Validation Plan
+- Run targeted HTML integration tests for CSV import rendering.
+- Run the existing import/API integration test file.
+- Run the full test suite if available and report any unrelated failures.

--- a/docs/frontend/csv_import_sources_zero_imported_implementation_report.md
+++ b/docs/frontend/csv_import_sources_zero_imported_implementation_report.md
@@ -1,0 +1,34 @@
+# Implementation Report
+
+## 1. Summary of Changes
+Updated the active Sources CSV import template to render the backend import contract fields (`created`, `skipped_duplicate`, `invalid`, and `rows`) instead of the non-existent `created_count`. The import panel now shows accessible summary messaging, created/skipped/invalid counts, and row-level messages for duplicate and invalid rows.
+
+## 2. Files Modified
+- `app/templates/sources/index.html` — active Sources import result UI.
+- `tests/integration/test_html_views.py` — HTML coverage for created, skipped duplicate, and invalid import row rendering.
+- `docs/frontend/csv_import_sources_zero_imported_implementation_plan.md` — frontend implementation plan.
+- `docs/frontend/csv_import_sources_zero_imported_implementation_report.md` — this implementation report.
+
+## 3. UI Behavior Implemented
+- Successful imports display the actual created count from `import_result.created`.
+- Duplicate skips display the backend `skipped_duplicate` count and row-level duplicate message.
+- Invalid rows display the backend `invalid` count and row-level validation/malformed CSV message.
+- Imports with invalid rows and zero created rows use error styling and avoid success-only “0 imported” messaging.
+- Mixed imports use warning styling to indicate partial completion.
+- Import results use semantic alert/status roles, table headers, a caption, and an explicitly associated file input label/help text.
+
+## 4. Assumptions Made
+- The active UI remains `app/templates/sources/index.html` based on the template search order documented in the bug report.
+- Existing backend row messages are appropriate to display directly in the HTML result table.
+
+## 5. Validation Performed
+- `PYTHONPATH=. uv run pytest tests/integration/test_html_views.py -q` — passed: `4 passed`.
+- `PYTHONPATH=. uv run pytest tests/integration/test_api_flow.py -q` — passed: `9 passed`.
+- `PYTHONPATH=. uv run pytest -q` — ran full suite; `85 passed`, `2 failed`. Failures are existing seeded-data UI test failures also noted by the backend report: `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view` and `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`.
+
+## 6. Known Limitations / Follow-Ups
+- The duplicate `app/web/templates/sources/index.html` still contains a separate import result implementation, but it is not active under the current template search order. No template-resolution cleanup was performed to avoid broadening scope.
+- Full-suite failures remain unrelated to this frontend import-result change and appear tied to missing seeded jobs/sources in existing UI tests.
+
+## 7. Commit Status
+Pending commit creation after report update; final commit hash will be provided in the orchestration response.

--- a/docs/qa/csv_import_sources_zero_imported_test_plan.md
+++ b/docs/qa/csv_import_sources_zero_imported_test_plan.md
@@ -1,0 +1,40 @@
+# Test Plan
+
+## 1. Feature Overview
+Validate the CSV source import bugfix for `/sources/import` and the active Sources UI import panel. The fix must allow common title-cased `source_type` values (`Greenhouse`, `Lever`) to import after normalization, preserve duplicate detection, surface malformed CSV rows as row-level errors, and prevent misleading UI-only `0 imported` messaging.
+
+## 2. Acceptance Criteria Mapping
+| Acceptance criterion | Test coverage |
+| --- | --- |
+| User can import `/Users/mjseno/Downloads/job_board.csv` from the UI Import CSV form using `Import sources`. | Manual/TestClient HTML upload of the provided file with count/schema-only evidence. |
+| If CSV format is broken, QA documents exactly what is wrong and how to fix it. | CSV inspection checks headers, row count, required fields, duplicates, source type distribution, and malformed extra-field rows. |
+| If upload feature is broken, feature must be fixed and verified. | HTML upload returns HTTP 200 and renders actionable result summary/messages. No upload blocker found. |
+| Unique valid rows should import as sources. | API tests for title-cased Greenhouse/Lever and corrected user-shaped CSV rows. Provided CSV valid rows import. |
+| Duplicate rows should be skipped. | API duplicate re-upload test and corrected provided CSV re-upload evidence. |
+| UI should not misleadingly report only `0 imported` with no explanation when validation errors occur. | UI tests verify created/skipped/invalid labels, row messages, malformed guidance, and absence of `Imported 0 sources`. |
+
+## 3. Test Scenarios
+1. Inspect provided CSV schema/counts without exposing row data.
+2. Upload provided CSV through HTML import path and verify result summary plus malformed-row guidance.
+3. Upload title-cased Greenhouse/Lever rows through backend import endpoint and verify created counts.
+4. Re-upload the same valid rows and verify duplicate skip counts.
+5. Upload malformed unquoted extra-field CSV row and verify row-level invalid status/message.
+6. Upload corrected user-shaped CSV with quoted comma-containing notes and verify success.
+7. Verify active UI displays created/skipped/invalid counts and row-level duplicate/invalid messages.
+8. Run targeted import regressions and full pytest regression suite.
+
+## 4. Edge Cases
+- Title-cased enum values normalized to lowercase before validation.
+- Optional notes containing commas must be quoted; unquoted commas create unexpected extra CSV fields.
+- Duplicate detection must work after normalization and on full re-upload.
+- Mixed import result with created and invalid rows must render warning/validation context instead of success-only messaging.
+
+## 5. Test Types Covered
+- Functional API import validation.
+- Negative malformed CSV validation.
+- Edge-case source type normalization and quoted notes.
+- UI integration rendering for import summary and row messages.
+- Regression suite execution with unrelated failure classification.
+
+## 6. Coverage Justification
+Coverage directly maps to every acceptance criterion and verifies both backend contract behavior and the active HTML template. The provided CSV was inspected/imported using count/schema-only evidence to avoid exposing row data.

--- a/docs/qa/csv_import_sources_zero_imported_test_report.md
+++ b/docs/qa/csv_import_sources_zero_imported_test_report.md
@@ -1,0 +1,49 @@
+# Test Report
+
+## 1. Execution Summary
+- Total focused CSV import QA tests added/executed: 3
+- Focused CSV import QA tests passed: 3
+- Focused CSV import QA tests failed: 0
+- Existing targeted import regression tests passed: 13
+- Full pytest suite collected: 90
+- Full pytest suite passed: 88
+- Full pytest suite failed: 2 unrelated pre-existing UI seeded-data tests
+
+## 2. Detailed Results
+| Test / command | Outcome | Evidence |
+| --- | --- | --- |
+| Provided CSV inspection/import script | Pass | Headers match expected 8-column shape; 47 data rows; source types: 21 `Greenhouse`, 26 `Lever`; 0 missing required fields; 0 duplicate normalized keys; 1 malformed extra-field row. API import result: HTTP 200, created 46, skipped 0, invalid 1. Corrected shape import: created 47, skipped 0, invalid 0. Corrected re-upload: created 0, skipped 47, invalid 0. |
+| Provided CSV HTML upload script | Pass | HTTP 200; UI renders Created, Skipped duplicates, Invalid rows; renders validation/partial-completion title; renders guidance `Quote values that contain commas.`; does not render misleading `Imported 0 sources`. |
+| `PYTHONPATH=. uv run pytest tests/api/test_csv_import_sources_zero_imported.py -q` | Pass | `.. [100%]` |
+| `PYTHONPATH=. uv run pytest tests/ui/test_csv_import_sources_zero_imported_ui.py -q` | Pass | `. [100%]` |
+| `PYTHONPATH=. uv run pytest tests/integration/test_api_flow.py tests/integration/test_html_views.py -q` | Pass | `............. [100%]` |
+| `PYTHONPATH=. uv run pytest -q` | Non-blocking fail | 88 passed, 2 failed. Failures are `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view` and `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`. |
+
+## 3. Failed Tests
+### Full regression only: `test_job_detail_renders_html_detail_view`
+- Error: `IndexError: list index out of range` at `jobs_response.json()[0]["id"]`.
+- Logs/evidence: `/jobs` returned HTTP 200 with an empty JSON list, so the test had no seeded job to open.
+
+### Full regression only: `test_source_detail_renders_html_detail_view`
+- Error: `AssertionError` because regex did not find `/sources/{id}` in the HTML response.
+- Logs/evidence: `/sources` rendered a valid empty Sources page, so the test had no seeded source link to open.
+
+## 4. Failure Classification
+- `test_job_detail_renders_html_detail_view`: Environment/Test Data Issue. Root cause hypothesis: test assumes persisted/seeded jobs in the shared application database, but the regression run had no job records. Reproduction: run `PYTHONPATH=. uv run pytest -q`; observe empty `/jobs` list and `IndexError`. Severity for this fix: Low/non-blocking because it does not exercise CSV import and existed in upstream implementation reports.
+- `test_source_detail_renders_html_detail_view`: Environment/Test Data Issue. Root cause hypothesis: test assumes persisted/seeded sources, but the Sources page is empty. Reproduction: run full suite; observe no `/sources/{id}` link. Severity for this fix: Low/non-blocking because focused CSV import API/UI tests pass.
+
+## 5. Observations
+- The provided CSV is not fully valid as-is because one row contains unquoted comma-separated extra fields in the `notes` position. Fix: quote any field value containing commas, e.g. wrap the entire notes value in double quotes.
+- Title-cased `Greenhouse` and `Lever` values now import after backend normalization.
+- The active UI now surfaces counts and row-level messages instead of hiding invalid-row reasons.
+- No flakiness observed in focused import tests.
+
+## 6. Regression Check
+- Backend import regression passed for mixed valid/invalid/duplicate behavior and new normalization/malformed/corrected-shape cases.
+- HTML import regression passed for created, skipped duplicate, invalid counts, and row-level messages.
+- Full regression has two unrelated seeded-data assumptions; they do not affect this CSV import fix.
+
+## 7. QA Decision
+Approved. The fix meets the user acceptance criteria. The only provided-CSV formatting issue is one malformed row caused by an unquoted field containing commas; quoting that field allows all 47 rows to import, and re-upload correctly skips 47 duplicates.
+
+[QA SIGN-OFF APPROVED]

--- a/docs/release/csv_import_sources_zero_imported_issue.md
+++ b/docs/release/csv_import_sources_zero_imported_issue.md
@@ -1,0 +1,31 @@
+# Issue
+
+## 1. Feature Name
+csv_import_sources_zero_imported
+
+## 2. Classification
+Bug / Issue Report
+
+## 3. Summary
+CSV source imports from the Sources UI reported `0 imported` for a user-provided job board CSV because title-cased `source_type` values were rejected and the active UI hid row-level import feedback.
+
+## 4. Related Documents
+- Bug Report: docs/bugs/csv_import_sources_zero_imported_bug_report.md
+- Backend Report: docs/backend/csv_import_sources_zero_imported_implementation_report.md
+- Frontend Report: docs/frontend/csv_import_sources_zero_imported_implementation_report.md
+- QA Report: docs/qa/csv_import_sources_zero_imported_test_report.md
+
+## 5. Acceptance Criteria
+- Import `/Users/mjseno/Downloads/job_board.csv` via the UI Import CSV form using `Import sources`.
+- Unique valid rows import as sources.
+- Duplicate rows are skipped.
+- Invalid or malformed rows show actionable row-level feedback.
+- CSV guidance is provided for notes or other values containing commas.
+
+## 6. QA Status
+- Approved: YES
+- Gate: [QA SIGN-OFF APPROVED]
+- HITL: HITL validation successful
+
+## 7. Linked GitHub Issue
+- https://github.com/michaelseno/job-intelligence-platform/issues/12

--- a/docs/release/csv_import_sources_zero_imported_pr.md
+++ b/docs/release/csv_import_sources_zero_imported_pr.md
@@ -1,0 +1,44 @@
+# Pull Request
+
+## 1. Feature Name
+csv_import_sources_zero_imported
+
+## 2. Summary
+Fixes the CSV source import path so user-provided source CSVs with title-cased source types import correctly, duplicate re-uploads are skipped, malformed rows are reported, and the active Sources UI shows actionable import results instead of a misleading `0 imported` message.
+
+## 3. Related Documents
+- Product Spec: docs/product/job_intelligence_platform_mvp_product_spec.md
+- Technical Design: docs/architecture/job_intelligence_platform_mvp_architecture.md
+- Bug Report: docs/bugs/csv_import_sources_zero_imported_bug_report.md
+- Backend Report: docs/backend/csv_import_sources_zero_imported_implementation_report.md
+- Frontend Report: docs/frontend/csv_import_sources_zero_imported_implementation_report.md
+- QA Report: docs/qa/csv_import_sources_zero_imported_test_report.md
+- QA Test Plan: docs/qa/csv_import_sources_zero_imported_test_plan.md
+
+## 4. Changes Included
+- Normalizes CSV `source_type` values such as `Greenhouse` and `Lever` before backend validation.
+- Preserves duplicate detection for repeated imports after normalization.
+- Reports malformed CSV rows with unexpected extra fields and guidance to quote values containing commas.
+- Updates the active Sources import UI to render created, skipped duplicate, invalid counts, and row-level messages.
+- Adds focused API and UI regression coverage for the CSV import bug.
+- Adds bug, QA, and release traceability documents for the issue.
+
+## 5. QA Status
+- Approved: YES
+- QA gate: [QA SIGN-OFF APPROVED]
+- HITL gate: HITL validation successful
+
+## 6. Test Coverage
+- `PYTHONPATH=. uv run pytest tests/api/test_csv_import_sources_zero_imported.py -q` passed.
+- `PYTHONPATH=. uv run pytest tests/ui/test_csv_import_sources_zero_imported_ui.py -q` passed.
+- `PYTHONPATH=. uv run pytest tests/integration/test_api_flow.py tests/integration/test_html_views.py -q` passed.
+- Full `PYTHONPATH=. uv run pytest -q` completed with 88 passed and 2 unrelated non-blocking UI test-data failures.
+- User acceptance evidence: provided CSV imported 46 rows and flagged 1 malformed row; corrected CSV imported 47 rows; corrected re-upload skipped 47 duplicates.
+
+## 7. Risks / Notes
+- The original CSV contains one malformed row caused by an unquoted value containing commas. Quote values containing commas to import all 47 rows.
+- Known non-blocking failures remain in `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view` and `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`; both are unrelated seeded-data assumptions where the page/database had no records to link.
+- No force-push or hook bypass is used for this release.
+
+## 8. Linked Issue
+- Closes #12

--- a/tests/api/test_csv_import_sources_zero_imported.py
+++ b/tests/api/test_csv_import_sources_zero_imported.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+
+CSV_HEADER = "name,source_type,base_url,external_identifier,adapter_key,company_name,is_active,notes\n"
+
+
+def test_csv_source_import_normalizes_title_case_and_skips_duplicate_reupload(client):
+    csv_body = (
+        CSV_HEADER
+        + "QA GH,Greenhouse,https://boards.greenhouse.io/qa-title,qa-title,,QA,true,normalized type\n"
+        + "QA Lever,Lever,https://jobs.lever.co/qa-title,qa-title-lever,,QA,true,normalized type\n"
+    )
+
+    first_response = client.post("/sources/import", files={"file": ("sources.csv", csv_body, "text/csv")})
+
+    assert first_response.status_code == 200
+    first_data = first_response.json()
+    assert first_data["created"] == 2
+    assert first_data["skipped_duplicate"] == 0
+    assert first_data["invalid"] == 0
+    assert [row["status"] for row in first_data["rows"]] == ["created", "created"]
+
+    second_response = client.post("/sources/import", files={"file": ("sources.csv", csv_body, "text/csv")})
+
+    assert second_response.status_code == 200
+    second_data = second_response.json()
+    assert second_data["created"] == 0
+    assert second_data["skipped_duplicate"] == 2
+    assert second_data["invalid"] == 0
+    assert [row["status"] for row in second_data["rows"]] == ["skipped_duplicate", "skipped_duplicate"]
+
+
+def test_csv_source_import_reports_malformed_extra_fields_and_accepts_corrected_shape(client):
+    malformed_csv = (
+        CSV_HEADER
+        + "Malformed,Greenhouse,https://boards.greenhouse.io/qa-malformed,qa-malformed,,QA,true,notes with comma,extra field\n"
+    )
+
+    malformed_response = client.post("/sources/import", files={"file": ("sources.csv", malformed_csv, "text/csv")})
+
+    assert malformed_response.status_code == 200
+    malformed_data = malformed_response.json()
+    assert malformed_data["created"] == 0
+    assert malformed_data["skipped_duplicate"] == 0
+    assert malformed_data["invalid"] == 1
+    assert malformed_data["rows"][0]["status"] == "invalid"
+    assert "Quote values that contain commas" in malformed_data["rows"][0]["message"]
+
+    corrected_csv = (
+        CSV_HEADER
+        + 'Corrected GH,Greenhouse,https://boards.greenhouse.io/qa-corrected,qa-corrected,,QA,true,"notes with comma, quoted"\n'
+        + "Corrected Lever,Lever,https://jobs.lever.co/qa-corrected,qa-corrected-lever,,QA,true,valid lever row\n"
+    )
+
+    corrected_response = client.post("/sources/import", files={"file": ("job_board.csv", corrected_csv, "text/csv")})
+
+    assert corrected_response.status_code == 200
+    corrected_data = corrected_response.json()
+    assert corrected_data["created"] == 2
+    assert corrected_data["skipped_duplicate"] == 0
+    assert corrected_data["invalid"] == 0
+    assert [row["status"] for row in corrected_data["rows"]] == ["created", "created"]

--- a/tests/integration/test_api_flow.py
+++ b/tests/integration/test_api_flow.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from sqlalchemy import select
 
 from app.domain.job_preferences import get_default_job_filter_preferences
-from app.persistence.models import JobTrackingEvent, Reminder
+from app.persistence.models import JobTrackingEvent, Reminder, Source
 
 
 class DummyResponse:
@@ -104,6 +104,85 @@ def test_csv_import_mixed_valid_invalid_and_duplicate(client):
     assert data["created"] == 1
     assert data["invalid"] == 1
     assert data["skipped_duplicate"] == 1
+
+
+def test_csv_import_normalizes_title_cased_source_type(client, session):
+    csv_body = "name,source_type,base_url,external_identifier,adapter_key,company_name,is_active,notes\nExample GH,Greenhouse,https://boards.greenhouse.io/example-title,example-title,,Example,true,Title case source type\nExample Lever,Lever,https://jobs.lever.co/example-lever,example-lever,,Example,true,Title case source type\n"
+
+    response = client.post(
+        "/sources/import",
+        files={"file": ("sources.csv", csv_body, "text/csv")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] == 2
+    assert data["invalid"] == 0
+    assert data["skipped_duplicate"] == 0
+    assert {row["status"] for row in data["rows"]} == {"created"}
+
+    stored_types = set(session.scalars(select(Source.source_type)))
+    assert stored_types == {"greenhouse", "lever"}
+
+
+def test_csv_import_preserves_duplicate_skip_with_normalized_source_type(client):
+    csv_body = "name,source_type,base_url,external_identifier,adapter_key,company_name,is_active,notes\nExample GH,Greenhouse,https://boards.greenhouse.io/duplicate-title,duplicate-title,,Example,true,Original\nExample GH Duplicate,greenhouse,https://boards.greenhouse.io/duplicate-title,duplicate-title,,Example,true,Duplicate\n"
+
+    response = client.post(
+        "/sources/import",
+        files={"file": ("sources.csv", csv_body, "text/csv")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] == 1
+    assert data["invalid"] == 0
+    assert data["skipped_duplicate"] == 1
+    assert data["rows"][1]["status"] == "skipped_duplicate"
+    assert "Duplicate source already exists." in data["rows"][1]["message"]
+
+
+def test_csv_import_malformed_row_returns_row_level_error(client):
+    csv_body = "name,source_type,base_url,external_identifier,adapter_key,company_name,is_active,notes\nMalformed Notes,Greenhouse,https://boards.greenhouse.io/malformed,malformed,,Example,true,first note,second note\n"
+
+    response = client.post(
+        "/sources/import",
+        files={"file": ("sources.csv", csv_body, "text/csv")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] == 0
+    assert data["invalid"] == 1
+    assert data["skipped_duplicate"] == 0
+    assert data["rows"] == [
+        {
+            "row_number": 2,
+            "status": "invalid",
+            "message": "Malformed CSV row: unexpected extra fields found. Quote values that contain commas.",
+            "source_id": None,
+        }
+    ]
+
+
+def test_csv_import_valid_user_csv_shape_imports_successfully(client):
+    csv_body = (
+        "name,source_type,base_url,external_identifier,adapter_key,company_name,is_active,notes\n"
+        'Acme Greenhouse,Greenhouse,https://boards.greenhouse.io/acme,acme,,Acme,true,"backend, platform roles"\n'
+        "Beta Lever,Lever,https://jobs.lever.co/beta,beta,,Beta,true,standard lever board\n"
+    )
+
+    response = client.post(
+        "/sources/import",
+        files={"file": ("job_board.csv", csv_body, "text/csv")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["created"] == 2
+    assert data["invalid"] == 0
+    assert data["skipped_duplicate"] == 0
+    assert [row["status"] for row in data["rows"]] == ["created", "created"]
 
 
 def test_jobs_api_treats_empty_source_filter_as_unset_and_keeps_integer_filtering(client, monkeypatch):

--- a/tests/integration/test_html_views.py
+++ b/tests/integration/test_html_views.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from io import BytesIO
+
 from app.domain.job_preferences import get_default_job_filter_preferences
 
 
@@ -126,3 +128,43 @@ def test_jobs_html_treats_empty_source_filter_as_unset(client, monkeypatch):
 
     assert response.status_code == 200
     assert job["title"] in response.text
+
+
+def test_sources_import_html_renders_created_skipped_and_invalid_rows(client):
+    csv_header = "name,source_type,base_url,external_identifier,adapter_key,company_name,is_active,notes\n"
+    valid_csv = csv_header + "Example Greenhouse,Greenhouse,https://boards.greenhouse.io/example,example,,Example,true,Initial import\n"
+
+    created_response = client.post(
+        "/sources/import",
+        headers={"accept": "text/html"},
+        files={"file": ("sources.csv", BytesIO(valid_csv.encode("utf-8")), "text/csv")},
+    )
+
+    assert created_response.status_code == 200
+    assert "Import completed" in created_response.text
+    assert "Created" in created_response.text
+    assert "Skipped duplicates" in created_response.text
+    assert "Invalid rows" in created_response.text
+    assert "<dd>1</dd>" in created_response.text
+    assert "Created</span>" in created_response.text
+    assert "source created" in created_response.text
+
+    mixed_csv = (
+        csv_header
+        + "Example Greenhouse,Greenhouse,https://boards.greenhouse.io/example,example,,Example,true,Duplicate import\n"
+        + "Malformed Greenhouse,Greenhouse,https://boards.greenhouse.io/malformed,malformed,,Malformed,true,notes with comma,extra field\n"
+    )
+
+    mixed_response = client.post(
+        "/sources/import",
+        headers={"accept": "text/html"},
+        files={"file": ("sources.csv", BytesIO(mixed_csv.encode("utf-8")), "text/csv")},
+    )
+
+    assert mixed_response.status_code == 200
+    assert "Import completed with validation errors" in mixed_response.text
+    assert "No sources were imported. Review the invalid rows below" in mixed_response.text
+    assert "Skipped Duplicate</span>" in mixed_response.text
+    assert "Invalid</span>" in mixed_response.text
+    assert "Duplicate source already exists." in mixed_response.text
+    assert "Malformed CSV row: unexpected extra fields found. Quote values that contain commas." in mixed_response.text

--- a/tests/ui/test_csv_import_sources_zero_imported_ui.py
+++ b/tests/ui/test_csv_import_sources_zero_imported_ui.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+
+CSV_HEADER = "name,source_type,base_url,external_identifier,adapter_key,company_name,is_active,notes\n"
+
+
+def test_sources_import_ui_displays_created_skipped_invalid_counts_and_row_messages(client):
+    initial_csv = CSV_HEADER + "UI GH,Greenhouse,https://boards.greenhouse.io/qa-ui,qa-ui,,QA,true,initial\n"
+    initial_response = client.post(
+        "/sources/import",
+        headers={"accept": "text/html"},
+        files={"file": ("sources.csv", BytesIO(initial_csv.encode("utf-8")), "text/csv")},
+    )
+
+    assert initial_response.status_code == 200
+    assert "Import completed" in initial_response.text
+    assert "Created" in initial_response.text
+    assert "Skipped duplicates" in initial_response.text
+    assert "Invalid rows" in initial_response.text
+    assert "source created" in initial_response.text
+
+    problem_csv = (
+        CSV_HEADER
+        + "UI GH Duplicate,Greenhouse,https://boards.greenhouse.io/qa-ui,qa-ui,,QA,true,duplicate\n"
+        + "UI Bad,Greenhouse,https://boards.greenhouse.io/qa-ui-bad,qa-ui-bad,,QA,true,needs quoting,extra\n"
+    )
+    problem_response = client.post(
+        "/sources/import",
+        headers={"accept": "text/html"},
+        files={"file": ("sources.csv", BytesIO(problem_csv.encode("utf-8")), "text/csv")},
+    )
+
+    assert problem_response.status_code == 200
+    assert "Import completed with validation errors" in problem_response.text
+    assert "No sources were imported. Review the invalid rows below" in problem_response.text
+    assert "Skipped Duplicate" in problem_response.text
+    assert "Invalid" in problem_response.text
+    assert "Duplicate source already exists." in problem_response.text
+    assert "Malformed CSV row: unexpected extra fields found. Quote values that contain commas." in problem_response.text
+    assert "Imported 0 sources" not in problem_response.text


### PR DESCRIPTION
# Pull Request

## 1. Feature Name
csv_import_sources_zero_imported

## 2. Summary
Fixes the CSV source import path so user-provided source CSVs with title-cased source types import correctly, duplicate re-uploads are skipped, malformed rows are reported, and the active Sources UI shows actionable import results instead of a misleading `0 imported` message.

## 3. Related Documents
- Product Spec: docs/product/job_intelligence_platform_mvp_product_spec.md
- Technical Design: docs/architecture/job_intelligence_platform_mvp_architecture.md
- Bug Report: docs/bugs/csv_import_sources_zero_imported_bug_report.md
- Backend Report: docs/backend/csv_import_sources_zero_imported_implementation_report.md
- Frontend Report: docs/frontend/csv_import_sources_zero_imported_implementation_report.md
- QA Report: docs/qa/csv_import_sources_zero_imported_test_report.md
- QA Test Plan: docs/qa/csv_import_sources_zero_imported_test_plan.md

## 4. Changes Included
- Normalizes CSV `source_type` values such as `Greenhouse` and `Lever` before backend validation.
- Preserves duplicate detection for repeated imports after normalization.
- Reports malformed CSV rows with unexpected extra fields and guidance to quote values containing commas.
- Updates the active Sources import UI to render created, skipped duplicate, invalid counts, and row-level messages.
- Adds focused API and UI regression coverage for the CSV import bug.
- Adds bug, QA, and release traceability documents for the issue.

## 5. QA Status
- Approved: YES
- QA gate: [QA SIGN-OFF APPROVED]
- HITL gate: HITL validation successful

## 6. Test Coverage
- `PYTHONPATH=. uv run pytest tests/api/test_csv_import_sources_zero_imported.py -q` passed.
- `PYTHONPATH=. uv run pytest tests/ui/test_csv_import_sources_zero_imported_ui.py -q` passed.
- `PYTHONPATH=. uv run pytest tests/integration/test_api_flow.py tests/integration/test_html_views.py -q` passed.
- Full `PYTHONPATH=. uv run pytest -q` completed with 88 passed and 2 unrelated non-blocking UI test-data failures.
- User acceptance evidence: provided CSV imported 46 rows and flagged 1 malformed row; corrected CSV imported 47 rows; corrected re-upload skipped 47 duplicates.

## 7. Risks / Notes
- The original CSV contains one malformed row caused by an unquoted value containing commas. Quote values containing commas to import all 47 rows.
- Known non-blocking failures remain in `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view` and `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`; both are unrelated seeded-data assumptions where the page/database had no records to link.
- No force-push or hook bypass is used for this release.

## 8. Linked Issue
- Closes #12
