### PR TITLE
Bugfix: source_health_cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Local-first FastAPI backend for the Job Intelligence Platform MVP.
 5. Start the app:
    - `uvicorn app.main:app --reload`
 
+### Database schema guardrail
+
+The app validates migrated PostgreSQL databases during startup. If the database
+revision is behind the repository head, startup fails with a clear message to run
+`alembic upgrade head` instead of allowing route-level ORM errors. Source health
+cleanup requires migration `20260429_0003`; after pulling this change, run
+`alembic upgrade head` against the same `DATABASE_URL` used by the server before
+restarting the app. The validated source additions are also applied by Alembic
+migration `20260429_0004`, so `alembic upgrade head` is required to seed them.
+
 ## MVP backend scope implemented
 
 - manual source creation and CSV import

--- a/alembic/versions/20260429_0003_source_company_provider_key.py
+++ b/alembic/versions/20260429_0003_source_company_provider_key.py
@@ -1,0 +1,53 @@
+"""add source company provider uniqueness
+
+Revision ID: 20260429_0003
+Revises: 20260424_0002
+Create Date: 2026-04-29 10:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+
+revision = "20260429_0003"
+down_revision = "20260424_0002"
+branch_labels = None
+depends_on = None
+
+
+ACTIVE_COMPANY_PROVIDER_UNIQUE_INDEX = "ix_sources_company_provider_active_unique"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _has_column(bind, "sources", "company_provider_key"):
+        op.add_column("sources", sa.Column("company_provider_key", sa.String(length=512), nullable=True))
+
+    # Import after the schema change so ORM writes can see the new column. The cleanup is
+    # idempotent and soft-deletes only rows in the confirmed source-health cleanup scope.
+    from app.domain.source_health_cleanup import cleanup_source_health_sources
+
+    with Session(bind=bind) as session:
+        cleanup_source_health_sources(session)
+
+    op.create_index(
+        ACTIVE_COMPANY_PROVIDER_UNIQUE_INDEX,
+        "sources",
+        ["company_provider_key"],
+        unique=True,
+        sqlite_where=sa.text("deleted_at IS NULL"),
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(ACTIVE_COMPANY_PROVIDER_UNIQUE_INDEX, table_name="sources")
+    op.drop_column("sources", "company_provider_key")
+
+
+def _has_column(bind, table_name: str, column_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return any(column["name"] == column_name for column in inspector.get_columns(table_name))

--- a/alembic/versions/20260429_0004_add_validated_sources.py
+++ b/alembic/versions/20260429_0004_add_validated_sources.py
@@ -1,0 +1,31 @@
+"""add validated source health sources
+
+Revision ID: 20260429_0004
+Revises: 20260429_0003
+Create Date: 2026-04-29 11:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy.orm import Session
+
+
+revision = "20260429_0004"
+down_revision = "20260429_0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    from app.domain.source_seed import add_validated_source_additions
+
+    bind = op.get_bind()
+    with Session(bind=bind) as session:
+        add_validated_source_additions(session)
+
+
+def downgrade() -> None:
+    # Source additions are intentionally not deleted on downgrade to avoid removing
+    # operator-managed rows or source run history that may have accumulated after seeding.
+    pass

--- a/app/adapters/lever/adapter.py
+++ b/app/adapters/lever/adapter.py
@@ -25,9 +25,10 @@ class LeverAdapter:
         payload = response.json()
         jobs: list[NormalizedJobCandidate] = []
         for item in payload:
+            lists_text = _extract_lists_text(item.get("lists"))
             description_parts = [
                 item.get("descriptionPlain"),
-                item.get("lists") and " ".join(entry.get("text", "") for group in item.get("lists", []) for entry in group.get("content", [])),
+                lists_text,
                 item.get("additionalPlain"),
             ]
             description_text = clean_text(" ".join(part for part in description_parts if part))
@@ -48,6 +49,28 @@ class LeverAdapter:
                 )
             )
         return AdapterFetchResult(jobs=jobs)
+
+
+def _extract_lists_text(lists_payload: object) -> str:
+    if not isinstance(lists_payload, list):
+        return ""
+
+    parts: list[str] = []
+    for group in lists_payload:
+        if not isinstance(group, dict):
+            continue
+        content = group.get("content", [])
+        if isinstance(content, str):
+            parts.append(content)
+            continue
+        if not isinstance(content, list):
+            continue
+        for entry in content:
+            if isinstance(entry, dict):
+                parts.append(clean_text(entry.get("text")))
+            elif isinstance(entry, str):
+                parts.append(entry)
+    return clean_text(" ".join(part for part in parts if part))
 
 
 def _parse_millis(value: int | None) -> datetime | None:

--- a/app/domain/source_health_cleanup.py
+++ b/app/domain/source_health_cleanup.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.domain.sources import build_source_company_provider_key
+from app.persistence.models import Source, utcnow
+
+
+REMOVED_LEVER_IDENTIFIERS = {
+    "alkami",
+    "browserstack",
+    "circleci",
+    "keepersecurity",
+    "postman",
+    "snyk",
+    "storable",
+    "subsplash",
+}
+REMOVED_GREENHOUSE_IDENTIFIERS = {"notion", "plaid", "hubspot"}
+
+
+@dataclass(frozen=True)
+class SourceHealthCleanupResult:
+    removed_source_ids: list[int]
+    duplicate_source_ids: list[int]
+    updated_key_source_ids: list[int]
+
+
+def cleanup_source_health_sources(session: Session) -> SourceHealthCleanupResult:
+    """Soft-delete known-invalid/removed sources and duplicate active company/provider sources.
+
+    The operation is idempotent: already-deleted rows are ignored, key backfills are stable,
+    and duplicate rows already soft-deleted by a previous run are not selected again.
+    """
+
+    now = utcnow()
+    active_sources = list(session.scalars(select(Source).where(Source.deleted_at.is_(None))))
+    updated_key_ids = _backfill_company_provider_keys(active_sources)
+    removed_ids = _soft_delete_removed_sources(active_sources, now)
+    duplicate_ids = _soft_delete_duplicate_sources(active_sources, now)
+    session.commit()
+    return SourceHealthCleanupResult(
+        removed_source_ids=removed_ids,
+        duplicate_source_ids=duplicate_ids,
+        updated_key_source_ids=updated_key_ids,
+    )
+
+
+def _backfill_company_provider_keys(sources: list[Source]) -> list[int]:
+    updated_ids: list[int] = []
+    for source in sources:
+        key = build_source_company_provider_key(
+            source.source_type,
+            source.company_name,
+            source.name,
+            source.adapter_key,
+        )
+        if source.company_provider_key != key:
+            source.company_provider_key = key
+            updated_ids.append(source.id)
+    return updated_ids
+
+
+def _soft_delete_removed_sources(sources: list[Source], deleted_at: datetime) -> list[int]:
+    removed_ids: list[int] = []
+    for source in sources:
+        identifier = (source.external_identifier or "").strip().lower()
+        should_remove = (source.source_type == "lever" and identifier in REMOVED_LEVER_IDENTIFIERS) or (
+            source.source_type == "greenhouse" and identifier in REMOVED_GREENHOUSE_IDENTIFIERS
+        )
+        if should_remove:
+            source.deleted_at = deleted_at
+            source.is_active = False
+            removed_ids.append(source.id)
+    return removed_ids
+
+
+def _soft_delete_duplicate_sources(sources: list[Source], deleted_at: datetime) -> list[int]:
+    groups: dict[str, list[Source]] = {}
+    for source in sources:
+        if source.deleted_at is not None:
+            continue
+        key = source.company_provider_key or build_source_company_provider_key(
+            source.source_type,
+            source.company_name,
+            source.name,
+            source.adapter_key,
+        )
+        groups.setdefault(key, []).append(source)
+
+    duplicate_ids: list[int] = []
+    for grouped_sources in groups.values():
+        if len(grouped_sources) <= 1:
+            continue
+        keeper = max(grouped_sources, key=_source_keeper_sort_key)
+        for source in grouped_sources:
+            if source.id == keeper.id:
+                continue
+            source.deleted_at = deleted_at
+            source.is_active = False
+            duplicate_ids.append(source.id)
+    return duplicate_ids
+
+
+def _source_keeper_sort_key(source: Source) -> tuple[int, int, datetime, int]:
+    healthy_rank = 1 if source.health_state == "healthy" else 0
+    success_rank = 1 if source.last_run_status == "success" else 0
+    recency = source.last_run_at or source.updated_at or source.created_at or datetime.min
+    return (healthy_rank, success_rank, recency, source.id)

--- a/app/domain/source_seed.py
+++ b/app/domain/source_seed.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.domain.common import clean_text
+from app.domain.sources import build_source_company_provider_key, build_source_dedupe_key
+from app.persistence.models import Source
+
+
+@dataclass(frozen=True)
+class ValidatedSourceDefinition:
+    company_name: str
+    source_type: str
+    base_url: str
+    external_identifier: str
+
+    @property
+    def name(self) -> str:
+        return f"{self.company_name} {self.source_type.title()}"
+
+
+@dataclass(frozen=True)
+class SourceSeedResult:
+    created_source_ids: list[int]
+    skipped_source_keys: list[str]
+
+
+VALIDATED_SOURCE_ADDITIONS: tuple[ValidatedSourceDefinition, ...] = (
+    ValidatedSourceDefinition("Point Wild", "greenhouse", "https://boards.greenhouse.io/pointwild", "pointwild"),
+    ValidatedSourceDefinition("Fundraise Up", "greenhouse", "https://boards.greenhouse.io/fundraiseup", "fundraiseup"),
+    ValidatedSourceDefinition("Shift Technology", "greenhouse", "https://boards.greenhouse.io/shifttechnology", "shifttechnology"),
+    ValidatedSourceDefinition("The Economist Group", "greenhouse", "https://boards.greenhouse.io/theeconomistgroup", "theeconomistgroup"),
+    ValidatedSourceDefinition("Tailscale", "greenhouse", "https://boards.greenhouse.io/tailscale", "tailscale"),
+    ValidatedSourceDefinition("HighLevel", "lever", "https://jobs.lever.co/gohighlevel", "gohighlevel"),
+    ValidatedSourceDefinition("Cloaked", "lever", "https://jobs.lever.co/cloaked-app", "cloaked-app"),
+    ValidatedSourceDefinition("Drivetrain", "lever", "https://jobs.lever.co/drivetrain", "drivetrain"),
+    ValidatedSourceDefinition("Celara", "lever", "https://jobs.lever.co/celaralabs", "celaralabs"),
+    ValidatedSourceDefinition("Fullscript", "lever", "https://jobs.lever.co/fullscript", "fullscript"),
+    ValidatedSourceDefinition("Panopto", "lever", "https://jobs.lever.co/panopto", "panopto"),
+    ValidatedSourceDefinition("dLocal", "lever", "https://jobs.lever.co/dlocal", "dlocal"),
+    ValidatedSourceDefinition("Coderio", "lever", "https://jobs.lever.co/coderio", "coderio"),
+)
+
+
+def add_validated_source_additions(session: Session) -> SourceSeedResult:
+    created_ids: list[int] = []
+    skipped_keys: list[str] = []
+
+    for definition in VALIDATED_SOURCE_ADDITIONS:
+        dedupe_key = build_source_dedupe_key(
+            definition.source_type,
+            definition.base_url,
+            definition.external_identifier,
+            None,
+        )
+        company_provider_key = build_source_company_provider_key(
+            definition.source_type,
+            definition.company_name,
+            definition.name,
+            None,
+        )
+        existing = session.scalar(
+            select(Source).where(
+                Source.deleted_at.is_(None),
+                or_(Source.company_provider_key == company_provider_key, Source.dedupe_key == dedupe_key),
+            )
+        )
+        if existing is not None:
+            skipped_keys.append(company_provider_key)
+            continue
+
+        source = Source(
+            name=definition.name,
+            source_type=definition.source_type,
+            adapter_key=None,
+            company_name=definition.company_name,
+            base_url=definition.base_url,
+            external_identifier=definition.external_identifier,
+            config_json={},
+            notes=None,
+            dedupe_key=dedupe_key,
+            company_provider_key=company_provider_key,
+            is_active=True,
+        )
+        session.add(source)
+        session.flush()
+        created_ids.append(source.id)
+
+    session.commit()
+    return SourceSeedResult(created_source_ids=created_ids, skipped_source_keys=skipped_keys)
+
+
+def validated_source_lookup() -> dict[str, ValidatedSourceDefinition]:
+    return {clean_text(source.company_name).lower(): source for source in VALIDATED_SOURCE_ADDITIONS}

--- a/app/domain/sources.py
+++ b/app/domain/sources.py
@@ -4,7 +4,7 @@ import csv
 import io
 from dataclasses import dataclass
 
-from sqlalchemy import distinct, func, select
+from sqlalchemy import distinct, func, or_, select
 from sqlalchemy.orm import Session
 
 from app.adapters.base.registry import SourceAdapterRegistry, UnsupportedAdapterError
@@ -69,7 +69,16 @@ class SourceService:
             payload.external_identifier,
             payload.adapter_key,
         )
-        duplicate_query = select(Source).where(Source.dedupe_key == dedupe_key, Source.deleted_at.is_(None))
+        company_provider_key = build_source_company_provider_key(
+            payload.source_type,
+            payload.company_name,
+            payload.name,
+            payload.adapter_key,
+        )
+        duplicate_query = select(Source).where(
+            Source.deleted_at.is_(None),
+            or_(Source.company_provider_key == company_provider_key, Source.dedupe_key == dedupe_key),
+        )
         if exclude_source_id is not None:
             duplicate_query = duplicate_query.where(Source.id != exclude_source_id)
         duplicate = self.session.scalar(duplicate_query)
@@ -97,6 +106,12 @@ class SourceService:
             config_json=payload.config_json or {},
             notes=clean_text(payload.notes) or None,
             dedupe_key=validation.dedupe_key or "",
+            company_provider_key=build_source_company_provider_key(
+                payload.source_type,
+                payload.company_name,
+                payload.name,
+                payload.adapter_key,
+            ),
             is_active=payload.is_active,
         )
         self.session.add(source)
@@ -134,6 +149,12 @@ class SourceService:
         source.external_identifier = clean_text(payload.external_identifier) or None
         source.notes = clean_text(payload.notes) or None
         source.dedupe_key = validation.dedupe_key or ""
+        source.company_provider_key = build_source_company_provider_key(
+            payload.source_type,
+            payload.company_name,
+            payload.name,
+            payload.adapter_key,
+        )
         source.is_active = payload.is_active
         source.config_json = payload.config_json or source.config_json or {}
         self.session.add(source)
@@ -226,6 +247,19 @@ def build_source_dedupe_key(source_type: str, base_url: str, external_identifier
     return "|".join(
         [slugify(source_type), slugify(adapter_key), normalize_url(base_url), slugify(external_identifier)]
     )
+
+
+def build_source_company_provider_key(
+    source_type: str,
+    company_name: str | None,
+    source_name: str | None,
+    adapter_key: str | None,
+) -> str:
+    company_key = slugify(company_name) or slugify(source_name)
+    provider_key = slugify(source_type)
+    if provider_key in {"common-pattern", "custom-adapter"}:
+        provider_key = "|".join([provider_key, slugify(adapter_key)])
+    return "|".join([company_key, provider_key])
 
 
 def validate_csv_row_shape(row: dict[str | None, str | list[str] | None]) -> list[str]:

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from starlette.staticfiles import StaticFiles
 
 from app.config.logging import configure_logging
 from app.config.settings import get_settings
+from app.persistence.schema_guard import should_validate_schema_on_startup, validate_database_schema_current
 from app.web.routes import router
 
 
@@ -19,6 +20,8 @@ scheduler = BackgroundScheduler(timezone="UTC")
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     configure_logging()
+    if should_validate_schema_on_startup(settings.database_url):
+        validate_database_schema_current(settings.database_url)
     if settings.scheduler_enabled and not scheduler.running:
         scheduler.start()
     try:

--- a/app/persistence/models.py
+++ b/app/persistence/models.py
@@ -24,6 +24,13 @@ class Source(Base):
             sqlite_where=text("deleted_at IS NULL"),
             postgresql_where=text("deleted_at IS NULL"),
         ),
+        Index(
+            "ix_sources_company_provider_active_unique",
+            "company_provider_key",
+            unique=True,
+            sqlite_where=text("deleted_at IS NULL"),
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -36,6 +43,7 @@ class Source(Base):
     config_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     dedupe_key: Mapped[str] = mapped_column(String(1024))
+    company_provider_key: Mapped[str | None] = mapped_column(String(512), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/persistence/schema_guard.py
+++ b/app/persistence/schema_guard.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, select, text
+from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.exc import SQLAlchemyError
+
+
+SCHEMA_OUT_OF_DATE_MESSAGE = (
+    "Database schema is out of date for this application version. "
+    "Run `alembic upgrade head` against the same DATABASE_URL before starting the server."
+)
+
+
+class DatabaseSchemaOutOfDateError(RuntimeError):
+    pass
+
+
+def validate_database_schema_current(database_url: str, *, engine: Engine | None = None) -> None:
+    """Fail fast when the connected database Alembic revision is behind code head.
+
+    Databases without an Alembic version table are ignored to preserve existing test
+    conventions that build an in-memory schema with SQLAlchemy metadata instead of
+    running migrations. Migrated databases with an older revision fail with a clear
+    operational recovery command.
+    """
+
+    owns_engine = engine is None
+    check_engine = engine or create_engine(database_url, future=True)
+    try:
+        with check_engine.connect() as connection:
+            inspector = inspect(connection)
+            if not inspector.has_table("alembic_version"):
+                return
+
+            current_revisions = set(connection.execute(select(text("version_num")).select_from(text("alembic_version"))).scalars())
+            head_revision = get_repository_head_revision()
+            if head_revision not in current_revisions:
+                current = ", ".join(sorted(current_revisions)) or "<none>"
+                raise DatabaseSchemaOutOfDateError(
+                    f"{SCHEMA_OUT_OF_DATE_MESSAGE} Current DB revision: {current}; required head revision: {head_revision}."
+                )
+    except DatabaseSchemaOutOfDateError:
+        raise
+    except SQLAlchemyError as exc:
+        raise RuntimeError(f"Database schema validation failed before startup: {exc}") from exc
+    finally:
+        if owns_engine:
+            check_engine.dispose()
+
+
+def should_validate_schema_on_startup(database_url: str) -> bool:
+    # SQLite metadata-created test databases commonly do not use Alembic at app startup.
+    # PostgreSQL/local deployment databases do, and are the environment affected here.
+    return make_url(database_url).get_backend_name() != "sqlite"
+
+
+def get_repository_head_revision() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    alembic_cfg = Config(str(repo_root / "alembic.ini"))
+    alembic_cfg.set_main_option("script_location", str(repo_root / "alembic"))
+    return ScriptDirectory.from_config(alembic_cfg).get_current_head()

--- a/docs/backend/source_health_cleanup_implementation_plan.md
+++ b/docs/backend/source_health_cleanup_implementation_plan.md
@@ -1,0 +1,52 @@
+# Implementation Plan
+
+## 1. Feature Overview
+Fix backend source health noise caused by invalid configured ATS sources, duplicate active source records, and a Lever payload parsing error.
+
+## 2. Technical Scope
+- Enforce one active source per normalized company/provider key while still allowing the same company on different providers.
+- Add idempotent source-health cleanup logic to soft-delete requested invalid/removed sources and duplicate active sources.
+- Add the 13 newly validated ATS sources through an idempotent migration/seed path.
+- Make Lever parsing tolerate `lists[].content` values that are strings, lists of strings, or lists of dicts.
+- Add a startup schema guardrail for migrated PostgreSQL databases so stale Alembic revisions fail fast with an `alembic upgrade head` recovery message.
+- Add focused backend tests for duplicate prevention, cleanup behavior, source removal rules, and Lever parser robustness.
+
+## 3. Source Inputs
+- `docs/bugs/source_health_cleanup.md`
+- Existing source service, source soft-delete, ingestion, adapter, and migration patterns.
+
+## 4. API Contracts Affected
+No API contract changes. Existing source create/update/import endpoints retain their response formats but reject active duplicate company/provider sources earlier.
+
+## 5. Data Models / Storage Affected
+- `sources.company_provider_key` added as a nullable persisted normalized business key.
+- Active unique index added on `company_provider_key` where `deleted_at IS NULL`.
+- Data cleanup soft-deletes known removed sources and active duplicates according to existing `deleted_at`/`is_active` conventions.
+
+## 6. Files Expected to Change
+- `app/domain/sources.py`
+- `app/domain/source_health_cleanup.py` or equivalent cleanup module
+- `app/domain/source_seed.py`
+- `app/persistence/schema_guard.py`
+- `app/main.py`
+- `app/persistence/models.py`
+- `app/adapters/lever/adapter.py`
+- `alembic/versions/*.py`
+- Focused tests under `tests/unit/` and `tests/adapter_contract/`
+- `docs/backend/source_health_cleanup_implementation_report.md`
+
+## 7. Security / Authorization Considerations
+No new endpoint or authorization surface is introduced. User-controlled source values are normalized before uniqueness checks. Cleanup uses existing soft-delete behavior and does not expose sensitive data.
+
+## 8. Dependencies / Constraints
+No new dependencies. Cleanup and source additions must be safe/idempotent and compatible with SQLite test databases and PostgreSQL production/local databases. PostgreSQL startup now requires the connected DB Alembic revision to be at repository head; operators should run `alembic upgrade head` before server use. Validated source additions are applied by migration `20260429_0004`.
+
+## 9. Assumptions
+- Provider identity is `source_type` for built-in ATS providers and `source_type + adapter_key` for adapter-key based providers.
+- When selecting duplicate keepers, healthy or successful sources are preferred, then the most recent run/update/create timestamp.
+
+## 10. Validation Plan
+- `python -m pytest tests/unit/test_sources.py tests/unit/test_source_health_cleanup.py tests/adapter_contract/test_lever_adapter.py`
+- `python -m pytest tests/unit/test_schema_guard.py`
+- `python -m pytest tests/unit/test_source_seed.py`
+- `python -m compileall app alembic`

--- a/docs/backend/source_health_cleanup_implementation_report.md
+++ b/docs/backend/source_health_cleanup_implementation_report.md
@@ -1,0 +1,79 @@
+# Implementation Report
+
+## 1. Summary of Changes
+Implemented backend source-health cleanup fixes for invalid configured sources, duplicate source prevention/cleanup, and Lever parser robustness.
+
+Follow-up remediation added a startup schema guardrail so migrated PostgreSQL databases behind repository Alembic head fail fast with an actionable `alembic upgrade head` message instead of route-level `UndefinedColumn` errors.
+
+Second follow-up added 13 newly validated ATS sources through an idempotent Alembic seed migration.
+
+## 2. Files Modified
+- `app/domain/sources.py` — added normalized company/provider key generation and duplicate validation.
+- `app/persistence/models.py` — added `Source.company_provider_key` and active unique index metadata.
+- `app/domain/source_health_cleanup.py` — added idempotent soft-delete cleanup for removed sources and duplicate active company/provider sources.
+- `app/domain/source_seed.py` — added the validated source catalog and idempotent seed function.
+- `app/persistence/schema_guard.py` — added Alembic revision guardrail helpers and actionable stale-schema error.
+- `app/main.py` — runs the schema guardrail during startup for non-SQLite databases.
+- `app/adapters/lever/adapter.py` — made Lever list-content parsing tolerant of strings, list strings, and dict entries.
+- `alembic/versions/20260429_0003_source_company_provider_key.py` — added migration to backfill keys, run cleanup, and create the active unique index.
+- `alembic/versions/20260429_0004_add_validated_sources.py` — added migration to seed 13 validated sources idempotently.
+- `tests/unit/test_sources.py` — added duplicate prevention coverage.
+- `tests/unit/test_source_health_cleanup.py` — added cleanup behavior coverage.
+- `tests/adapter_contract/test_lever_adapter.py` — added Lever parser robustness coverage.
+- `tests/integration/test_source_health_migrations.py` — asserted the new migration column/index.
+- `tests/unit/test_schema_guard.py` — added stale/current/no-version guardrail coverage.
+- `tests/unit/test_source_seed.py` — added validated source seed/idempotency/no-notes coverage.
+- `README.md` — documented that source health cleanup requires migration `20260429_0003` / `alembic upgrade head` before server use.
+- `docs/backend/source_health_cleanup_implementation_plan.md` — documented implementation plan.
+
+## 3. API Contract Implementation
+No API contract changes. Existing create/update/import flows now reject duplicate active company/provider sources through existing validation behavior.
+
+Startup behavior now fails before serving PostgreSQL-backed routes if the connected migrated database is behind Alembic head.
+
+## 4. Data / Persistence Implementation
+Added nullable `sources.company_provider_key` plus a partial unique index on active non-deleted rows. Migration backfills this key, soft-deletes confirmed removed sources, soft-deletes duplicate active company/provider rows, then creates the unique index.
+
+The application does not auto-run migrations. Operators must run `alembic upgrade head` against the server `DATABASE_URL`. Migration `20260429_0004` seeds the validated sources and skips existing active company/provider or dedupe-key matches.
+
+## 5. Key Logic Implemented
+- Duplicate key: normalized company name when present, otherwise source name, plus provider.
+- Built-in providers use `source_type`; adapter-key providers include `adapter_key`.
+- Cleanup removes confirmed invalid/requested sources and chooses duplicate keepers by healthy status, successful last run, recency, then id.
+- Insider Lever remains valid; parser no longer calls `.get()` on string content.
+- PostgreSQL startup checks compare the connected DB `alembic_version` to repository head and raise a clear stale-schema error when behind.
+- Added validated sources: Point Wild Greenhouse, Fundraise Up Greenhouse, Shift Technology Greenhouse, The Economist Group Greenhouse, Tailscale Greenhouse, HighLevel Lever, Cloaked Lever, Drivetrain Lever, Celara Lever, Fullscript Lever, Panopto Lever, dLocal Lever, and Coderio Lever.
+- Validation context/role text is not persisted; seeded source `notes` are `None`.
+
+## 6. Security / Authorization Implemented
+No new endpoint or auth surface. Existing source service validation is reused; cleanup uses soft-delete only and does not log or expose sensitive data.
+
+## 7. Error Handling Implemented
+Duplicate source attempts continue to return the existing `Duplicate source already exists.` validation error path. Lever parser skips unexpected list shapes instead of failing ingestion with `AttributeError`.
+
+Stale migrated databases now fail fast with: `Database schema is out of date... Run alembic upgrade head...`.
+
+## 8. Observability / Logging
+No new logging added; no external call behavior changed.
+
+## 9. Assumptions Made
+- Provider identity is `source_type` for built-in ATS providers and `source_type + adapter_key` for adapter-key based providers.
+- Soft-delete (`deleted_at` set and `is_active=False`) is the existing project convention for source removal.
+
+## 10. Validation Performed
+- `python -m pytest ...` failed because `python` is unavailable in this environment.
+- `python3 -m pytest ...` failed because pytest is not installed for the system Python.
+- `python3 -m compileall app alembic` passed.
+- `PYTHONPATH=. uv run --with-editable . pytest tests/unit/test_sources.py tests/unit/test_source_health_cleanup.py tests/adapter_contract/test_lever_adapter.py tests/integration/test_source_health_migrations.py` passed: `13 passed in 1.16s`.
+- `PYTHONPATH=. uv run --with-editable . pytest tests/unit/test_schema_guard.py tests/unit/test_sources.py tests/unit/test_source_health_cleanup.py tests/adapter_contract/test_lever_adapter.py tests/integration/test_source_health_migrations.py` passed after guardrail remediation: `17 passed, 4 warnings in 1.24s`.
+- `python3 -m compileall app alembic` passed after guardrail remediation.
+- `PYTHONPATH=. uv run --with-editable . pytest tests/unit/test_source_seed.py tests/unit/test_schema_guard.py tests/unit/test_sources.py tests/unit/test_source_health_cleanup.py tests/adapter_contract/test_lever_adapter.py tests/integration/test_source_health_migrations.py` passed after source additions: `20 passed, 4 warnings in 1.25s`.
+- `python3 -m compileall app alembic` passed after source additions.
+
+## 11. Known Limitations / Follow-Ups
+- No frontend changes were required.
+- Manual local recovery/source seeding is still required for already-stale PostgreSQL databases: run `alembic upgrade head` using the same `DATABASE_URL` as the server, then restart the app.
+- The bug report file is present as an untracked upstream artifact and was not modified.
+
+## 12. Commit Status
+Commit was not created per user instruction: “Do not commit, push, or create a PR.”

--- a/docs/bugs/source_health_cleanup.md
+++ b/docs/bugs/source_health_cleanup.md
@@ -1,0 +1,192 @@
+# Bug Report
+
+## 1. Summary
+Source Health is accurately showing persisted backend source rows, but the active source data contains invalid/outdated ATS source configurations plus duplicate active sources for the same company/provider. Most reported 404s reproduce directly against the external ATS APIs. One reported Lever failure (`Insider Lever`) is an application parser robustness bug, not an external 404.
+
+## 2. Investigation Context
+- Source of report: user/HITL validation on active branch `bugfix/source_health_cleanup`.
+- Related workflow: backend source configuration, ingestion, and `/source-health` operations view.
+- Environment inspected: configured local `.env` PostgreSQL database `postgresql+psycopg://postgres:postgres@localhost:5432/job_intelligence_platform`; checked-in `job_intelligence_platform.db` is 0 bytes and has no tables.
+- Relevant screens/routes: `/source-health`, `/ops/sources`, `/sources`, source batch/manual ingestion.
+- Scope: backend/data-ingestion bugfix only unless UI evidence appears.
+
+## 3. Observed Symptoms
+- Source Health lists active errored sources with latest health messages such as:
+  - `Client error '404 Not Found' for url 'https://api.lever.co/v0/postings/alkami?mode=json'`
+  - `Client error '404 Not Found' for url 'https://boards-api.greenhouse.io/v1/boards/notion/jobs'`
+  - `Insider Lever`: `'str' object has no attribute 'get'`
+  - `HubSpot Greenhouse`: `Source returned zero jobs. Verify whether this is expected.`
+- Active healthy duplicate rows exist for the same company/provider, e.g. Asana Greenhouse appears as both `https://job-boards.greenhouse.io/asana` and `https://boards.greenhouse.io/asana`.
+- Expected behavior:
+  - Invalid external ATS endpoints should not remain active configured sources.
+  - Duplicate prevention should allow only one active source per `company + provider`; same company with a different provider is allowed.
+  - Parser should handle known Lever payload variants without an opaque `AttributeError`.
+
+## 4. Evidence Collected
+
+### Files/modules inspected
+- `app/domain/sources.py`
+  - `SourceService.validate()` checks duplicates only by `Source.dedupe_key` (`lines 66-77`).
+  - `build_source_dedupe_key()` includes `source_type`, `adapter_key`, normalized `base_url`, and `external_identifier` (`lines 225-228`). This permits duplicate company/provider sources when only `base_url` host differs.
+  - `import_csv()` calls the same validation path (`lines 185-222`).
+- `app/persistence/models.py`
+  - Active unique index is only on `dedupe_key` where `deleted_at IS NULL` (`lines 19-27`).
+- `alembic/versions/20260424_0002_sources_soft_delete_schema.py`
+  - Migration creates the same active unique index on `dedupe_key` only (`lines 35-42`).
+- `app/domain/ingestion.py`
+  - Source health is written in `_update_source_health()` from run status and job count (`lines 171-186`). Zero jobs becomes `warning`; failed run becomes `error`.
+- `app/domain/operations.py`
+  - Source Health lists every non-deleted source ordered by name (`line 14`); no grouping/deduping is performed in query.
+- `app/adapters/lever/adapter.py`
+  - Fetch URL is constructed as `https://api.lever.co/v0/postings/{external_identifier}?mode=json` (`lines 20-24`).
+  - Parser assumes each `lists[].content[]` entry is a dict and calls `entry.get(...)` (`line 30`).
+- `app/adapters/greenhouse/adapter.py`
+  - Fetch URL is constructed as `https://boards-api.greenhouse.io/v1/boards/{external_identifier}/jobs` (`lines 20-24`).
+  - Parser reads `payload.get("jobs", [])` (`line 27`).
+- `app/templates/ops/source_health.html` and `app/web/templates/ops/source_health.html`
+  - Duplicate template files exist. `app/web/routes.py:64-67` loads `app/templates` before `app/web/templates`, so the active template is `app/templates/ops/source_health.html`. This duplication affects maintainability but is not the ingestion/source duplication root cause.
+
+### Database evidence
+- Active duplicate company/provider groups found in PostgreSQL:
+  - Asana Greenhouse: ids `66`, `25`
+  - Coinbase Greenhouse: ids `21`, `63`
+  - Databricks Greenhouse: ids `22`, `64`
+  - Discord Greenhouse: ids `68`, `28`
+  - Figma Greenhouse: ids `61`, `19`
+  - HubSpot Greenhouse: ids `65`, `23`
+  - Reddit Greenhouse: ids `67`, `26`
+  - Stripe Greenhouse: ids `59`, `17`
+- These duplicates differ by `base_url` host (`boards.greenhouse.io` vs `job-boards.greenhouse.io`), creating different `dedupe_key` values despite the same company/provider/external identifier.
+
+### External ATS checks
+Direct HTTP checks reproduced the reported external responses:
+- Lever 404s returned `404 application/json; charset=utf-8` with body `{"ok":false,"error":"Document not found"}` for `alkami`, `browserstack`, `circleci`, `keepersecurity`, `postman`, `snyk`, `storable`, `subsplash`, and also `insider`.
+- Greenhouse 404s returned `404 application/json` with body `{"status":404,"error":"Job not found"}` for `notion` and `plaid`.
+- HubSpot Greenhouse returned `200 application/json` with body `{"jobs":[],"meta":{"total":0}}`.
+- Insider actual configured slug is `insiderone`, not `insider`; `https://api.lever.co/v0/postings/insiderone?mode=json` returned `200 application/json` with 168 jobs.
+- Lever payload shape inspection for `insiderone` showed `lists[].content` can be a string; iterating it yields characters (`'\n'`, `'<'`, `'l'`, ...), which explains `entry.get(...)` failing in `app/adapters/lever/adapter.py:30`.
+
+## 5. Execution Path / Failure Trace
+1. A source is created manually or via CSV import through `SourceService.create_source()` / `import_csv()`.
+2. Validation builds `dedupe_key = source_type|adapter_key|normalized_base_url|external_identifier`.
+3. If the same company/provider/external identifier is entered with a different `base_url`, the dedupe key differs and the active unique index allows the duplicate.
+4. Ingestion calls the adapter for the source provider:
+   - Lever uses the `external_identifier` as the Lever company slug.
+   - Greenhouse uses the `external_identifier` as the Greenhouse board token.
+5. HTTP 404s raise via `response.raise_for_status()`, then `IngestionOrchestrator.run_source()` records `run.status='failed'` and source `health_state='error'`.
+6. Zero-job successful responses record `run.status='success'`, `jobs_fetched_count=0`, and source `health_state='warning'`.
+7. `/source-health` lists all non-deleted sources without grouping, so data duplicates appear as duplicate healthy/warning rows.
+
+## 6. Failure Classification
+- Primary classification: **Application Bug** for duplicate prevention and Lever parser robustness.
+- Source-specific external 404s: **Data / Fixture Issue** in configured source data, because the external ATS endpoints currently return 404 outside the app.
+- HubSpot zero jobs: **Data / Fixture Issue / expected external response**, unless product wants zero-job sources hidden/disabled.
+- Severity: **High**. Source Health and batch ingestion are operationally noisy and duplicate active sources can repeatedly ingest the same jobs; however, core app availability is not blocked and no data loss was observed.
+
+## 7. Root Cause Analysis
+
+### Most Likely Root Cause: duplicate active healthy rows
+- Immediate failure point: `OperationsService.list_source_health()` returns all non-deleted source rows; duplicates are already present in the database.
+- Underlying root cause: active uniqueness is defined by URL-sensitive `dedupe_key`, not by the required business key `company + provider`.
+- Supporting evidence:
+  - `build_source_dedupe_key()` includes normalized `base_url` (`app/domain/sources.py:225-228`).
+  - Unique index is only on `dedupe_key` (`app/persistence/models.py:19-27`).
+  - Active duplicates have same company/provider/external identifier but different Greenhouse base hosts.
+- UI/query behavior is not the origin; it is surfacing persisted rows as designed.
+
+### Confirmed Root Cause: reported external ATS 404s
+- Immediate failure point: `response.raise_for_status()` in Lever/Greenhouse adapters.
+- Underlying cause: configured ATS slugs/board tokens currently return 404 directly from external ATS APIs.
+- Supporting evidence: direct HTTP checks reproduced the same 404 statuses and provider error bodies.
+
+### Confirmed Root Cause: `Insider Lever` parser error
+- Immediate failure point: `entry.get("text", "")` in `app/adapters/lever/adapter.py:30`.
+- Underlying cause: Lever `lists[].content` may be a string/HTML blob for `insiderone`, but the parser assumes an iterable of dict entries.
+- Supporting evidence: external `insiderone` endpoint returns 200 with 168 jobs; payload shape inspection showed string content entries that reproduce why a string reaches `.get`.
+
+### Confirmed Root Cause: `HubSpot Greenhouse` warning
+- Immediate failure point: `_update_source_health()` converts successful zero-job ingestion to `warning` (`app/domain/ingestion.py:178-181`).
+- Underlying cause: external Greenhouse endpoint for `hubspot` currently returns a valid 200 response with zero jobs.
+- Supporting evidence: direct HTTP response `{"jobs":[],"meta":{"total":0}}`.
+
+## 8. Confidence Level
+**High.** The diagnosis is backed by source inspection, active database queries, and direct external ATS response checks. The only uncertainty is whether any uninspected external source list/import file outside this repository originally seeded the duplicate rows.
+
+## 9. Recommended Fix
+
+Likely owner: **dev-backend**.
+
+1. **Duplicate prevention rule**
+   - Update `SourceService.validate()` / duplicate lookup to enforce one active source per normalized `company + provider` (`company_name` preferred, fallback to source `name`; provider = `source_type`, possibly plus `adapter_key` for custom providers if product wants that distinction).
+   - Keep allowing the same company with different providers, e.g. Keeper Security Greenhouse and Keeper Security Lever are allowed by rule, but invalid Lever should be removed if 404.
+   - Add a DB-level protection if feasible: a generated/explicit `company_provider_key` column or equivalent migration-backed unique index where `deleted_at IS NULL`. Python-only validation is not enough for concurrency/import safety.
+   - Update tests to cover same company/provider with different base URL as duplicate and same company/different provider as allowed.
+
+2. **Existing duplicate cleanup**
+   - Soft-delete or disable duplicate active sources.
+   - Follow user rule: keep the most recently successful/healthy source; if neither is healthy, keep the most recent source only if product still wants it monitored.
+   - For duplicated Greenhouse healthy sources, suggested retained ids based on current DB evidence:
+     - Asana: keep `66`, remove/disable `25`
+     - Coinbase: keep `21`, remove/disable `63`
+     - Databricks: keep `22`, remove/disable `64`
+     - Discord: keep `68`, remove/disable `28`
+     - Figma: keep `61`, remove/disable `19`
+     - Reddit: keep `67`, remove/disable `26`
+     - Stripe: keep `59`, remove/disable `17`
+     - HubSpot: if retaining a warning source, keep most recent `65`, remove/disable `23`; consider disabling/removing both if zero jobs is not useful.
+
+3. **External 404 source cleanup**
+   - Remove or soft-delete active sources whose ATS endpoint currently returns 404. Do not treat these as HTTP client/code bugs.
+
+4. **Lever parser robustness**
+   - In `app/adapters/lever/adapter.py`, normalize `lists` parsing so `group.get("content")` can be either a list of dicts, a list of strings, or a string. Extract text safely and avoid `.get` on non-dicts.
+   - Consider adding a clear warning or parser fallback rather than failing the whole source for one unexpected list shape.
+   - Add fixture-based unit coverage for `insiderone`/`padsplit`-style Lever list content.
+
+5. **Template/file cleanup (optional, frontend/backend coordination only if desired)**
+   - There are duplicate `ops/source_health.html` templates under `app/templates` and `app/web/templates`; active loader order uses `app/templates` first. This is not causing source row duplication, but stale duplicate template files can confuse future changes.
+
+## 10. Suggested Validation Steps
+- Backend tests:
+  - Creating/importing two Greenhouse sources for the same company/provider with different `base_url` must reject the second source.
+  - Creating same company with Greenhouse and Lever must be allowed.
+  - Existing deleted sources must not block a new active source under the same company/provider key.
+  - Lever adapter parses payloads where `lists[].content` is a string and where it is a list of dicts.
+  - HubSpot-style Greenhouse `200 {"jobs":[]}` remains a successful run with warning, unless product changes expected behavior.
+- Data validation after cleanup:
+  - Query active sources grouped by normalized company/provider; all counts should be `1`.
+  - `/source-health` should no longer show duplicate active healthy rows.
+  - Removed 404 sources should no longer appear as active Source Health errors.
+  - `Insider Lever` should fetch jobs successfully after parser fix, if kept active.
+
+## 11. Open Questions / Missing Evidence
+- What import/source list outside the repository created ids `59-77` and the earlier deleted duplicates? No static CSV/seed/source config file containing the reported company names was found in the repository.
+- Product should confirm whether HubSpot should be removed because it currently has zero jobs, or kept as a warning source for future openings.
+- Product should confirm whether duplicate prevention should normalize company names only by lowercase/whitespace or use stricter slug normalization matching `slugify()`.
+
+## 12. Final Investigator Decision
+**Ready for developer fix.** Backend/data-ingestion fixes are sufficient based on current evidence; frontend changes are not required unless the team chooses to remove stale duplicate templates.
+
+## Per-source determination and recommended action
+
+| Source | Current active id(s) | Determination | Evidence | Recommended action |
+|---|---:|---|---|---|
+| Alkami Technology Lever | 70 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`; DB health message matches. | Remove/soft-delete active source. |
+| BrowserStack Lever | 77 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`. | Remove/soft-delete active source. |
+| CircleCI Lever | 76 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`. | Remove/soft-delete active source. |
+| Keeper Security Lever | 69 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`; separate Greenhouse provider history exists and is allowed by rule. | Remove/soft-delete Lever source only. |
+| Postman Lever | 74 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`. | Remove/soft-delete active source. |
+| Snyk Lever | 75 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`. | Remove/soft-delete active source. |
+| Storable Lever | 72 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`. | Remove/soft-delete active source. |
+| Subsplash Lever | 71 | External/source-side 404 / invalid configured source | Direct Lever check returned 404 `Document not found`; same company Greenhouse provider is allowed by rule. | Remove/soft-delete Lever source only. |
+| Insider Lever | 73 | App parser bug | Configured slug `insiderone` returns 200 with jobs; Lever parser assumes dict entries and fails on string `lists[].content`. | Fix Lever parser; keep/retry source after fix. Do not remove as 404. |
+| Notion Greenhouse | 60 | External/source-side 404 / invalid configured source | Direct Greenhouse check returned 404 `Job not found`. | Remove/soft-delete active source. |
+| Plaid Greenhouse | 62 | External/source-side 404 / invalid configured source | Direct Greenhouse check returned 404 `Job not found`. | Remove/soft-delete active source. |
+| HubSpot Greenhouse | 23, 65 | Expected external zero jobs + duplicate config | Direct Greenhouse check returned 200 with `jobs: []`; two active same company/provider rows exist. | Remove/disable duplicate; keep id 65 only if monitoring zero-job source is desired, otherwise remove/disable both. |
+| Asana Greenhouse | 25, 66 | Duplicate config/app uniqueness gap | Same company/provider/external id, different base_url, both healthy. | Keep id 66; remove/disable id 25. |
+| Coinbase Greenhouse | 21, 63 | Duplicate config/app uniqueness gap | Same company/provider/external id, different base_url, both healthy. | Keep id 21; remove/disable id 63. |
+| Databricks Greenhouse | 22, 64 | Duplicate config/app uniqueness gap | Same company/provider/external id, different base_url, both healthy. | Keep id 22; remove/disable id 64. |
+| Discord Greenhouse | 28, 68 | Duplicate config/app uniqueness gap | Same company/provider/external id, different base_url, both healthy. | Keep id 68; remove/disable id 28. |
+| Figma Greenhouse | 19, 61 | Duplicate config/app uniqueness gap | Same company/provider/external id, different base_url, both healthy. | Keep id 61; remove/disable id 19. |
+| Reddit Greenhouse | 26, 67 | Duplicate config/app uniqueness gap | Same company/provider/external id, different base_url, both healthy. | Keep id 67; remove/disable id 26. |
+| Stripe Greenhouse | 17, 59 | Duplicate config/app uniqueness gap | Same company/provider/external id, different base_url, both healthy. | Keep id 59; remove/disable id 17. |

--- a/docs/bugs/source_health_cleanup_unapplied_migration_blocker.md
+++ b/docs/bugs/source_health_cleanup_unapplied_migration_blocker.md
@@ -1,0 +1,119 @@
+# Bug Report
+
+## 1. Summary
+`GET /sources` returns 500 after restarting the server because the running ORM model includes `Source.company_provider_key`, but the local PostgreSQL schema is still at Alembic revision `20260424_0002` and does not contain the `sources.company_provider_key` column added by migration `20260429_0003`.
+
+## 2. Investigation Context
+- Source of report: HITL validation blocker after QA sign-off on active branch `bugfix/source_health_cleanup`.
+- Related workflow: Sources management page, source-health cleanup migration, local PostgreSQL startup/deployment workflow.
+- Branch context: current active correction branch; no new branch should be created.
+- Failing route/action: `GET /sources`.
+- User-provided call path: `app/web/routes.py:list_sources` -> `build_source_page_context` -> `SourceService.list_sources()` -> SQLAlchemy query.
+- User-provided error: `sqlalchemy.exc.ProgrammingError: (psycopg.errors.UndefinedColumn) column sources.company_provider_key does not exist`.
+
+## 3. Observed Symptoms
+- Failing workflow: opening `/sources` after restarting the server.
+- Exact error summary:
+  ```text
+  sqlalchemy.exc.ProgrammingError: (psycopg.errors.UndefinedColumn) column sources.company_provider_key does not exist
+  Failing query selects sources.company_provider_key from sources
+  ```
+- Local database inspection confirmed:
+  ```text
+  alembic_version= 20260424_0002
+  has_company_provider_key= False
+  ```
+- Expected behavior:
+  - After deploying/running code with the new ORM model, the target database should be upgraded to Alembic head (`20260429_0003`) before routes query `Source` rows.
+  - If migrations are not applied, the app should fail with clearer operational guidance or the runbook should make the required step explicit.
+
+## 4. Evidence Collected
+- `app/persistence/models.py`
+  - `Source` now maps `company_provider_key` and includes a partial unique index on it (`lines 27-33`, `line 46`).
+- `app/domain/sources.py`
+  - `SourceService.validate()` queries `Source.company_provider_key` while checking duplicates (`lines 72-80`).
+  - `create_source()` and `update_source()` assign `company_provider_key` (`lines 109-114`, `lines 152-157`).
+  - `SourceService.list_sources()` selects full `Source` ORM entities, so SQLAlchemy includes every mapped column, including `company_provider_key`.
+- `alembic/versions/20260429_0003_source_company_provider_key.py`
+  - Adds `sources.company_provider_key` if missing (`lines 24-27`).
+  - Runs source-health cleanup/backfill after adding the column (`lines 29-34`).
+  - Creates active unique index `ix_sources_company_provider_active_unique` (`lines 36-43`).
+- `README.md`
+  - Local quick start requires migrations before app start: `alembic upgrade head` (`lines 11-17`).
+- `app/main.py`
+  - Startup/lifespan configures logging and scheduler only; it does not run migrations or check schema compatibility (`lines 19-28`).
+- `app/persistence/db.py`
+  - Engine/session are created from settings; no schema validation or migration guard exists (`lines 17-27`).
+- `docs/qa/source_health_cleanup_qa_report.md`
+  - QA already documented the same risk: local PostgreSQL not upgraded causes `UndefinedColumn: column sources.company_provider_key does not exist` (`lines 15`, `25-35`).
+  - QA sign-off explicitly states local/deployed PostgreSQL databases must run Alembic migration `20260429_0003` before using code with the new ORM model (`line 57`).
+
+## 5. Execution Path / Failure Trace
+1. Server starts with code from `bugfix/source_health_cleanup`.
+2. SQLAlchemy imports `app.persistence.models.Source`, whose mapping includes `company_provider_key`.
+3. Local PostgreSQL remains at Alembic revision `20260424_0002`; the `sources` table does not have `company_provider_key`.
+4. User requests `/sources`.
+5. `app/web/routes.py:list_sources()` renders HTML and calls `build_source_page_context()`.
+6. `build_source_page_context()` calls `SourceService.list_sources()`.
+7. `list_sources()` executes `select(Source)`, causing SQLAlchemy to select all mapped columns, including `sources.company_provider_key`.
+8. PostgreSQL rejects the query with `UndefinedColumn`, producing a 500 response.
+
+## 6. Failure Classification
+- Primary classification: **Environment / Configuration Issue**.
+- Contributing classification: **Application Bug / Deployment Guardrail Gap** because the app provides no startup/schema compatibility guard and route failure is an opaque 500 instead of a clear migration-required message.
+- Severity: **Blocker** for HITL validation in this local environment because `/sources` cannot load until the database is migrated.
+
+## 7. Root Cause Analysis
+### Confirmed Root Cause
+- Immediate failure point: SQLAlchemy-generated `SELECT` for `Source` includes `sources.company_provider_key`, but PostgreSQL table `sources` lacks that column.
+- Underlying root cause: database migrations were not applied after code introduced ORM column `Source.company_provider_key` and Alembic migration `20260429_0003`.
+- Supporting evidence:
+  - Local DB `alembic_version` is `20260424_0002`.
+  - Local `sources` columns do not include `company_provider_key`.
+  - Migration `20260429_0003` is the migration that adds the missing column.
+  - README local workflow requires `alembic upgrade head` before app start.
+
+### Plausible Contributing Factors
+- QA documented the operational risk, but the app does not enforce or surface schema mismatch at startup.
+- Existing tests exposed a related local PostgreSQL mismatch through background cleanup using `SessionLocal`, indicating test harness isolation/documentation may need improvement.
+
+## 8. Confidence Level
+**High.** The reported traceback, migration file, ORM model, README workflow, QA report, and direct local DB inspection all point to the same missing migration.
+
+## 9. Recommended Fix
+Likely owner: **dev-backend**.
+
+Recommended remediation:
+1. **No application data/model logic rollback is indicated.** The missing column is expected after the source-health cleanup implementation.
+2. **Add clearer migration guardrails.** Implement a lightweight startup or request-time schema/version check that compares DB Alembic revision to code head, then fails fast with an actionable message such as: `Database schema is not current; run alembic upgrade head`.
+   - Candidate location: `app/main.py` lifespan or a persistence helper imported during startup.
+   - Constraint: do not auto-run migrations in app startup unless explicitly approved; safer local/deployment pattern is fail-fast plus runbook command.
+3. **Update documentation/runbook.** Add a branch-specific note to `README.md` or release/implementation docs that after pulling this branch, run `alembic upgrade head` before starting/restarting the app against PostgreSQL.
+4. **Improve test harness isolation or skip behavior.** The QA report showed broader tests can hit local PostgreSQL through background cleanup. Add/adjust tests so background tasks use the test session factory or explicitly document that local PostgreSQL must be migrated before running broader source regression tests.
+5. **Optionally add a small schema compatibility test.** Verify that ORM mapped columns introduced by migrations are present after `alembic upgrade head`, extending the existing migration integration test coverage if needed.
+
+## 10. Suggested Validation Steps
+- Temporary local validation after applying migration:
+  - Run Alembic upgrade against the same `DATABASE_URL` used by the server.
+  - Confirm `alembic_version` is `20260429_0003` or head.
+  - Reload `/sources`; expected result is HTTP 200 and rendered Sources page.
+  - Reload `/source-health`; expected result is HTTP 200 and no duplicate/removed source rows from cleanup scope.
+- Regression validation for guardrail/doc fix:
+  - Start app against an intentionally stale DB and confirm a clear migration-required startup/request error instead of an opaque route traceback.
+  - Run source management tests with migrated local PostgreSQL or fully isolated test DB sessions.
+
+## 11. Open Questions / Missing Evidence
+- Whether the project wants automatic migration execution on local startup is not specified. Current conventions use manual `alembic upgrade head`.
+- Need developer decision on exact guardrail style: fail-fast startup exception, health-check warning, admin banner, or deployment documentation only.
+
+## 12. Final Investigator Decision
+**Ready for developer fix.** Immediate unblock is an unapplied migration. A backend follow-up is recommended for clearer guardrails/documentation/tests so the same schema mismatch is caught before HITL users hit a 500.
+
+## Temporary Local Workaround
+Clearly labeled workaround, not a code fix:
+
+```bash
+DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5432/job_intelligence_platform" .venv/bin/alembic -c alembic.ini upgrade head
+```
+
+Then restart/reload the server and retry `GET /sources`.

--- a/docs/bugs/source_health_new_sources_validation.md
+++ b/docs/bugs/source_health_new_sources_validation.md
@@ -1,0 +1,121 @@
+# Bug Report
+
+## 1. Summary
+HITL release readiness for `bugfix/source_health_cleanup` is paused again because a new requested ATS source list must be validated, added by a downstream developer, and re-QA'd before release. Investigation validated all 13 proposed source endpoints against current adapter behavior: each returns HTTP 200, parses successfully, and returns at least one job. No proposed `company + provider` duplicate was found in repository definitions or the inspected local PostgreSQL `sources` table.
+
+## 2. Investigation Context
+- Source of report: HITL release gate change request.
+- Branch context: current active branch `bugfix/source_health_cleanup`; no new branch should be created.
+- Related workflow: source-health cleanup / source configuration additions.
+- User action requested: validate proposed Greenhouse/Lever sources before any source addition.
+- Important requirement: final CSV column is validation context only and must **not** be saved as source notes/description.
+
+## 3. Observed Symptoms
+- No runtime failure was reported for these proposed sources.
+- Release readiness is invalidated because new source additions require validation and QA.
+- Expected behavior:
+  - Add only sources whose ATS API returns HTTP 200, parses with current app adapter behavior, and returns at least one job.
+  - Skip invalid, empty, parser-failing, or existing duplicate `company + provider` sources.
+  - Preserve one active source per normalized `company + provider`.
+
+## 4. Evidence Collected
+- Repository search found no proposed source names/slugs in tracked `*.py`, `*.md`, `*.json`, `*.yml`, `*.yaml`, `*.csv`, `*.txt`, or `*.sql` files.
+- Local PostgreSQL raw query against `sources` found `0` existing rows matching proposed company names or slugs.
+- Current adapter files inspected:
+  - `app/adapters/greenhouse/adapter.py` uses API URL `https://boards-api.greenhouse.io/v1/boards/{external_identifier}/jobs`.
+  - `app/adapters/lever/adapter.py` uses API URL `https://api.lever.co/v0/postings/{external_identifier}?mode=json` and now includes robust `_extract_lists_text()` handling for list/string Lever content.
+- Direct HTTP and adapter validation were run with source stubs using current app adapter classes. All proposed sources returned HTTP 200, parsed successfully, and returned non-zero jobs.
+
+## 5. Execution Path / Failure Trace
+Validation path used for each proposed source:
+1. Construct expected ATS API URL from provider and slug.
+2. Fetch direct endpoint and record HTTP status/content type/response size.
+3. Instantiate the current `GreenhouseAdapter` or `LeverAdapter` with a source-like stub.
+4. Call `fetch_jobs()` to validate parser behavior and normalized job candidate generation.
+5. Count returned jobs.
+6. Search returned title/location/description text for the provided validation-context role/note where practical.
+7. Check repository and local DB for existing duplicate company/provider entries.
+
+## 6. Failure Classification
+- Primary classification: **Requirements / validation gate change**, not a product defect.
+- Severity: **Blocker** for release readiness because the user explicitly requested new source additions and QA rerun before release can proceed.
+- Duplicate/config risk: **Not observed** for the proposed list.
+
+## 7. Root Cause Analysis
+### Confirmed Root Cause
+Release readiness is blocked by a new HITL source-addition request, not by a failing existing implementation.
+
+Supporting evidence:
+- User added 13 proposed sources after QA sign-off.
+- Source-addition requirements require validation before addition.
+- Prior QA sign-off did not cover these new sources.
+
+### Parser/config findings
+- No parser failures were observed for the proposed sources under current adapter behavior.
+- No existing duplicate `company + provider` rows were found for the proposed sources.
+- `dLocal` is endpoint/parser/job-count valid, but the provided validation-context role (`Senior Automation Engineer`) was not found in title/description search; this does not violate the stated source-validity criteria.
+
+## 8. Confidence Level
+**High.** All proposed sources were checked through direct ATS HTTP and current adapter parsing, and local/repository duplicate checks found no existing matching source configuration.
+
+## 9. Recommended Fix
+Likely owner: **dev-backend** for source data addition, then **QA** for rerun.
+
+Developer-ready guidance:
+1. Add the 13 confirmed valid sources listed below.
+2. Preserve `company_name`, `source_type`, `base_url`, and `external_identifier` exactly as validated unless the source creation path normalizes provider casing.
+3. Do **not** save the final validation-context role/note as `notes`, description, or source metadata.
+4. Before adding, ensure the local/deployed DB has migration `20260429_0003` applied because the current source model expects `company_provider_key`.
+5. Use the existing source creation/service path so `company_provider_key` and duplicate validation are applied.
+6. If any source is added manually/imported via CSV and a duplicate is reported at add time, skip that row and report it rather than creating a second active source.
+
+## 10. Suggested Validation Steps
+- After addition, query active sources grouped by normalized `company + provider`; all groups should have count `1`.
+- Confirm the 13 new sources appear in `/sources` and `/source-health` with blank notes unless notes are intentionally set elsewhere.
+- Run targeted source service tests and adapter contract tests.
+- Run a source-health UI/API smoke check after the additions.
+- Optionally run one ingestion per newly added source or a batch run limited to the new sources to verify persisted `SourceRun` success/warning states.
+
+## 11. Open Questions / Missing Evidence
+- Whether dLocal should still be added even though the provided role-context string was not found. Under the stated validation criteria it is valid because the endpoint returns 200, adapter parsing succeeds, and it returns jobs.
+- Exact mechanism for adding sources was not specified: API/manual form, CSV import, or data migration/maintenance script.
+
+## 12. Final Investigator Decision
+**Ready for developer source addition and QA rerun.** All proposed sources are valid by the stated source-validity criteria, with the context caveat for dLocal.
+
+## Per-source validation table
+
+| Proposed source | Provider | API endpoint checked | HTTP / parser result | Job count | Existing duplicate? | Role-context evidence | Decision |
+|---|---|---|---|---:|---|---|---|
+| Point Wild | Greenhouse | `https://boards-api.greenhouse.io/v1/boards/pointwild/jobs` | HTTP 200; adapter parsed | 15 | No | Found titles: `QA Automation Engineer (Mobile/Android)` across remote locations | Valid: add |
+| Fundraise Up | Greenhouse | `https://boards-api.greenhouse.io/v1/boards/fundraiseup/jobs` | HTTP 200; adapter parsed | 155 | No | Found titles: `Senior QA Engineer (Automation / Fullstack)` across remote locations | Valid: add |
+| Shift Technology | Greenhouse | `https://boards-api.greenhouse.io/v1/boards/shifttechnology/jobs` | HTTP 200; adapter parsed | 33 | No | Found titles: `QA Engineer - functional testing`, `QA Engineer - ISTQB foundation certified` | Valid: add |
+| The Economist Group | Greenhouse | `https://boards-api.greenhouse.io/v1/boards/theeconomistgroup/jobs` | HTTP 200; adapter parsed | 80 | No | Found title: `Quality Engineer / SDET` | Valid: add |
+| Tailscale | Greenhouse | `https://boards-api.greenhouse.io/v1/boards/tailscale/jobs` | HTTP 200; adapter parsed | 48 | No | Fully remote context found practically: 44 jobs contained remote context | Valid: add |
+| HighLevel | Lever | `https://api.lever.co/v0/postings/gohighlevel?mode=json` | HTTP 200; adapter parsed | 109 | No | Found titles: `Lead Software Development Engineer in Test - CRM Core Modules`, `SDET II - Core Platform`, `Software Development Engineer in Test III ...` | Valid: add |
+| Cloaked | Lever | `https://api.lever.co/v0/postings/cloaked-app?mode=json` | HTTP 200; adapter parsed | 9 | No | Found title: `Quality Assurance Automation Engineer` | Valid: add |
+| Drivetrain | Lever | `https://api.lever.co/v0/postings/drivetrain?mode=json` | HTTP 200; adapter parsed | 27 | No | Found titles: `Lead - Software Development Engineer in Test (SDET) / QA Manager`, `Software Development Engineer in Test (SDET) / Senior SDET` | Valid: add |
+| Celara | Lever | `https://api.lever.co/v0/postings/celaralabs?mode=json` | HTTP 200; adapter parsed | 2 | No | Found title: `QA Automation Engineer (GFW - QA - 20260310)` | Valid: add |
+| Fullscript | Lever | `https://api.lever.co/v0/postings/fullscript?mode=json` | HTTP 200; adapter parsed | 29 | No | Found title: `Senior SDET (Software Development Engineer in Test)` | Valid: add |
+| Panopto | Lever | `https://api.lever.co/v0/postings/panopto?mode=json` | HTTP 200; adapter parsed | 15 | No | Found title: `SDET, Elai (Contractor)` | Valid: add |
+| dLocal | Lever | `https://api.lever.co/v0/postings/dlocal?mode=json` | HTTP 200; adapter parsed | 107 | No | Provided role-context `Senior Automation Engineer` not found in practical title/description search; source still returns jobs | Valid by source criteria: add, with context caveat |
+| Coderio | Lever | `https://api.lever.co/v0/postings/coderio?mode=json` | HTTP 200; adapter parsed | 39 | No | Found titles: `Principal QA Automation Engineer`, `QA Engineer`; also unrelated automation titles | Valid: add |
+
+## Recommended add list
+- Point Wild Greenhouse — `pointwild`
+- Fundraise Up Greenhouse — `fundraiseup`
+- Shift Technology Greenhouse — `shifttechnology`
+- The Economist Group Greenhouse — `theeconomistgroup`
+- Tailscale Greenhouse — `tailscale`
+- HighLevel Lever — `gohighlevel`
+- Cloaked Lever — `cloaked-app`
+- Drivetrain Lever — `drivetrain`
+- Celara Lever — `celaralabs`
+- Fullscript Lever — `fullscript`
+- Panopto Lever — `panopto`
+- dLocal Lever — `dlocal`
+- Coderio Lever — `coderio`
+
+## Recommended skip list
+- None by the confirmed source-validity criteria.
+- Caveat: if product requires role-context match in addition to endpoint/parser/non-empty validation, review dLocal before adding because the provided `Senior Automation Engineer` context was not found.

--- a/docs/qa/source_health_cleanup_qa_report.md
+++ b/docs/qa/source_health_cleanup_qa_report.md
@@ -1,0 +1,59 @@
+# Test Report
+
+## 1. Execution Summary
+- Total targeted tests: 13
+- Targeted passed: 13
+- Targeted failed: 0
+- Broader source regression tests: 44 executed, 42 passed, 2 failed due local database schema/environment mismatch during background cleanup task
+- Compile check: passed
+
+## 2. Detailed Results
+| Test / validation | Outcome | Evidence |
+|---|---:|---|
+| `PYTHONPATH=. uv run --with-editable . pytest tests/unit/test_sources.py tests/unit/test_source_health_cleanup.py tests/adapter_contract/test_lever_adapter.py tests/integration/test_source_health_migrations.py` | Passed | `13 passed in 1.22s` |
+| `PYTHONPATH=. uv run --with-editable . python -m compileall app alembic` | Passed | Completed listings for `app` and `alembic` without errors. |
+| Broader source regression command covering unit/API/integration/adapter source tests | Environment-limited | `42 passed, 2 failed in 1.60s`; failures are `psycopg.errors.UndefinedColumn: column sources.company_provider_key does not exist` from local PostgreSQL used by background cleanup, not from the in-memory test session. |
+| Changed-file scope inspection | Passed | Changed files are backend/domain/persistence/adapter, Alembic, tests, and docs only. No frontend templates/routes/static files changed. |
+| Code inspection: cleanup idempotency/safety | Passed | Cleanup selects non-deleted sources, backfills stable keys, soft-deletes only configured removal identifiers and duplicate active groups, and commits once. Existing unit test confirms second cleanup run returns no new removals/duplicates. |
+| Code inspection: migration ordering | Passed | Migration adds nullable `company_provider_key`, runs cleanup/backfill, then creates active unique index. Integration test verifies column and index. |
+
+## 3. Failed Tests
+### Broader regression environment failures
+- `tests/api/test_source_edit_delete_qa.py::test_deleted_and_nonexistent_source_endpoints_return_not_found`
+- `tests/integration/test_source_edit_delete_html.py::test_source_delete_html_flow_hides_deleted_source_from_management_surfaces`
+
+Error excerpt:
+```text
+psycopg.errors.UndefinedColumn: column sources.company_provider_key does not exist
+SQL: SELECT ... sources.company_provider_key ... FROM sources WHERE sources.id = %(pk_1)s::INTEGER
+```
+
+Reproduction steps:
+1. Run the broader source regression command in the current workspace with the local `.env` PostgreSQL database not upgraded to the new migration.
+2. Trigger source delete flow tests.
+3. Background task `run_source_delete_cleanup()` opens `app.persistence.db.SessionLocal()` against local PostgreSQL instead of the pytest in-memory SQLite fixture.
+4. ORM model expects `sources.company_provider_key`; local DB schema does not yet contain it.
+
+## 4. Failure Classification
+| Failure | Classification | Root cause hypothesis | Severity / impact |
+|---|---|---|---|
+| Two broader regression failures above | Environment Issue / test harness isolation issue | Local PostgreSQL schema has not been upgraded to migration `20260429_0003`, and the existing background cleanup task bypasses the pytest session override. | Non-blocking for this bugfix validation after migration; blocks using that local DB without running migrations. |
+
+No targeted acceptance-criteria test failed.
+
+## 5. Observations
+- The implementation treats removed sources as soft-deleted (`deleted_at` set, `is_active=False`), matching existing source deletion conventions.
+- HubSpot Greenhouse is included in `REMOVED_GREENHOUSE_IDENTIFIERS`, satisfying the confirmed removal decision.
+- Insider Lever is not in the removal identifiers and is covered by Lever parser contract tests.
+- Duplicate prevention is enforced in service validation and with a migration-backed partial unique index on `company_provider_key` for non-deleted rows.
+- No frontend issue was proven; implementation made no frontend changes.
+
+## 6. Regression Check
+- Targeted source-health cleanup, duplicate prevention, Lever adapter, and migration integration coverage passed.
+- Broader source regression was mostly successful but exposed an environment/test isolation limitation when the local PostgreSQL database is not migrated.
+- Existing duplicate template files remain unchanged; they were previously identified as maintainability noise, not the source-health root cause.
+
+## 7. QA Decision
+Approved for the implemented backend/data-ingestion bugfix, with the operational limitation that deployed/local PostgreSQL databases must run Alembic migration `20260429_0003` before application code using the new ORM model is exercised.
+
+[QA SIGN-OFF APPROVED]

--- a/docs/qa/source_health_cleanup_test_plan.md
+++ b/docs/qa/source_health_cleanup_test_plan.md
@@ -1,0 +1,46 @@
+# Test Plan
+
+## 1. Feature Overview
+Validate the backend/data-ingestion source-health cleanup bugfix on branch `bugfix/source_health_cleanup`. The fix must remove confirmed invalid external 404/zero-job configured sources, preserve Insider Lever with a parser robustness fix, enforce one active source per normalized company/provider, clean existing duplicates safely, and avoid frontend changes unless proven necessary.
+
+## 2. Acceptance Criteria Mapping
+| Acceptance criterion | Validation approach |
+|---|---|
+| Confirm source-health 404s are external vs app/config/code issue. | Reviewed bug evidence and cleanup implementation scope; verified tests target removal of confirmed invalid configured sources rather than adapter HTTP behavior changes. |
+| Remove configured sources confirmed as external 404. | Inspect `app/domain/source_health_cleanup.py`; run cleanup unit coverage for Lever and Greenhouse removals. |
+| Remove HubSpot Greenhouse from configured sources. | Inspect removed Greenhouse identifiers and cleanup unit coverage. |
+| Remove HubSpot Greenhouse from configured sources. | Inspect cleanup constants and unit test coverage for `hubspot`. |
+| One active source per normalized company + provider; same company with different provider allowed. | Run `tests/unit/test_sources.py` duplicate prevention tests; inspect source key generation and active unique index migration. |
+| Cleanup existing duplicates by keeping most recently successful/healthy source. | Run cleanup unit test for duplicate keeper selection; inspect keeper sort logic. |
+| Fix Insider Lever parser bug while keeping Insider configured. | Run Lever adapter contract tests for string and mixed `lists[].content`; inspect cleanup does not remove `insiderone`. |
+| Cleanup stale/duplicate project files only if directly related. | Inspect changed files list for scope. |
+| Backend/data-ingestion only unless frontend issue proven. | Inspect changed files list and template files; no frontend code/template changes in implementation. |
+
+## 3. Test Scenarios
+1. Duplicate Greenhouse source with same company/provider and different base URL is rejected.
+2. Same company on Greenhouse and Lever remains allowed.
+3. Deleted source with same company/provider does not block a new active source.
+4. Cleanup soft-deletes confirmed invalid Lever sources and HubSpot Greenhouse.
+5. Cleanup preserves Insider Lever (`insiderone`).
+6. Cleanup soft-deletes duplicate active company/provider rows and keeps the healthier/more recent successful source.
+7. Cleanup is idempotent when executed more than once.
+8. Migration adds `company_provider_key` and active unique index.
+9. Lever parser handles `lists[].content` as string and mixed list/dict content.
+10. Source-management/source-health-adjacent regression suite remains stable where the environment supports execution.
+
+## 4. Edge Cases
+- Legacy rows with missing `company_provider_key` are backfilled.
+- Soft-deleted rows are ignored by cleanup and duplicate validation.
+- Same company with different provider is not considered duplicate.
+- Lever list content may be a string, list of strings, list of dicts, or malformed/unexpected entries.
+- Cleanup repeated after prior execution should not re-delete rows or produce duplicate results.
+
+## 5. Test Types Covered
+- Unit: source validation and cleanup logic.
+- Adapter contract: Lever parser payload variants.
+- Integration: Alembic migration column/index behavior.
+- Regression: source deletion, source edit/delete, source batch, CSV import, HTML/source surfaces, Greenhouse/Lever adapter contract tests.
+- Static/compile: Python compile check for app and Alembic code.
+
+## 6. Coverage Justification
+The selected tests directly exercise the changed backend components (`sources`, `source_health_cleanup`, `models`, Alembic migration, Lever adapter) and include regression checks across adjacent source-management behavior. Frontend validation is limited to file-scope inspection because no frontend issue was proven and no frontend files changed.

--- a/docs/qa/source_health_cleanup_unapplied_migration_blocker_retest.md
+++ b/docs/qa/source_health_cleanup_unapplied_migration_blocker_retest.md
@@ -1,0 +1,52 @@
+# Test Report
+
+## 1. Execution Summary
+- Retest scope: HITL blocker correction for unapplied migration guardrail plus original source-health cleanup regression.
+- Targeted tests executed: 17
+- Targeted passed: 17
+- Targeted failed: 0
+- Compile check: passed
+- Broader source regression: environment-limited by intentionally stale local PostgreSQL; failure mode is now the expected actionable schema guardrail, not an opaque `/sources` ORM undefined-column route failure.
+
+## 2. Detailed Results
+| Test / validation | Outcome | Evidence |
+|---|---:|---|
+| `PYTHONPATH=. uv run --with-editable . pytest tests/unit/test_schema_guard.py tests/unit/test_sources.py tests/unit/test_source_health_cleanup.py tests/adapter_contract/test_lever_adapter.py tests/integration/test_source_health_migrations.py` | Passed | `17 passed, 4 warnings in 1.22s` |
+| `PYTHONPATH=. uv run --with-editable . python -m compileall app alembic` | Passed | Completed app/Alembic compile traversal without errors. |
+| Manual stale DB guardrail check via `validate_database_schema_current(get_settings().database_url)` | Passed | Message: `Database schema is out of date for this application version. Run alembic upgrade head against the same DATABASE_URL before starting the server. Current DB revision: 20260424_0002; required head revision: 20260429_0003.` |
+| Broader source regression command covering unit/API/integration/adapter source tests | Environment-limited / expected guardrail | `20 passed, 24 errors`; every TestClient startup error shown was `DatabaseSchemaOutOfDateError` with `alembic upgrade head`, current revision `20260424_0002`, and required head `20260429_0003`. This confirms fail-fast behavior before route-level ORM queries. |
+| README/runbook inspection | Passed | `README.md` documents startup schema guardrail and instructs running `alembic upgrade head` against the server `DATABASE_URL`. |
+| Startup integration inspection | Passed | `app/main.py` lifespan calls `validate_database_schema_current(settings.database_url)` for non-SQLite databases before scheduler startup/request handling. |
+
+## 3. Failed Tests
+No targeted acceptance-criteria tests failed.
+
+### Environment-limited broader regression errors
+The broader regression suite cannot complete while the configured local PostgreSQL remains intentionally stale. This is now the expected guardrail behavior:
+
+```text
+app.persistence.schema_guard.DatabaseSchemaOutOfDateError: Database schema is out of date for this application version. Run `alembic upgrade head` against the same DATABASE_URL before starting the server. Current DB revision: 20260424_0002; required head revision: 20260429_0003.
+```
+
+This is not the prior blocker failure (`psycopg.errors.UndefinedColumn` during `/sources` query). The first actionable signal is now startup schema validation.
+
+## 4. Failure Classification
+| Failure / limitation | Classification | Root cause hypothesis | Severity / impact |
+|---|---|---|---|
+| Broader TestClient/API/integration tests error at startup in current local environment | Environment Issue / Expected Guardrail | Local PostgreSQL is still at Alembic revision `20260424_0002`; repository head is `20260429_0003`. The new guard correctly blocks startup until migration is applied. | Non-blocking for guardrail validation; broader route regression requires running `alembic upgrade head` first. |
+
+## 5. Observations
+- Original source-health cleanup behavior remains covered by the 17-test targeted suite: invalid external sources, HubSpot removal, duplicate prevention, duplicate cleanup idempotency/keeper selection, migration column/index, and Lever parser robustness.
+- Schema guard unit tests cover stale revision message, current revision allowance, metadata-only test DB behavior, and non-SQLite startup targeting.
+- The manual stale DB check used the actual configured local `DATABASE_URL` and reproduced the exact expected actionable message with current and required revisions.
+- No frontend changes were introduced or required for this blocker correction.
+
+## 6. Regression Check
+- Original targeted cleanup tests still pass after guardrail remediation.
+- Compile regression passes for application and migration code.
+- Broader route-level regression is intentionally blocked by stale DB guardrail until the local database is migrated; this is the desired prevention of opaque `/sources` 500s.
+
+## 7. QA Decision
+Approved. The HITL blocker remediation changes the first failure from an opaque route-level `UndefinedColumn` to a fail-fast actionable schema message that tells the operator to run `alembic upgrade head` and includes current/required revisions. Original source-health cleanup acceptance criteria remain green in targeted automated coverage.
+
+[QA SIGN-OFF APPROVED]

--- a/docs/qa/source_health_new_sources_qa_report.md
+++ b/docs/qa/source_health_new_sources_qa_report.md
@@ -1,0 +1,69 @@
+# Test Report
+
+## 1. Execution Summary
+- Retest scope: original source-health cleanup, schema guardrail, and 13 newly validated ATS source additions.
+- Targeted tests executed: 20
+- Targeted passed: 20
+- Targeted failed: 0
+- Unit + adapter contract regression tests executed: 49
+- Unit + adapter contract passed: 49
+- Compile check: passed
+- Broader API/HTML regression: environment-limited by the expected stale local PostgreSQL schema guardrail.
+
+## 2. Detailed Results
+| Test / validation | Outcome | Evidence |
+|---|---:|---|
+| `PYTHONPATH=. uv run --with-editable . pytest tests/unit/test_schema_guard.py tests/unit/test_sources.py tests/unit/test_source_health_cleanup.py tests/unit/test_source_seed.py tests/adapter_contract/test_lever_adapter.py tests/integration/test_source_health_migrations.py` | Passed | `20 passed, 4 warnings in 1.23s` |
+| `PYTHONPATH=. uv run --with-editable . pytest tests/unit tests/adapter_contract` | Passed | `49 passed, 4 warnings in 0.41s` |
+| `PYTHONPATH=. uv run --with-editable . python -m compileall app alembic` | Passed | Completed app/Alembic compile traversal without errors. |
+| Seed definition inspection | Passed | `VALIDATED_SOURCE_ADDITIONS` contains 13 entries matching the validated list and generated normalized company/provider keys. |
+| API/HTML source regression command | Environment-limited / expected guardrail | `1 passed, 24 errors`; TestClient startup fails fast with `DatabaseSchemaOutOfDateError`, current DB revision `20260429_0003`, required head `20260429_0004`, and `alembic upgrade head` instruction. |
+| Changed-file scope inspection | Passed | New implementation is backend/domain, Alembic, tests, README/docs. No frontend route/template/static change was required. |
+
+## 3. Failed Tests
+No targeted acceptance-criteria tests failed.
+
+### Environment-limited broader regression errors
+The broader API/HTML regression suite cannot complete in the current local environment because local PostgreSQL is intentionally behind repository Alembic head after the new source migration:
+
+```text
+DatabaseSchemaOutOfDateError: Database schema is out of date for this application version. Run `alembic upgrade head` against the same DATABASE_URL before starting the server. Current DB revision: 20260429_0003; required head revision: 20260429_0004.
+```
+
+This is the expected schema guardrail behavior and is not an opaque route-level `UndefinedColumn` failure.
+
+## 4. Failure Classification
+| Failure / limitation | Classification | Root cause hypothesis | Severity / impact |
+|---|---|---|---|
+| Broader TestClient/API/HTML tests blocked at startup | Environment Issue / Expected Guardrail | Local PostgreSQL has not run `20260429_0004_add_validated_sources.py`; guardrail blocks startup until `alembic upgrade head` is applied. | Non-blocking for targeted QA; route-level smoke/regression requires migrating local DB first. |
+
+## 5. Observations
+- `app/domain/source_seed.py` defines exactly 13 validated source additions:
+  - Point Wild Greenhouse
+  - Fundraise Up Greenhouse
+  - Shift Technology Greenhouse
+  - The Economist Group Greenhouse
+  - Tailscale Greenhouse
+  - HighLevel Lever
+  - Cloaked Lever
+  - Drivetrain Lever
+  - Celara Lever
+  - Fullscript Lever
+  - Panopto Lever
+  - dLocal Lever
+  - Coderio Lever
+- Seed logic sets `notes=None`; the user-provided final role/context column is not persisted as source notes/description.
+- Seed logic uses both `company_provider_key` and legacy `dedupe_key` lookup and skips active duplicates, preserving one active source per normalized company/provider.
+- Migration `20260429_0004_add_validated_sources.py` runs the seed idempotently after `20260429_0003`.
+- README now documents that `alembic upgrade head` is required for the source-health cleanup and validated source seed migrations.
+
+## 6. Regression Check
+- Original source-health cleanup criteria remain covered by passing tests for confirmed removal, HubSpot removal, duplicate prevention/cleanup, migration/index behavior, schema guardrail, and Lever parser robustness.
+- New source-addition criteria are covered by `tests/unit/test_source_seed.py` and migration integration coverage.
+- Unit and adapter contract regression suite passed.
+- API/HTML regression was attempted but appropriately blocked by the stale local DB guardrail; manual route smoke should be performed after applying `alembic upgrade head` to the local PostgreSQL database.
+
+## 7. QA Decision
+Approved. Targeted automated evidence confirms original cleanup behavior, schema guardrail behavior, and idempotent addition of all 13 validated sources without persisting the role/context column. Broader route testing is limited only by the expected stale local DB guardrail and requires operator migration before server smoke testing.
+
+[QA SIGN-OFF APPROVED]

--- a/docs/release/source_health_cleanup_issue.md
+++ b/docs/release/source_health_cleanup_issue.md
@@ -1,0 +1,24 @@
+# GitHub Issue
+
+## 1. Feature Name
+source_health_cleanup
+
+## 2. Issue Type
+Bug / Issue Report
+
+## 3. Summary
+Source Health showed invalid ATS source configurations, duplicate active company/provider sources, and an Insider Lever parsing failure. The workflow cleans up bad source data, prevents duplicate active sources, and adds validated replacement sources.
+
+## 4. Related Documents
+- Bug Report: docs/bugs/source_health_cleanup.md
+- Migration Blocker Report: docs/bugs/source_health_cleanup_unapplied_migration_blocker.md
+- New Sources Validation: docs/bugs/source_health_new_sources_validation.md
+- Backend Plan: docs/backend/source_health_cleanup_implementation_plan.md
+- Backend Report: docs/backend/source_health_cleanup_implementation_report.md
+- QA Plan: docs/qa/source_health_cleanup_test_plan.md
+- QA Report: docs/qa/source_health_cleanup_qa_report.md
+- Migration Retest: docs/qa/source_health_cleanup_unapplied_migration_blocker_retest.md
+- New Sources QA: docs/qa/source_health_new_sources_qa_report.md
+
+## 5. Linked GitHub Issue
+- https://github.com/michaelseno/job-intelligence-platform/issues/16

--- a/docs/release/source_health_cleanup_pr.md
+++ b/docs/release/source_health_cleanup_pr.md
@@ -1,0 +1,45 @@
+# Pull Request
+
+## 1. Feature Name
+source_health_cleanup
+
+## 2. Summary
+Fixes source-health noise by cleaning invalid/duplicate source rows, hardening duplicate prevention, repairing Insider Lever parsing, adding a migration schema guardrail, and seeding 13 validated ATS sources.
+
+## 3. Related Documents
+- Bug Report: docs/bugs/source_health_cleanup.md
+- Migration Blocker Report: docs/bugs/source_health_cleanup_unapplied_migration_blocker.md
+- New Sources Validation: docs/bugs/source_health_new_sources_validation.md
+- Backend Plan: docs/backend/source_health_cleanup_implementation_plan.md
+- Backend Report: docs/backend/source_health_cleanup_implementation_report.md
+- QA Plan: docs/qa/source_health_cleanup_test_plan.md
+- QA Report: docs/qa/source_health_cleanup_qa_report.md
+- Migration Retest: docs/qa/source_health_cleanup_unapplied_migration_blocker_retest.md
+- New Sources QA: docs/qa/source_health_new_sources_qa_report.md
+
+## 4. Changes Included
+- Adds source health cleanup/backfill logic to soft-delete confirmed bad 404 sources, HubSpot Greenhouse, and duplicate active company/provider rows.
+- Enforces active duplicate prevention with `company_provider_key` in service validation and migration-backed partial unique indexing.
+- Fixes the Lever adapter to tolerate Insider-style string/mixed `lists[].content` payloads.
+- Adds startup schema guardrail to fail fast when PostgreSQL has unapplied Alembic migrations.
+- Seeds 13 validated ATS sources idempotently through Alembic migration `20260429_0004`.
+- Updates tests and documentation covering cleanup, migrations, schema guardrails, parser behavior, and source seeding.
+
+## 5. QA Status
+- Approved: YES
+- Latest QA status: [QA SIGN-OFF APPROVED]
+- HITL validation: HITL validation successful
+
+## 6. Test Coverage
+- Source addition targeted tests: `20 passed, 4 warnings`.
+- Unit + adapter contract regression: `49 passed, 4 warnings`.
+- Compile check: passed.
+- Original cleanup targeted evidence includes duplicate prevention, cleanup idempotency, migration/index coverage, and Insider Lever parser coverage.
+
+## 7. Risks / Notes
+- Operators must run `alembic upgrade head` against the active `DATABASE_URL` before local/deployed app usage so migrations through `20260429_0004` are applied.
+- Broader API/HTML regression was environment-limited until the local PostgreSQL database is migrated; the new guardrail intentionally blocks stale-schema startup.
+- Earlier stash `stash@{0}` for unrelated source batch run docs was not applied and is not included.
+
+## 8. Linked Issue
+- Closes #16

--- a/tests/adapter_contract/test_lever_adapter.py
+++ b/tests/adapter_contract/test_lever_adapter.py
@@ -33,3 +33,48 @@ def test_lever_adapter_normalizes_jobs(monkeypatch):
     assert len(result.jobs) == 1
     assert result.jobs[0].employment_type == "Full-time"
     assert result.jobs[0].location_text == "Spain"
+
+
+def test_lever_adapter_tolerates_string_list_content(monkeypatch):
+    payload = [
+        {
+            "id": "insider-1",
+            "text": "Backend Engineer",
+            "hostedUrl": "https://jobs.example.com/backend",
+            "categories": {"location": "Remote", "commitment": "Full-time"},
+            "descriptionPlain": "Core platform role.",
+            "lists": [{"text": "Benefits", "content": "<p>Visa sponsorship available</p>"}],
+            "additionalPlain": "Distributed team.",
+            "createdAt": 1713866400000,
+        }
+    ]
+    monkeypatch.setattr("app.adapters.lever.adapter.httpx.get", lambda *args, **kwargs: DummyResponse(payload))
+    source = type("Source", (), {"external_identifier": "insiderone", "company_name": "Insider", "name": "Insider", "base_url": "https://example.com"})()
+
+    result = LeverAdapter().fetch_jobs(source)
+
+    assert len(result.jobs) == 1
+    assert "Visa sponsorship available" in result.jobs[0].description_text
+
+
+def test_lever_adapter_tolerates_mixed_list_content(monkeypatch):
+    payload = [
+        {
+            "id": "mixed-1",
+            "text": "Data Engineer",
+            "hostedUrl": "https://jobs.example.com/data",
+            "categories": {},
+            "lists": [
+                {"content": [{"text": "Python"}, "SQL", {"unexpected": "ignored"}]},
+                "unexpected group",
+            ],
+        }
+    ]
+    monkeypatch.setattr("app.adapters.lever.adapter.httpx.get", lambda *args, **kwargs: DummyResponse(payload))
+    source = type("Source", (), {"external_identifier": "example", "company_name": "Example", "name": "Example", "base_url": "https://example.com"})()
+
+    result = LeverAdapter().fetch_jobs(source)
+
+    assert len(result.jobs) == 1
+    assert "Python" in result.jobs[0].description_text
+    assert "SQL" in result.jobs[0].description_text

--- a/tests/integration/test_source_health_migrations.py
+++ b/tests/integration/test_source_health_migrations.py
@@ -11,12 +11,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.domain.operations import OperationsService
+from app.domain.source_seed import VALIDATED_SOURCE_ADDITIONS
 from app.persistence.models import Source, utcnow
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ALEMBIC_INI = REPO_ROOT / "alembic.ini"
 ACTIVE_SOURCE_UNIQUE_INDEX = "ix_sources_dedupe_key_active_unique"
+ACTIVE_COMPANY_PROVIDER_UNIQUE_INDEX = "ix_sources_company_provider_active_unique"
 LEGACY_SOURCE_UNIQUE_CONSTRAINT = "uq_sources_dedupe_key"
 
 
@@ -47,6 +49,7 @@ def test_alembic_upgrade_adds_deleted_at_and_enforces_active_source_uniqueness(t
     inspector = inspect(engine)
     columns = {column["name"] for column in inspector.get_columns("sources")}
     assert "deleted_at" in columns
+    assert "company_provider_key" in columns
 
     fk_tables = {
         "source_runs": "source_id",
@@ -64,9 +67,14 @@ def test_alembic_upgrade_adds_deleted_at_and_enforces_active_source_uniqueness(t
         constraint["name"] for constraint in inspector.get_unique_constraints("sources")
     }
     assert any(index["name"] == ACTIVE_SOURCE_UNIQUE_INDEX for index in inspector.get_indexes("sources"))
+    assert any(index["name"] == ACTIVE_COMPANY_PROVIDER_UNIQUE_INDEX for index in inspector.get_indexes("sources"))
 
     with Session(engine) as session:
         service = OperationsService(session)
+        seeded_sources = session.query(Source).filter(Source.deleted_at.is_(None)).all()
+        assert len(seeded_sources) == len(VALIDATED_SOURCE_ADDITIONS)
+        assert all(source.notes is None for source in seeded_sources)
+
         source = Source(
             name="Legacy Source",
             source_type="greenhouse",
@@ -78,7 +86,7 @@ def test_alembic_upgrade_adds_deleted_at_and_enforces_active_source_uniqueness(t
         session.add(source)
         session.commit()
 
-        assert [item.name for item in service.list_source_health()] == ["Legacy Source"]
+        assert "Legacy Source" in [item.name for item in service.list_source_health()]
 
         duplicate_active = Source(
             name="Duplicate Active Source",
@@ -109,6 +117,8 @@ def test_alembic_upgrade_adds_deleted_at_and_enforces_active_source_uniqueness(t
         session.add(replacement)
         session.commit()
 
-        assert [item.name for item in service.list_source_health()] == ["Replacement Source"]
+        source_health_names = [item.name for item in service.list_source_health()]
+        assert "Legacy Source" not in source_health_names
+        assert "Replacement Source" in source_health_names
 
     engine.dispose()

--- a/tests/unit/test_schema_guard.py
+++ b/tests/unit/test_schema_guard.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+from app.persistence.schema_guard import (
+    DatabaseSchemaOutOfDateError,
+    get_repository_head_revision,
+    should_validate_schema_on_startup,
+    validate_database_schema_current,
+)
+
+
+def test_schema_guard_fails_with_actionable_message_for_stale_revision():
+    engine = _engine()
+    _set_revision(engine, "20260424_0002")
+
+    with pytest.raises(DatabaseSchemaOutOfDateError) as exc_info:
+        validate_database_schema_current("sqlite+pysqlite:///:memory:", engine=engine)
+
+    message = str(exc_info.value)
+    assert "Database schema is out of date" in message
+    assert "alembic upgrade head" in message
+    assert "20260424_0002" in message
+    assert get_repository_head_revision() in message
+
+
+def test_schema_guard_allows_current_head_revision():
+    engine = _engine()
+    _set_revision(engine, get_repository_head_revision())
+
+    validate_database_schema_current("sqlite+pysqlite:///:memory:", engine=engine)
+
+
+def test_schema_guard_ignores_metadata_only_test_database_without_alembic_version():
+    engine = _engine()
+
+    validate_database_schema_current("sqlite+pysqlite:///:memory:", engine=engine)
+
+
+def test_startup_schema_guard_targets_migrated_non_sqlite_databases():
+    assert should_validate_schema_on_startup("postgresql+psycopg://postgres:postgres@localhost/db") is True
+    assert should_validate_schema_on_startup("sqlite:///./job_intelligence_platform.db") is False
+
+
+def _engine():
+    return create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+
+def _set_revision(engine, revision: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        connection.execute(text("INSERT INTO alembic_version (version_num) VALUES (:revision)"), {"revision": revision})

--- a/tests/unit/test_source_health_cleanup.py
+++ b/tests/unit/test_source_health_cleanup.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from app.domain.source_health_cleanup import cleanup_source_health_sources
+from app.persistence.models import Source, utcnow
+
+
+def test_cleanup_soft_deletes_confirmed_removed_sources(session):
+    invalid_lever = _source(
+        name="Alkami Technology Lever",
+        source_type="lever",
+        external_identifier="alkami",
+        company_name="Alkami Technology",
+    )
+    removed_greenhouse = _source(
+        name="HubSpot Greenhouse",
+        source_type="greenhouse",
+        external_identifier="hubspot",
+        company_name="HubSpot",
+    )
+    valid_insider = _source(
+        name="Insider Lever",
+        source_type="lever",
+        external_identifier="insiderone",
+        company_name="Insider",
+    )
+    session.add_all([invalid_lever, removed_greenhouse, valid_insider])
+    session.commit()
+
+    result = cleanup_source_health_sources(session)
+
+    assert set(result.removed_source_ids) == {invalid_lever.id, removed_greenhouse.id}
+    assert invalid_lever.deleted_at is not None
+    assert invalid_lever.is_active is False
+    assert removed_greenhouse.deleted_at is not None
+    assert removed_greenhouse.is_active is False
+    assert valid_insider.deleted_at is None
+    assert valid_insider.is_active is True
+
+
+def test_cleanup_soft_deletes_duplicates_and_keeps_recent_healthy_source(session):
+    older = _source(
+        name="Asana Greenhouse Old",
+        source_type="greenhouse",
+        external_identifier="asana",
+        company_name="Asana",
+        base_url="https://boards.greenhouse.io/asana",
+        dedupe_key="greenhouse|old|asana",
+    )
+    older.health_state = "healthy"
+    older.last_run_status = "success"
+    older.last_run_at = utcnow() - timedelta(days=2)
+    newer = _source(
+        name="Asana Greenhouse New",
+        source_type="greenhouse",
+        external_identifier="asana",
+        company_name="Asana",
+        base_url="https://job-boards.greenhouse.io/asana",
+        dedupe_key="greenhouse|new|asana",
+    )
+    newer.health_state = "healthy"
+    newer.last_run_status = "success"
+    newer.last_run_at = utcnow() - timedelta(hours=1)
+    session.add_all([older, newer])
+    session.commit()
+
+    result = cleanup_source_health_sources(session)
+
+    assert result.duplicate_source_ids == [older.id]
+    assert older.deleted_at is not None
+    assert older.is_active is False
+    assert newer.deleted_at is None
+    assert newer.is_active is True
+    assert newer.company_provider_key == "asana|greenhouse"
+
+
+def test_cleanup_is_idempotent(session):
+    source = _source(name="Postman Lever", source_type="lever", external_identifier="postman", company_name="Postman")
+    session.add(source)
+    session.commit()
+
+    first = cleanup_source_health_sources(session)
+    second = cleanup_source_health_sources(session)
+
+    assert first.removed_source_ids == [source.id]
+    assert second.removed_source_ids == []
+    assert second.duplicate_source_ids == []
+
+
+def _source(
+    *,
+    name: str,
+    source_type: str,
+    external_identifier: str,
+    company_name: str,
+    base_url: str | None = None,
+    dedupe_key: str | None = None,
+) -> Source:
+    return Source(
+        name=name,
+        source_type=source_type,
+        company_name=company_name,
+        base_url=base_url or f"https://example.com/{external_identifier}",
+        external_identifier=external_identifier,
+        config_json={},
+        dedupe_key=dedupe_key or f"{source_type}|{external_identifier}",
+        is_active=True,
+    )

--- a/tests/unit/test_source_seed.py
+++ b/tests/unit/test_source_seed.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from app.domain.source_seed import VALIDATED_SOURCE_ADDITIONS, add_validated_source_additions
+from app.domain.sources import build_source_company_provider_key
+from app.persistence.models import Source
+
+
+def test_add_validated_sources_creates_all_sources_without_notes(session):
+    result = add_validated_source_additions(session)
+
+    sources = session.query(Source).filter(Source.deleted_at.is_(None)).all()
+    assert len(result.created_source_ids) == 13
+    assert len(sources) == 13
+    assert {source.company_name for source in sources} == {definition.company_name for definition in VALIDATED_SOURCE_ADDITIONS}
+    assert all(source.notes is None for source in sources)
+    assert all(source.is_active is True for source in sources)
+    assert all(source.company_provider_key for source in sources)
+
+
+def test_add_validated_sources_is_idempotent_and_skips_active_duplicates(session):
+    first = add_validated_source_additions(session)
+    second = add_validated_source_additions(session)
+
+    sources = session.query(Source).filter(Source.deleted_at.is_(None)).all()
+    assert len(first.created_source_ids) == 13
+    assert second.created_source_ids == []
+    assert len(second.skipped_source_keys) == 13
+    assert len(sources) == 13
+
+
+def test_add_validated_sources_respects_company_provider_duplicate(session):
+    duplicate_definition = VALIDATED_SOURCE_ADDITIONS[0]
+    duplicate_key = build_source_company_provider_key(
+        duplicate_definition.source_type,
+        duplicate_definition.company_name,
+        duplicate_definition.name,
+        None,
+    )
+    session.add(
+        Source(
+            name="Existing Point Wild Greenhouse",
+            source_type=duplicate_definition.source_type,
+            company_name=duplicate_definition.company_name,
+            base_url="https://job-boards.greenhouse.io/pointwild",
+            external_identifier=duplicate_definition.external_identifier,
+            config_json={},
+            dedupe_key="existing-pointwild-greenhouse",
+            company_provider_key=duplicate_key,
+            is_active=True,
+        )
+    )
+    session.commit()
+
+    result = add_validated_source_additions(session)
+
+    assert len(result.created_source_ids) == 12
+    assert duplicate_key in result.skipped_source_keys
+    assert session.query(Source).filter(Source.company_name == duplicate_definition.company_name, Source.deleted_at.is_(None)).count() == 1

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -38,6 +38,83 @@ def test_update_source_supports_partial_patch_without_self_duplicate_failure(ses
     assert updated.dedupe_key == source.dedupe_key
 
 
+def test_duplicate_prevention_uses_company_provider_not_base_url(session):
+    service = SourceService(session, SourceAdapterRegistry())
+    service.create_source(
+        SourceCreateRequest(
+            name="Asana Greenhouse",
+            source_type="greenhouse",
+            base_url="https://boards.greenhouse.io/asana",
+            external_identifier="asana",
+            company_name="Asana",
+        )
+    )
+
+    result = service.validate(
+        SourceCreateRequest(
+            name="Asana GH New Host",
+            source_type="greenhouse",
+            base_url="https://job-boards.greenhouse.io/asana",
+            external_identifier="asana",
+            company_name="Asana",
+        )
+    )
+
+    assert result.valid is False
+    assert "Duplicate source already exists." in result.errors
+
+
+def test_duplicate_prevention_allows_same_company_different_provider(session):
+    service = SourceService(session, SourceAdapterRegistry())
+    service.create_source(
+        SourceCreateRequest(
+            name="Keeper Security Greenhouse",
+            source_type="greenhouse",
+            base_url="https://boards.greenhouse.io/keepersecurity",
+            external_identifier="keepersecurity",
+            company_name="Keeper Security",
+        )
+    )
+
+    result = service.validate(
+        SourceCreateRequest(
+            name="Keeper Security Lever",
+            source_type="lever",
+            base_url="https://jobs.lever.co/keepersecurity",
+            external_identifier="keepersecurity",
+            company_name="Keeper Security",
+        )
+    )
+
+    assert result.valid is True
+
+
+def test_deleted_company_provider_duplicate_does_not_block_new_active_source(session):
+    service = SourceService(session, SourceAdapterRegistry())
+    source = service.create_source(
+        SourceCreateRequest(
+            name="Deleted GH",
+            source_type="greenhouse",
+            base_url="https://boards.greenhouse.io/deleted",
+            external_identifier="deleted",
+            company_name="DeletedCo",
+        )
+    )
+    service.delete_source(source.id)
+
+    result = service.validate(
+        SourceCreateRequest(
+            name="Deleted GH Replacement",
+            source_type="greenhouse",
+            base_url="https://job-boards.greenhouse.io/deleted",
+            external_identifier="deleted",
+            company_name="DeletedCo",
+        )
+    )
+
+    assert result.valid is True
+
+
 def test_delete_impact_counts_runs_linked_jobs_and_tracked_jobs(session):
     service = SourceService(session, SourceAdapterRegistry())
     source = service.create_source(


### PR DESCRIPTION
# Pull Request

## 1. Feature Name
source_health_cleanup

## 2. Summary
Fixes source-health noise by cleaning invalid/duplicate source rows, hardening duplicate prevention, repairing Insider Lever parsing, adding a migration schema guardrail, and seeding 13 validated ATS sources.

## 3. Related Documents
- Bug Report: docs/bugs/source_health_cleanup.md
- Migration Blocker Report: docs/bugs/source_health_cleanup_unapplied_migration_blocker.md
- New Sources Validation: docs/bugs/source_health_new_sources_validation.md
- Backend Plan: docs/backend/source_health_cleanup_implementation_plan.md
- Backend Report: docs/backend/source_health_cleanup_implementation_report.md
- QA Plan: docs/qa/source_health_cleanup_test_plan.md
- QA Report: docs/qa/source_health_cleanup_qa_report.md
- Migration Retest: docs/qa/source_health_cleanup_unapplied_migration_blocker_retest.md
- New Sources QA: docs/qa/source_health_new_sources_qa_report.md

## 4. Changes Included
- Adds source health cleanup/backfill logic to soft-delete confirmed bad 404 sources, HubSpot Greenhouse, and duplicate active company/provider rows.
- Enforces active duplicate prevention with `company_provider_key` in service validation and migration-backed partial unique indexing.
- Fixes the Lever adapter to tolerate Insider-style string/mixed `lists[].content` payloads.
- Adds startup schema guardrail to fail fast when PostgreSQL has unapplied Alembic migrations.
- Seeds 13 validated ATS sources idempotently through Alembic migration `20260429_0004`.
- Updates tests and documentation covering cleanup, migrations, schema guardrails, parser behavior, and source seeding.

## 5. QA Status
- Approved: YES
- Latest QA status: [QA SIGN-OFF APPROVED]
- HITL validation: HITL validation successful

## 6. Test Coverage
- Source addition targeted tests: `20 passed, 4 warnings`.
- Unit + adapter contract regression: `49 passed, 4 warnings`.
- Compile check: passed.
- Original cleanup targeted evidence includes duplicate prevention, cleanup idempotency, migration/index coverage, and Insider Lever parser coverage.

## 7. Risks / Notes
- Operators must run `alembic upgrade head` against the active `DATABASE_URL` before local/deployed app usage so migrations through `20260429_0004` are applied.
- Broader API/HTML regression was environment-limited until the local PostgreSQL database is migrated; the new guardrail intentionally blocks stale-schema startup.
- Earlier stash `stash@{0}` for unrelated source batch run docs was not applied and is not included.

## 8. Linked Issue
- Closes #16
