### PR TITLE
Feature: transient_untracked_ingestion_jobs

### DIFF
--- a/alembic/versions/20260501_0005_cleanup_untracked_jobs.py
+++ b/alembic/versions/20260501_0005_cleanup_untracked_jobs.py
@@ -1,0 +1,52 @@
+"""cleanup untracked persisted jobs
+
+Revision ID: 20260501_0005
+Revises: 20260429_0004
+Create Date: 2026-05-01 00:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import bindparam, text
+
+
+revision = "20260501_0005"
+down_revision = "20260429_0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    target_job_ids = [row[0] for row in bind.execute(text("SELECT id FROM job_postings WHERE tracking_status IS NULL")).fetchall()]
+    if not target_job_ids:
+        return
+
+    decision_ids = [
+        row[0]
+        for row in bind.execute(
+            text("SELECT id FROM job_decisions WHERE job_posting_id IN :job_ids").bindparams(bindparam("job_ids", expanding=True)),
+            {"job_ids": target_job_ids},
+        ).fetchall()
+    ]
+    if decision_ids:
+        bind.execute(
+            text("DELETE FROM job_decision_rules WHERE job_decision_id IN :decision_ids").bindparams(bindparam("decision_ids", expanding=True)),
+            {"decision_ids": decision_ids},
+        )
+
+    for table in ("job_decisions", "job_tracking_events", "reminders", "digest_items", "job_source_links"):
+        bind.execute(
+            text(f"DELETE FROM {table} WHERE job_posting_id IN :job_ids").bindparams(bindparam("job_ids", expanding=True)),
+            {"job_ids": target_job_ids},
+        )
+    bind.execute(
+        text("DELETE FROM job_postings WHERE id IN :job_ids AND tracking_status IS NULL").bindparams(bindparam("job_ids", expanding=True)),
+        {"job_ids": target_job_ids},
+    )
+
+
+def downgrade() -> None:
+    # Irreversible data cleanup: deleted untracked jobs and dependents cannot be restored.
+    pass

--- a/app/domain/classification.py
+++ b/app/domain/classification.py
@@ -31,6 +31,16 @@ class RuleResult:
     explanation_text: str
 
 
+@dataclass
+class ClassificationSnapshot:
+    decision_version: str
+    bucket: str
+    final_score: int
+    sponsorship_state: str
+    decision_reason_summary: str
+    rules: list[RuleResult]
+
+
 ROLE_POSITIVES = DEFAULT_ROLE_POSITIVES
 ROLE_NEGATIVES = DEFAULT_ROLE_NEGATIVES
 REMOTE_POSITIVES = DEFAULT_REMOTE_POSITIVES
@@ -47,7 +57,7 @@ class ClassificationService:
     def __init__(self, session: Session) -> None:
         self.session = session
 
-    def classify_job(self, job: JobPosting, preferences: JobFilterPreferences) -> JobDecision:
+    def preview_job(self, job, preferences: JobFilterPreferences) -> ClassificationSnapshot:
         text = " ".join(filter(None, [job.title, job.location_text, job.description_text, job.sponsorship_text]))
         lower = clean_text(text).lower()
         rules: list[RuleResult] = []
@@ -148,19 +158,29 @@ class ClassificationService:
             bucket = "rejected"
             summary = "Rejected because the role did not align with target role families."
 
-        self.session.execute(update(JobDecision).where(JobDecision.job_posting_id == job.id).values(is_current=False))
-        decision = JobDecision(
-            job_posting_id=job.id,
+        return ClassificationSnapshot(
             decision_version=self.decision_version,
             bucket=bucket,
             final_score=score,
             sponsorship_state=sponsorship_state,
             decision_reason_summary=summary,
+            rules=rules,
+        )
+
+    def persist_snapshot(self, job: JobPosting, snapshot: ClassificationSnapshot) -> JobDecision:
+        self.session.execute(update(JobDecision).where(JobDecision.job_posting_id == job.id).values(is_current=False))
+        decision = JobDecision(
+            job_posting_id=job.id,
+            decision_version=snapshot.decision_version,
+            bucket=snapshot.bucket,
+            final_score=snapshot.final_score,
+            sponsorship_state=snapshot.sponsorship_state,
+            decision_reason_summary=snapshot.decision_reason_summary,
             is_current=True,
         )
         self.session.add(decision)
         self.session.flush()
-        for rule in rules:
+        for rule in snapshot.rules:
             self.session.add(
                 JobDecisionRule(
                     job_decision_id=decision.id,
@@ -178,3 +198,6 @@ class ClassificationService:
         job.latest_decision_id = decision.id
         self.session.flush()
         return decision
+
+    def classify_job(self, job: JobPosting, preferences: JobFilterPreferences) -> JobDecision:
+        return self.persist_snapshot(job, self.preview_job(job, preferences))

--- a/app/domain/ingestion.py
+++ b/app/domain/ingestion.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
@@ -7,7 +9,11 @@ from app.adapters.base.registry import SourceAdapterRegistry
 from app.domain.classification import ClassificationService
 from app.domain.common import fingerprint, normalize_url, payload_hash, utcnow
 from app.domain.job_preferences import JobFilterPreferences
+from app.domain.transient_ingestion import TransientIngestionJob, new_transient_job_id, transient_ingestion_registry
 from app.persistence.models import JobPosting, JobSourceLink, Source, SourceRun
+
+
+logger = logging.getLogger(__name__)
 
 
 class IngestionOrchestrator:
@@ -30,17 +36,22 @@ class IngestionOrchestrator:
                 raise ValueError("; ".join(validation_errors))
             result = adapter.fetch_jobs(source)
             warnings.extend(result.warnings)
-            seen_job_ids: list[int] = []
+            transient_jobs: list[TransientIngestionJob] = []
             for candidate in result.jobs:
-                job, state = self._upsert_job(source, run, candidate)
-                seen_job_ids.append(job.id)
-                if state == "created":
-                    created += 1
-                elif state == "updated":
-                    updated += 1
+                match = self._resolve_persisted_tracked_match(source, candidate)
+                if match is not None:
+                    job, state = self._upsert_tracked_job(source, run, candidate, match)
+                    if state == "created":
+                        created += 1
+                    elif state == "updated":
+                        updated += 1
+                    else:
+                        unchanged += 1
+                    self.classifier.classify_job(job, preferences)
                 else:
-                    unchanged += 1
-                self.classifier.classify_job(job, preferences)
+                    transient_jobs.append(self._build_transient_job(source, run, candidate, preferences))
+
+            transient_ingestion_registry.replace_source_results(source.id, transient_jobs)
 
             run.status = "success" if not warnings else "partial_success"
             run.jobs_fetched_count = len(result.jobs)
@@ -50,6 +61,16 @@ class IngestionOrchestrator:
             run.warning_count = len(warnings)
             run.empty_result_flag = len(result.jobs) == 0
             run.log_summary = "; ".join(warnings) if warnings else "ingestion completed"
+            logger.info(
+                "ingestion completed source_id=%s run_id=%s fetched=%s created=%s updated=%s unchanged=%s transient=%s",
+                source.id,
+                run.id,
+                len(result.jobs),
+                created,
+                updated,
+                unchanged,
+                len(transient_jobs),
+            )
             self._update_source_health(source, run)
         except Exception as exc:
             run.status = "failed"
@@ -64,11 +85,13 @@ class IngestionOrchestrator:
             self.session.refresh(run)
         return run
 
-    def _upsert_job(self, source: Source, run: SourceRun, candidate) -> tuple[JobPosting, str]:
+    def _candidate_keys(self, candidate) -> tuple[str | None, str]:
         normalized_url = normalize_url(candidate.job_url)
         candidate_key = fingerprint(candidate.company_name, candidate.title, candidate.location_text, candidate.description_text)
+        return normalized_url, candidate_key
 
-        link_match = None
+    def _resolve_persisted_tracked_match(self, source: Source, candidate) -> JobPosting | None:
+        normalized_url, candidate_key = self._candidate_keys(candidate)
         if candidate.external_job_id:
             link_match = self.session.scalar(
                 select(JobSourceLink).where(
@@ -76,67 +99,65 @@ class IngestionOrchestrator:
                     JobSourceLink.external_job_id == candidate.external_job_id,
                 )
             )
-        job = None
-        if link_match:
-            job = self.session.get(JobPosting, link_match.job_posting_id)
-        if job is None:
-            job = self.session.scalar(
-                select(JobPosting).where(
-                    or_(JobPosting.normalized_job_url == normalized_url, JobPosting.canonical_key == candidate_key)
-                )
+            if link_match:
+                linked_job = self.session.get(JobPosting, link_match.job_posting_id)
+                if linked_job is not None and linked_job.tracking_status is not None:
+                    return linked_job
+        return self.session.scalar(
+            select(JobPosting).where(
+                JobPosting.tracking_status.is_not(None),
+                or_(JobPosting.normalized_job_url == normalized_url, JobPosting.canonical_key == candidate_key),
             )
+        )
 
+    def _build_transient_job(self, source: Source, run: SourceRun, candidate, preferences: JobFilterPreferences) -> TransientIngestionJob:
+        normalized_url, candidate_key = self._candidate_keys(candidate)
         now = utcnow()
-        state = "created"
-        if job is None:
-            job = JobPosting(
-                canonical_key=candidate_key,
-                primary_source_id=source.id,
-                title=candidate.title,
-                company_name=candidate.company_name,
-                job_url=candidate.job_url,
-                normalized_job_url=normalized_url,
-                location_text=candidate.location_text,
-                employment_type=candidate.employment_type,
-                remote_type=candidate.remote_type,
-                description_text=candidate.description_text,
-                description_html=candidate.description_html,
-                sponsorship_text=candidate.sponsorship_text,
-                posted_at=candidate.posted_at,
-                first_seen_at=now,
-                last_seen_at=now,
-                last_ingested_at=now,
-            )
-            self.session.add(job)
-            self.session.flush()
-        else:
-            existing_hash = payload_hash({
-                "title": job.title,
-                "description_text": job.description_text or "",
-                "location_text": job.location_text or "",
-                "job_url": job.job_url,
-            })
-            incoming_hash = payload_hash({
-                "title": candidate.title,
-                "description_text": candidate.description_text,
-                "location_text": candidate.location_text or "",
-                "job_url": candidate.job_url,
-            })
-            state = "unchanged" if existing_hash == incoming_hash else "updated"
-            job.title = candidate.title
-            job.company_name = candidate.company_name
-            job.job_url = candidate.job_url
-            job.normalized_job_url = normalized_url
-            job.location_text = candidate.location_text
-            job.employment_type = candidate.employment_type
-            job.remote_type = candidate.remote_type
-            job.description_text = candidate.description_text
-            job.description_html = candidate.description_html
-            job.sponsorship_text = candidate.sponsorship_text
-            job.posted_at = candidate.posted_at
-            job.last_seen_at = now
-            job.last_ingested_at = now
-            job.current_state = "active"
+        snapshot = self.classifier.preview_job(candidate, preferences)
+        return TransientIngestionJob(
+            transient_job_id=new_transient_job_id(),
+            source_id=source.id,
+            source_run_id=run.id,
+            external_job_id=candidate.external_job_id,
+            canonical_key=candidate_key,
+            normalized_job_url=normalized_url,
+            title=candidate.title,
+            company_name=candidate.company_name,
+            job_url=candidate.job_url,
+            location_text=candidate.location_text,
+            employment_type=candidate.employment_type,
+            remote_type=candidate.remote_type,
+            description_text=candidate.description_text,
+            description_html=candidate.description_html,
+            sponsorship_text=candidate.sponsorship_text,
+            posted_at=candidate.posted_at,
+            raw_payload=candidate.raw_payload,
+            classification=snapshot,
+            first_seen_at=now,
+            last_seen_at=now,
+            created_at=now,
+        )
+
+    def _upsert_tracked_job(self, source: Source, run: SourceRun, candidate, job: JobPosting) -> tuple[JobPosting, str]:
+        normalized_url = normalize_url(candidate.job_url)
+        now = utcnow()
+        existing_hash = payload_hash({"title": job.title, "description_text": job.description_text or "", "location_text": job.location_text or "", "job_url": job.job_url})
+        incoming_hash = payload_hash({"title": candidate.title, "description_text": candidate.description_text, "location_text": candidate.location_text or "", "job_url": candidate.job_url})
+        state = "unchanged" if existing_hash == incoming_hash else "updated"
+        job.title = candidate.title
+        job.company_name = candidate.company_name
+        job.job_url = candidate.job_url
+        job.normalized_job_url = normalized_url
+        job.location_text = candidate.location_text
+        job.employment_type = candidate.employment_type
+        job.remote_type = candidate.remote_type
+        job.description_text = candidate.description_text
+        job.description_html = candidate.description_html
+        job.sponsorship_text = candidate.sponsorship_text
+        job.posted_at = candidate.posted_at
+        job.last_seen_at = now
+        job.last_ingested_at = now
+        job.current_state = "active"
 
         link = self.session.scalar(
             select(JobSourceLink).where(

--- a/app/domain/tracking.py
+++ b/app/domain/tracking.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
-from app.domain.common import utcnow
-from app.persistence.models import JobPosting, JobTrackingEvent
+from app.domain.classification import ClassificationService
+from app.domain.common import payload_hash, utcnow
+from app.domain.transient_ingestion import TransientIngestionJob, transient_ingestion_registry
+from app.persistence.models import JobPosting, JobSourceLink, JobTrackingEvent
 
 
 VALID_TRACKING_STATUSES = {"saved", "applied", "interview", "rejected", "offer"}
@@ -41,6 +43,129 @@ class TrackingService:
         self.session.commit()
         self.session.refresh(job)
         return job
+
+    def track_transient_job(self, transient_job_id: str, tracking_status: str, note_text: str | None = None) -> tuple[JobPosting, bool]:
+        if not tracking_status or tracking_status not in VALID_TRACKING_STATUSES:
+            raise ValueError("Invalid tracking status.")
+        transient = transient_ingestion_registry.get(transient_job_id)
+        if transient is None:
+            raise LookupError("Transient job not found.")
+        try:
+            job = self._find_existing_match(transient)
+            if job is not None and job.tracking_status is None:
+                raise RuntimeError("Transient job matches an untracked persisted row. Refresh ingestion after cleanup.")
+            created = job is None
+            now = utcnow()
+            if job is None:
+                job = JobPosting(
+                    canonical_key=transient.canonical_key,
+                    primary_source_id=transient.source_id,
+                    title=transient.title,
+                    company_name=transient.company_name,
+                    job_url=transient.job_url,
+                    normalized_job_url=transient.normalized_job_url,
+                    location_text=transient.location_text,
+                    employment_type=transient.employment_type,
+                    remote_type=transient.remote_type,
+                    description_text=transient.description_text,
+                    description_html=transient.description_html,
+                    sponsorship_text=transient.sponsorship_text,
+                    posted_at=transient.posted_at,
+                    first_seen_at=transient.first_seen_at,
+                    last_seen_at=now,
+                    last_ingested_at=now,
+                    tracking_status=tracking_status,
+                )
+                self.session.add(job)
+                self.session.flush()
+            else:
+                self._update_job_from_transient(job, transient, tracking_status, now)
+            self._upsert_source_link(job, transient, now)
+            ClassificationService(self.session).persist_snapshot(job, transient.classification)
+            self.session.add(
+                JobTrackingEvent(
+                    job_posting_id=job.id,
+                    event_type="save" if tracking_status == "saved" else "status_change",
+                    tracking_status=tracking_status,
+                    note_text=note_text,
+                    created_at=now,
+                )
+            )
+            self.session.commit()
+            transient_ingestion_registry.consume(transient_job_id)
+            self.session.refresh(job)
+            return job, created
+        except Exception:
+            self.session.rollback()
+            raise
+
+    def _find_existing_match(self, transient: TransientIngestionJob) -> JobPosting | None:
+        if transient.external_job_id:
+            link_match = self.session.scalar(
+                select(JobSourceLink).where(
+                    JobSourceLink.source_id == transient.source_id,
+                    JobSourceLink.external_job_id == transient.external_job_id,
+                )
+            )
+            if link_match:
+                return self.session.get(JobPosting, link_match.job_posting_id)
+        return self.session.scalar(
+            select(JobPosting).where(
+                or_(
+                    JobPosting.normalized_job_url == transient.normalized_job_url,
+                    JobPosting.canonical_key == transient.canonical_key,
+                )
+            )
+        )
+
+    def _update_job_from_transient(self, job: JobPosting, transient: TransientIngestionJob, tracking_status: str, now) -> None:
+        job.title = transient.title
+        job.company_name = transient.company_name
+        job.job_url = transient.job_url
+        job.normalized_job_url = transient.normalized_job_url
+        job.location_text = transient.location_text
+        job.employment_type = transient.employment_type
+        job.remote_type = transient.remote_type
+        job.description_text = transient.description_text
+        job.description_html = transient.description_html
+        job.sponsorship_text = transient.sponsorship_text
+        job.posted_at = transient.posted_at
+        job.last_seen_at = now
+        job.last_ingested_at = now
+        job.current_state = "active"
+        job.tracking_status = tracking_status
+        self.session.add(job)
+
+    def _upsert_source_link(self, job: JobPosting, transient: TransientIngestionJob, now) -> JobSourceLink:
+        link = self.session.scalar(
+            select(JobSourceLink).where(
+                JobSourceLink.job_posting_id == job.id,
+                JobSourceLink.source_id == transient.source_id,
+                JobSourceLink.source_job_url == transient.job_url,
+            )
+        )
+        if link is None:
+            link = JobSourceLink(
+                job_posting_id=job.id,
+                source_id=transient.source_id,
+                source_run_id=transient.source_run_id,
+                external_job_id=transient.external_job_id,
+                source_job_url=transient.job_url,
+                raw_payload_json=transient.raw_payload,
+                content_hash=payload_hash(transient.raw_payload),
+                is_primary=(job.primary_source_id == transient.source_id),
+                first_seen_at=transient.first_seen_at,
+                last_seen_at=now,
+            )
+            self.session.add(link)
+        else:
+            link.source_run_id = transient.source_run_id
+            link.external_job_id = transient.external_job_id
+            link.raw_payload_json = transient.raw_payload
+            link.content_hash = payload_hash(transient.raw_payload)
+            link.last_seen_at = now
+        self.session.flush()
+        return link
 
     def list_events(self, job_id: int) -> list[JobTrackingEvent]:
         return list(

--- a/app/domain/transient_ingestion.py
+++ b/app/domain/transient_ingestion.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from threading import RLock
+from uuid import uuid4
+
+from app.domain.classification import ClassificationSnapshot
+
+
+@dataclass(frozen=True)
+class TransientIngestionJob:
+    transient_job_id: str
+    source_id: int
+    source_run_id: int
+    external_job_id: str | None
+    canonical_key: str
+    normalized_job_url: str | None
+    title: str
+    company_name: str | None
+    job_url: str
+    location_text: str | None
+    employment_type: str | None
+    remote_type: str | None
+    description_text: str
+    description_html: str | None
+    sponsorship_text: str | None
+    posted_at: datetime | None
+    raw_payload: dict
+    classification: ClassificationSnapshot
+    first_seen_at: datetime
+    last_seen_at: datetime
+    created_at: datetime
+
+
+class TransientIngestionRegistry:
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._by_id: dict[str, TransientIngestionJob] = {}
+        self._ids_by_source: dict[int, set[str]] = {}
+        self._ids_by_run: dict[int, set[str]] = {}
+
+    def replace_source_results(self, source_id: int, jobs: list[TransientIngestionJob]) -> None:
+        with self._lock:
+            for transient_job_id in self._ids_by_source.get(source_id, set()).copy():
+                self._remove_locked(transient_job_id)
+            deduped: dict[tuple[str, str], TransientIngestionJob] = {}
+            for job in jobs:
+                if job.external_job_id:
+                    key = ("external", f"{job.source_id}:{job.external_job_id}")
+                elif job.normalized_job_url:
+                    key = ("url", job.normalized_job_url)
+                else:
+                    key = ("canonical", job.canonical_key)
+                deduped[key] = job
+            for job in deduped.values():
+                self._by_id[job.transient_job_id] = job
+                self._ids_by_source.setdefault(job.source_id, set()).add(job.transient_job_id)
+                self._ids_by_run.setdefault(job.source_run_id, set()).add(job.transient_job_id)
+
+    def list(self, source_id: int | None = None) -> list[TransientIngestionJob]:
+        with self._lock:
+            if source_id is None:
+                return list(self._by_id.values())
+            ids = self._ids_by_source.get(source_id, set())
+            return [self._by_id[job_id] for job_id in ids if job_id in self._by_id]
+
+    def get(self, transient_job_id: str) -> TransientIngestionJob | None:
+        with self._lock:
+            return self._by_id.get(transient_job_id)
+
+    def consume(self, transient_job_id: str) -> TransientIngestionJob | None:
+        with self._lock:
+            job = self._by_id.get(transient_job_id)
+            if job is None:
+                return None
+            self._remove_locked(transient_job_id)
+            return job
+
+    def clear(self) -> None:
+        with self._lock:
+            self._by_id.clear()
+            self._ids_by_source.clear()
+            self._ids_by_run.clear()
+
+    def _remove_locked(self, transient_job_id: str) -> None:
+        job = self._by_id.pop(transient_job_id, None)
+        if job is None:
+            return
+        source_ids = self._ids_by_source.get(job.source_id)
+        if source_ids is not None:
+            source_ids.discard(transient_job_id)
+            if not source_ids:
+                self._ids_by_source.pop(job.source_id, None)
+        run_ids = self._ids_by_run.get(job.source_run_id)
+        if run_ids is not None:
+            run_ids.discard(transient_job_id)
+            if not run_ids:
+                self._ids_by_run.pop(job.source_run_id, None)
+
+
+transient_ingestion_registry = TransientIngestionRegistry()
+
+
+def new_transient_job_id() -> str:
+    return str(uuid4())

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -229,6 +229,27 @@ class TrackingStatusRequest(BaseModel):
     note_text: str | None = None
 
 
+class TransientJobListItemResponse(BaseModel):
+    transient_job_id: str
+    source_id: int
+    source_run_id: int
+    title: str
+    company_name: str | None
+    job_url: str
+    location_text: str | None
+    employment_type: str | None
+    remote_type: str | None
+    posted_at: datetime | None
+    latest_bucket: str | None
+    latest_score: int | None
+    tracking_status: None = None
+    created_at: datetime
+
+
+class TransientJobListResponse(BaseModel):
+    items: list[TransientJobListItemResponse]
+
+
 class DigestItemResponse(BaseModel):
     job_posting_id: int
     bucket: str

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -97,11 +97,20 @@ tbody tr:hover { background: #fafbfc; }
 .badge--danger { color: var(--danger-600); background: var(--danger-50); }
 .badge--info { color: var(--info-600); background: var(--info-50); }
 .badge--neutral { color: var(--text-secondary); background: var(--bg-surface-subtle); }
+.badge-temporary, .badge-temporary:hover { color: var(--warning-600); background: var(--warning-50); border: 1px solid #fde68a; }
+.button-primary { background: var(--brand-600); border-color: var(--brand-600); color: white; }
+.button-primary:hover { background: var(--brand-700); }
+.button-secondary { background: white; border-color: var(--border-strong); }
+.button[disabled], button[disabled], select[disabled] { cursor: not-allowed; opacity: .6; }
 .alert { padding: 16px 18px; }
 .alert--info { border-color: #bae6fd; background: var(--info-50); }
 .alert--success { border-color: #bbf7d0; background: var(--success-50); }
 .alert--warning { border-color: #fde68a; background: var(--warning-50); }
 .alert--danger { border-color: #fecaca; background: var(--danger-50); }
+.alert-info { border-color: #bae6fd; background: var(--info-50); }
+.alert-success { border-color: #bbf7d0; background: var(--success-50); }
+.alert-warning { border-color: #fde68a; background: var(--warning-50); }
+.alert-danger, .alert-error { border-color: #fecaca; background: var(--danger-50); }
 .alert__title { font-weight: 600; margin-bottom: 4px; }
 .empty-state { padding: 40px 24px; text-align: center; display: grid; gap: 12px; place-items: center; }
 .empty-state__icon { width: 48px; height: 48px; border-radius: 14px; display: grid; place-items: center; background: var(--brand-50); color: var(--brand-700); }
@@ -116,6 +125,15 @@ tbody tr:hover { background: #fafbfc; }
 .reminder-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--border-default); }
 .hidden { display: none !important; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.temporary-results-callout { display: grid; gap: 6px; }
+.temporary-results-callout h2, .temporary-results-callout h3, .temporary-results-callout p { margin: 0; }
+.row-transient { background: var(--warning-50); }
+.row-transient:hover { background: #fff7dc; }
+.job-card-transient { border-color: #fde68a; background: var(--warning-50); }
+.tracking-form { display: flex; gap: 8px; align-items: center; }
+.tracking-form select { min-width: 150px; }
+.tracking-form-transient[aria-busy="true"] { opacity: .85; }
+.badge-stack { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
 .source-batch-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; padding: 12px; margin-bottom: 12px; border: 1px solid var(--border-default); border-radius: var(--radius-md); background: var(--bg-surface-subtle); }
 .source-batch-toolbar__actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
 .source-batch-toolbar__help { margin: 0; max-width: 520px; }

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('keydown', (event) => { if (event.key === 'Escape' && sidebar.classList.contains('is-open')) closeSidebar(); });
   }
   document.querySelectorAll('form[data-clean-empty-query="true"]').forEach((form) => form.addEventListener('submit', () => form.querySelectorAll('input[name], select[name], textarea[name]').forEach((field) => { if (!field.value) field.disabled = true; })));
+  initTransientTrackingForms();
   initPreferenceGuards();
   initJobPreferencesPage();
   initSourceBatchRuns();
@@ -124,6 +125,32 @@ function initJobPreferencesPage() {
   function renderMode() { const setup = isSetup(); elements.title.textContent = setup ? 'Set up Job Preferences' : 'Job Preferences'; elements.desc.textContent = setup ? 'Answer a few questions so the app can filter and rank jobs for your search.' : 'Configure the criteria used to filter, score, and rank jobs.'; elements.progress.classList.toggle('hidden', !setup); elements.advanced.classList.toggle('hidden', setup); elements.reset.classList.toggle('hidden', setup); document.querySelectorAll('[data-wizard-step]').forEach((panel) => panel.classList.toggle('hidden', setup ? Number(panel.dataset.wizardStep) !== currentStep : false)); setStep(setup ? currentStep : 0); setStatus(activePreferences ? 'active' : 'setup'); if (activePreferences && activePreferences.configured_at) elements.lastSaved.textContent = `Last saved ${new Date(activePreferences.configured_at).toLocaleString()}`; }
   renderOptions(); populateAdvanced(activePreferences || mapWizardToPreferences(wizard, defaults)); renderMode(); if (!JobPreferencesStore.isStorageAvailable()) { elements.storage.classList.remove('hidden'); elements.save.disabled = true; }
   document.getElementById('category-search').addEventListener('input', () => { renderOptions(); }); document.getElementById('location-search')?.addEventListener('input', () => { renderCountryGroups(); syncInputs(); }); document.getElementById('location-clear')?.addEventListener('click', () => { wizard.selected_countries = []; renderCountryGroups(); syncInputs(); updateDirty(); }); form.addEventListener('click', (event) => { if (event.target instanceof HTMLInputElement && event.target.matches('[data-region-checkbox]')) event.stopPropagation(); }); form.addEventListener('change', (event) => { if (event.target instanceof HTMLInputElement && event.target.matches('[data-region-checkbox]')) { const region = COUNTRIES_BY_REGION.find((item) => item.id === event.target.value); if (region) { const ids = region.countries.map((country) => country.id); wizard.selected_countries = event.target.checked ? dedupe([...wizard.selected_countries, ...ids]) : wizard.selected_countries.filter((id) => !ids.includes(id)); } syncInputs(); updateDirty(); return; } if (event.target.name === 'work_arrangements') { let work = selected('work_arrangements'); if (event.target.value === 'any' && event.target.checked) work = ['any']; else work = work.filter((v) => v !== 'any'); wizard.work_arrangements = work; } collectWizardFromInputs(); syncInputs(); updateDirty(); }); form.addEventListener('input', (event) => { if (event.target.id === 'location-search') return; collectWizardFromInputs(); updateDirty(); }); elements.next.addEventListener('click', () => { if (validateStep(currentStep)) setStep(Math.min(3, currentStep + 1)); }); elements.back.addEventListener('click', () => setStep(Math.max(0, currentStep - 1))); elements.reset.addEventListener('click', () => { envelope = JobPreferencesStore.readEnvelope(); if (!envelope) return; unmatchedSavedCountryIds = envelope && envelope.wizard && Array.isArray(envelope.wizard.selected_countries) ? dedupe(envelope.wizard.selected_countries).filter((id) => !COUNTRY_IDS.has(id)) : []; wizard = normalizeWizard(envelope.wizard); activePreferences = envelope.preferences; baselineWizard = JSON.stringify(wizard); baselinePreferences = editablePreferenceSnapshot(activePreferences); renderOptions(); populateAdvanced(activePreferences); updateDirty(); }); form.addEventListener('submit', (event) => { event.preventDefault(); save(); }); updateDirty();
+}
+
+function initTransientTrackingForms() {
+  document.querySelectorAll('form[data-transient-tracking-form]').forEach((form) => {
+    const select = form.querySelector('select[name="tracking_status"]');
+    const button = form.querySelector('button[type="submit"]');
+    const syncButton = () => { if (button && select) button.disabled = !select.value; };
+    syncButton();
+    select?.addEventListener('change', syncButton);
+    form.addEventListener('submit', () => {
+      if (select && select.value) {
+        const hidden = document.createElement('input');
+        hidden.type = 'hidden';
+        hidden.name = 'tracking_status';
+        hidden.value = select.value;
+        form.appendChild(hidden);
+        select.disabled = true;
+      }
+      if (button) {
+        button.disabled = true;
+        button.textContent = 'Saving…';
+      }
+      form.setAttribute('aria-busy', 'true');
+      form.closest('tr, article')?.setAttribute('aria-busy', 'true');
+    });
+  });
 }
 
 document.addEventListener('submit', (event) => { const form = event.target; if (!(form instanceof HTMLFormElement) || form.dataset.requiresJobPreferencesSubmit !== 'true') return; const preferences = JobPreferencesStore.read(); if (!preferences) { event.preventDefault(); JobPreferencesStore.redirectToSetup(); return; } let input = form.querySelector('input[name="job_preferences_json"]'); if (!input) { input = document.createElement('input'); input.type = 'hidden'; input.name = 'job_preferences_json'; form.appendChild(input); } input.value = JSON.stringify(preferences); });

--- a/app/templates/jobs/list.html
+++ b/app/templates/jobs/list.html
@@ -7,7 +7,7 @@
   <div>
     <div class="eyebrow">Management table</div>
     <h2>Job pipeline</h2>
-    <p>Filter, scan, and update job tracking states without leaving the current workflow.</p>
+    <p>Filter, scan, and update tracked jobs alongside temporary results from the latest ingestion run.</p>
   </div>
   <div class="page-actions">
     <a class="btn btn--secondary" href="/tracking">Open tracking queue</a>
@@ -50,8 +50,21 @@
     <a class="btn btn--ghost" href="/jobs">Reset</a>
   </form>
 
+  {% if transient_count %}
+    <section class="callout callout-warning temporary-results-callout" aria-labelledby="temporary-results-title">
+      <h3 id="temporary-results-title">Temporary ingestion results</h3>
+      <p>Untracked jobs from the latest ingestion run are only available during this app session. Track a job to save it. Running ingestion again replaces this temporary list.</p>
+    </section>
+  {% endif %}
+
   {% if jobs %}
-    <p class="muted">{{ jobs|length }} actionable job(s) found.</p>
+    <p class="muted">
+      {% if transient_count %}
+        {{ jobs|length }} jobs shown: {{ persisted_count }} tracked, {{ transient_count }} temporary from the latest ingestion run.
+      {% else %}
+        {{ jobs|length }} actionable job(s) found.
+      {% endif %}
+    </p>
     <div class="table-wrap">
       <table>
         <thead>
@@ -59,9 +72,9 @@
         </thead>
         <tbody>
           {% for job in jobs %}
-            <tr>
+            <tr class="{% if job.is_transient %}row-transient{% endif %}"{% if job.is_transient %} aria-busy="false"{% endif %}>
               <td>
-                <a class="table-link" href="/jobs/{{ job.id }}">{{ job.title }}</a>
+                <a class="table-link" href="{{ job.detail_href }}">{{ job.title }}</a>
                 <div class="muted">{{ job.company_name }} · {{ job.location_text or 'Location not specified' }}</div>
               </td>
               <td>
@@ -69,14 +82,26 @@
                 {% if job.source_deleted %}{{ ui.badge('Deleted source', 'neutral') }}{% endif %}
               </td>
               <td>{{ ui.badge(job.bucket|title, ui.tone_from_status(job.bucket)) }}</td>
-              <td>{{ ui.badge((job.tracking_status or 'untracked')|replace('_', ' ')|title, ui.tone_from_status(job.tracking_status)) }}</td>
+              <td>{% if job.is_transient %}{{ ui.temporary_badge() }}{% else %}{{ ui.badge((job.tracking_status or 'untracked')|replace('_', ' ')|title, ui.tone_from_status(job.tracking_status)) }}{% endif %}</td>
               <td>{{ format_dt(job.last_seen_at) if format_dt else job.last_seen_at }}</td>
               <td>
                 <div class="row-actions">
-                  <a class="btn btn--ghost btn--sm" href="/jobs/{{ job.id }}">Open</a>
-                  <form method="post" action="/jobs/{{ job.id }}/keep?next=/jobs">
-                    <button class="btn btn--secondary btn--sm" type="submit">Keep</button>
-                  </form>
+                  <a class="btn btn--ghost btn--sm" href="{{ job.detail_href }}">Open</a>
+                  {% if job.is_transient %}
+                    <form method="post" action="/ingestion/transient-jobs/{{ job.transient_job_id }}/tracking-status" class="tracking-form tracking-form-transient" data-transient-tracking-form>
+                      <input type="hidden" name="next" value="/jobs">
+                      <label class="sr-only" for="tracking-status-{{ job.id }}">Tracking status for {{ job.title }}</label>
+                      <select id="tracking-status-{{ job.id }}" name="tracking_status" required>
+                        <option value="">Select status</option>
+                        {% for status in tracking_statuses %}<option value="{{ status }}">{{ status|replace('_', ' ')|title }}</option>{% endfor %}
+                      </select>
+                      <button class="btn btn--primary btn--sm" type="submit">Track job</button>
+                    </form>
+                  {% else %}
+                    <form method="post" action="/jobs/{{ job.id }}/keep?next=/jobs">
+                      <button class="btn btn--secondary btn--sm" type="submit" {% if job.tracking_status %}disabled{% endif %}>{% if job.tracking_status %}Already tracked{% else %}Keep{% endif %}</button>
+                    </form>
+                  {% endif %}
                 </div>
               </td>
             </tr>

--- a/app/templates/jobs/transient_detail.html
+++ b/app/templates/jobs/transient_detail.html
@@ -1,0 +1,104 @@
+{% extends 'base.html' %}
+{% import 'macros/ui.html' as ui %}
+{% block title %}{% if job %}{{ job.title }} · Temporary Job{% else %}Temporary job unavailable{% endif %} · Job Intelligence{% endblock %}
+{% block page_title %}{% if job %}Temporary job{% else %}Temporary job unavailable{% endif %}{% endblock %}
+{% block content %}
+  {% if not job %}
+    <section class="page-header">
+      <div>
+        <div class="eyebrow">Temporary result</div>
+        <h2>Temporary job unavailable</h2>
+        <p>This temporary result is no longer available. Run ingestion again or track a currently visible result.</p>
+      </div>
+    </section>
+    <section class="alert alert--danger" role="alert">This temporary result is no longer available. Run ingestion again or track a currently visible result.</section>
+    <a class="btn btn--secondary" href="/jobs">Back to Jobs</a>
+  {% else %}
+    <section class="page-header">
+      <div>
+        <div class="eyebrow">Temporary result</div>
+        <h2>{{ job.title }}</h2>
+        <p>{{ job.company_name or 'Unknown company' }} · Track this job to save it.</p>
+      </div>
+      <div class="page-actions"><a class="btn btn--ghost" href="/jobs">Back to Jobs</a></div>
+    </section>
+
+    <section class="callout callout-warning temporary-results-callout" aria-labelledby="temporary-detail-title">
+      <h3 id="temporary-detail-title">Temporary ingestion result</h3>
+      <p>This job is only available during this app session. Track it to save it. Running ingestion again replaces temporary results.</p>
+    </section>
+
+    <div class="content-grid content-grid--detail">
+      <div class="stack-panels">
+        <section class="surface">
+          <div class="section-heading">
+            <h3>Classification</h3>
+            <div class="badge-stack">{{ ui.temporary_badge() }} {{ ui.badge(job.classification.bucket|title, ui.tone_from_status(job.classification.bucket)) }}</div>
+          </div>
+          <dl class="detail-list">
+            <div><dt>Score</dt><dd>{{ job.classification.final_score }}</dd></div>
+            <div><dt>Sponsorship state</dt><dd>{{ job.classification.sponsorship_state|replace('_', ' ')|title }}</dd></div>
+            <div><dt>Decision summary</dt><dd>{{ job.classification.decision_reason_summary }}</dd></div>
+            <div><dt>Source</dt><dd>{{ source.name if source else 'Source #' ~ job.source_id }}</dd></div>
+            <div><dt>Location</dt><dd>{{ job.location_text or 'Not provided' }}</dd></div>
+          </dl>
+        </section>
+
+        <section class="surface">
+          <h3>Matched rules</h3>
+          {% if matched_rules %}
+            <div class="stack-list">
+              {% for rule in matched_rules %}
+                <article class="rule-card">
+                  <strong>{{ rule.rule_key|replace('_', ' ')|title }} (+{{ rule.score_delta }})</strong>
+                  <p>{{ rule.explanation_text }}</p>
+                  {% if rule.evidence_snippet %}<p class="muted">{{ rule.evidence_snippet }}</p>{% endif %}
+                </article>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="muted">No positive rule evidence available.</p>
+          {% endif %}
+        </section>
+
+        <section class="surface">
+          <h3>Negative signals</h3>
+          {% if negative_rules %}
+            <div class="stack-list">
+              {% for rule in negative_rules %}
+                <article class="rule-card">
+                  <strong>{{ rule.rule_key|replace('_', ' ')|title }} ({{ rule.score_delta }})</strong>
+                  <p>{{ rule.explanation_text }}</p>
+                </article>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="muted">No negative rules available for this temporary result.</p>
+          {% endif %}
+        </section>
+
+        <section class="surface">
+          <h3>Description excerpt</h3>
+          <div class="rich-copy">{{ job.description_text or 'No description text captured.' }}</div>
+        </section>
+      </div>
+
+      <aside class="stack-panels">
+        <section class="surface">
+          <h3>Track to save</h3>
+          <form method="post" action="/ingestion/transient-jobs/{{ job.transient_job_id }}/tracking-status" class="tracking-form tracking-form-transient" data-transient-tracking-form>
+            <input type="hidden" name="next" value="/jobs">
+            <label class="sr-only" for="tracking-status-{{ job.transient_job_id }}">Tracking status for {{ job.title }}</label>
+            <select id="tracking-status-{{ job.transient_job_id }}" name="tracking_status" required>
+              <option value="">Select status</option>
+              {% for status in tracking_statuses %}<option value="{{ status }}">{{ status|replace('_', ' ')|title }}</option>{% endfor %}
+            </select>
+            <button class="btn btn--primary" type="submit">Track job</button>
+          </form>
+          <p class="muted">Tracking this job saves it and moves future actions to the normal persisted job page.</p>
+          <a class="btn btn--secondary" href="{{ job.job_url }}" target="_blank" rel="noreferrer">Open source posting</a>
+        </section>
+      </aside>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/app/templates/macros/ui.html
+++ b/app/templates/macros/ui.html
@@ -2,6 +2,10 @@
 <span class="badge badge--{{ tone }}">{{ label }}</span>
 {%- endmacro %}
 
+{% macro temporary_badge() -%}
+<span class="badge badge-temporary" title="Temporary untracked ingestion result">Temporary</span><span class="sr-only">This is a temporary untracked ingestion result. Track it to save it.</span>
+{%- endmacro %}
+
 {% macro empty_state(title, body, cta_href=None, cta_label=None) -%}
 <section class="empty-state">
   <div class="empty-state__icon">◎</div>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -276,6 +276,34 @@ def to_job_card(job: JobPosting, source: Source | None, decision: JobDecision | 
         "last_ingested_at": job.last_ingested_at,
         "reason_summary": reason,
         "reminder": reminder,
+        "is_transient": False,
+        "detail_href": f"/jobs/{job.id}",
+    }
+
+
+def to_transient_job_card(job: TransientIngestionJob, source: Source | None) -> dict[str, Any]:
+    return {
+        "id": job.transient_job_id,
+        "transient_job_id": job.transient_job_id,
+        "title": job.title,
+        "company_name": job.company_name or source.name if source else "Unknown company",
+        "source_name": source.name if source else f"Source #{job.source_id}",
+        "source_id": job.source_id,
+        "source_deleted": bool(source and source.deleted_at is not None),
+        "job_url": job.job_url,
+        "location_text": job.location_text,
+        "remote_type": job.remote_type,
+        "current_state": "temporary",
+        "bucket": job.classification.bucket,
+        "score": job.classification.final_score,
+        "manual_keep": False,
+        "tracking_status": None,
+        "last_seen_at": job.last_seen_at,
+        "last_ingested_at": job.last_seen_at,
+        "reason_summary": job.classification.decision_reason_summary,
+        "reminder": None,
+        "is_transient": True,
+        "detail_href": f"/jobs/transient/{job.transient_job_id}",
     }
 
 
@@ -314,6 +342,46 @@ def filter_jobs_by_source(session: Session, jobs: list[JobPosting], source_id: i
         if link:
             filtered.append(job)
     return filtered
+
+
+def filter_transient_jobs(
+    jobs: list[TransientIngestionJob],
+    bucket: str | None,
+    tracking_status: str | None,
+    source_id: int | None,
+    search: str | None,
+) -> list[TransientIngestionJob]:
+    if tracking_status:
+        return []
+    filtered = jobs
+    if bucket:
+        filtered = [job for job in filtered if job.classification.bucket == bucket]
+    if source_id is not None:
+        filtered = [job for job in filtered if job.source_id == source_id]
+    if search:
+        needle = search.lower()
+        filtered = [
+            job
+            for job in filtered
+            if needle in (job.title or "").lower()
+            or needle in (job.company_name or "").lower()
+            or needle in (job.description_text or "").lower()
+        ]
+    return filtered
+
+
+def sort_job_cards(cards: list[dict[str, Any]], sort: str) -> list[dict[str, Any]]:
+    def date_key(job: dict[str, Any]) -> str:
+        value = job.get("last_seen_at")
+        return value.isoformat() if hasattr(value, "isoformat") else str(value or "")
+
+    if sort == "highest_score":
+        return sorted(cards, key=lambda job: (job.get("score") if job.get("score") is not None else -9999, date_key(job)), reverse=True)
+    if sort == "title":
+        return sorted(cards, key=lambda job: (job.get("title") or "").lower())
+    if sort == "company":
+        return sorted(cards, key=lambda job: (job.get("company_name") or "").lower())
+    return sorted(cards, key=date_key, reverse=True)
 
 
 def serialize_job(job: JobPosting) -> JobResponse:
@@ -896,7 +964,9 @@ async def run_source(
     run = IngestionOrchestrator(session, registry).run_source(source, preferences)
     if wants_html(request) or content_type.startswith("application/x-www-form-urlencoded"):
         if run.status in {"success", "partial_success"}:
-            return redirect(with_message(next_url or f"/sources/{source_id}", "success", f"Ingestion finished for {source.name}: fetched {run.jobs_fetched_count} jobs."))
+            transient_count = len(transient_ingestion_registry.list(source_id))
+            temporary_copy = f" {transient_count} temporary untracked result(s) are available on Jobs." if transient_count else ""
+            return redirect(with_message(next_url or f"/sources/{source_id}", "success", f"Ingestion finished for {source.name}: fetched {run.jobs_fetched_count} jobs.{temporary_copy}"))
         else:
             return redirect(with_message(next_url or f"/sources/{source_id}", "error", f"Ingestion failed for {source.name}. Review source health for details."))
     return run
@@ -922,7 +992,12 @@ def list_jobs(
     primary_sources = get_primary_source_map(session, jobs)
     decisions = get_current_decision_map(session, jobs)
     reminder_map = get_pending_reminder_map(session)
-    job_cards = [to_job_card(job, primary_sources.get(job.id), decisions.get(job.id), reminder_map.get(job.id)) for job in jobs]
+    persisted_cards = [to_job_card(job, primary_sources.get(job.id), decisions.get(job.id), reminder_map.get(job.id)) for job in jobs]
+    transient_jobs = filter_transient_jobs(transient_ingestion_registry.list(source_id), bucket, tracking_status, source_id, search)
+    transient_source_ids = {job.source_id for job in transient_jobs}
+    transient_sources = {source.id: source for source in session.scalars(select(Source).where(Source.id.in_(transient_source_ids)))} if transient_source_ids else {}
+    transient_cards = [to_transient_job_card(job, transient_sources.get(job.source_id)) for job in transient_jobs]
+    job_cards = sort_job_cards([*persisted_cards, *transient_cards], sort)
     sources = list(session.scalars(select(Source).where(Source.deleted_at.is_(None)).order_by(Source.name.asc())))
     return render(
         request,
@@ -932,6 +1007,8 @@ def list_jobs(
             "page_key": "jobs",
             "requires_job_preferences": True,
             "jobs": job_cards,
+            "persisted_count": len(persisted_cards),
+            "transient_count": len(transient_cards),
             "filters": {
                 "bucket": bucket or "",
                 "tracking_status": tracking_status or "",
@@ -988,6 +1065,40 @@ async def update_transient_tracking_status(transient_job_id: str, request: Reque
     body = JobResponse.model_validate(job).model_dump(mode="json")
     body["persisted_job_id"] = job.id
     return JSONResponse(status_code=status.HTTP_201_CREATED if created else status.HTTP_200_OK, content=body)
+
+
+@router.get("/jobs/transient/{transient_job_id}", response_class=HTMLResponse)
+def get_transient_job_detail(request: Request, transient_job_id: str, session: Session = Depends(get_session_dependency)):
+    job = transient_ingestion_registry.get(transient_job_id)
+    if job is None:
+        return render(
+            request,
+            session,
+            "jobs/transient_detail.html",
+            {
+                "page_key": "jobs",
+                "job": None,
+                "source": None,
+                "matched_rules": [],
+                "negative_rules": [],
+            },
+            status_code=404,
+        )
+    source = session.get(Source, job.source_id)
+    matched_rules = [rule for rule in job.classification.rules if rule.outcome == "matched"]
+    negative_rules = [rule for rule in job.classification.rules if rule.outcome != "matched"]
+    return render(
+        request,
+        session,
+        "jobs/transient_detail.html",
+        {
+            "page_key": "jobs",
+            "job": job,
+            "source": source,
+            "matched_rules": matched_rules,
+            "negative_rules": negative_rules,
+        },
+    )
 
 
 @router.get("/jobs/{job_id}")

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -35,6 +35,7 @@ from app.domain.source_batch_runs import (
     build_session_factory_from_session,
 )
 from app.domain.sources import SourceService
+from app.domain.transient_ingestion import TransientIngestionJob, transient_ingestion_registry
 from app.domain.tracking import TrackingService, VALID_TRACKING_STATUSES
 from app.persistence.db import get_db_session
 from app.persistence.models import Digest, DigestItem, JobDecision, JobDecisionRule, JobPosting, JobSourceLink, Reminder, Source, SourceRun
@@ -57,6 +58,8 @@ from app.schemas import (
     SourceRunResponse,
     SourceUpdateRequest,
     TrackingStatusRequest,
+    TransientJobListItemResponse,
+    TransientJobListResponse,
 )
 from app.web.dependencies import get_registry
 
@@ -315,6 +318,55 @@ def filter_jobs_by_source(session: Session, jobs: list[JobPosting], source_id: i
 
 def serialize_job(job: JobPosting) -> JobResponse:
     return JobResponse.model_validate(job)
+
+
+def serialize_transient_list_item(job: TransientIngestionJob) -> TransientJobListItemResponse:
+    return TransientJobListItemResponse(
+        transient_job_id=job.transient_job_id,
+        source_id=job.source_id,
+        source_run_id=job.source_run_id,
+        title=job.title,
+        company_name=job.company_name,
+        job_url=job.job_url,
+        location_text=job.location_text,
+        employment_type=job.employment_type,
+        remote_type=job.remote_type,
+        posted_at=job.posted_at,
+        latest_bucket=job.classification.bucket,
+        latest_score=job.classification.final_score,
+        tracking_status=None,
+        created_at=job.created_at,
+    )
+
+
+def serialize_transient_detail(job: TransientIngestionJob) -> dict[str, Any]:
+    return {
+        **serialize_transient_list_item(job).model_dump(),
+        "id": job.transient_job_id,
+        "description_text": job.description_text,
+        "sponsorship_text": job.sponsorship_text,
+        "decision": {
+            "id": None,
+            "decision_version": job.classification.decision_version,
+            "bucket": job.classification.bucket,
+            "final_score": job.classification.final_score,
+            "sponsorship_state": job.classification.sponsorship_state,
+            "decision_reason_summary": job.classification.decision_reason_summary,
+            "created_at": job.created_at,
+            "rules": [rule.__dict__ for rule in job.classification.rules],
+        },
+        "source_links": [
+            {
+                "source_id": job.source_id,
+                "source_run_id": job.source_run_id,
+                "external_job_id": job.external_job_id,
+                "source_job_url": job.job_url,
+                "last_seen_at": job.last_seen_at,
+            }
+        ],
+        "tracking_events": [],
+        "is_transient": True,
+    }
 
 
 def enqueue_source_delete_cleanup(background_tasks: BackgroundTasks, source_id: int) -> None:
@@ -890,6 +942,52 @@ def list_jobs(
             "available_sources": sources,
         },
     )
+
+
+@router.get("/ingestion/transient-jobs", response_model=TransientJobListResponse)
+def list_transient_jobs(source_id: int | None = Depends(parse_optional_source_id)):
+    items = [serialize_transient_list_item(job) for job in transient_ingestion_registry.list(source_id)]
+    return TransientJobListResponse(items=items)
+
+
+@router.get("/ingestion/transient-jobs/{transient_job_id}")
+def get_transient_job(transient_job_id: str):
+    job = transient_ingestion_registry.get(transient_job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Transient job not found.")
+    return serialize_transient_detail(job)
+
+
+@router.post("/ingestion/transient-jobs/{transient_job_id}/tracking-status")
+async def update_transient_tracking_status(transient_job_id: str, request: Request, session: Session = Depends(get_session_dependency)):
+    content_type = request.headers.get("content-type", "")
+    next_url = None
+    if content_type.startswith("application/json"):
+        payload = TrackingStatusRequest(**(await request.json()))
+    else:
+        form = await request.form()
+        next_url = form.get("next")
+        payload = TrackingStatusRequest(
+            tracking_status=str(form.get("tracking_status", "")),
+            note_text=str(form.get("note_text", "")) or None,
+        )
+
+    try:
+        job, created = TrackingService(session).track_transient_job(transient_job_id, payload.tracking_status, payload.note_text)
+    except ValueError as exc:
+        if content_type.startswith("application/json"):
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return redirect(with_message(str(next_url or "/jobs"), "error", str(exc)))
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    if wants_html(request) or not content_type.startswith("application/json"):
+        return redirect(with_message(str(next_url or f"/jobs/{job.id}"), "success", "Job tracked and saved."))
+    body = JobResponse.model_validate(job).model_dump(mode="json")
+    body["persisted_job_id"] = job.id
+    return JSONResponse(status_code=status.HTTP_201_CREATED if created else status.HTTP_200_OK, content=body)
 
 
 @router.get("/jobs/{job_id}")

--- a/app/web/static/app.js
+++ b/app/web/static/app.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.addEventListener('keydown', (event) => { if (event.key === 'Escape' && sidebar.classList.contains('is-open')) closeSidebar(); });
   }
   document.querySelectorAll('form[data-clean-empty-query="true"]').forEach((form) => form.addEventListener('submit', () => form.querySelectorAll('input[name], select[name], textarea[name]').forEach((field) => { if (!field.value) field.disabled = true; })));
+  initTransientTrackingForms();
   initPreferenceGuards();
   initJobPreferencesPage();
 });
@@ -102,6 +103,32 @@ function initJobPreferencesPage() {
   function renderMode() { const setup = isSetup(); elements.title.textContent = setup ? 'Set up Job Preferences' : 'Job Preferences'; elements.desc.textContent = setup ? 'Answer a few questions so the app can filter and rank jobs for your search.' : 'Configure the criteria used to filter, score, and rank jobs.'; elements.progress.classList.toggle('hidden', !setup); elements.advanced.classList.toggle('hidden', setup); elements.reset.classList.toggle('hidden', setup); document.querySelectorAll('[data-wizard-step]').forEach((panel) => panel.classList.toggle('hidden', setup ? Number(panel.dataset.wizardStep) !== currentStep : false)); setStep(setup ? currentStep : 0); setStatus(activePreferences ? 'active' : 'setup'); if (activePreferences && activePreferences.configured_at) elements.lastSaved.textContent = `Last saved ${new Date(activePreferences.configured_at).toLocaleString()}`; }
   renderOptions(); populateAdvanced(activePreferences || mapWizardToPreferences(wizard, defaults)); renderMode(); if (!JobPreferencesStore.isStorageAvailable()) { elements.storage.classList.remove('hidden'); elements.save.disabled = true; }
   document.getElementById('category-search').addEventListener('input', () => { renderOptions(); }); form.addEventListener('change', (event) => { if (event.target.name === 'work_arrangements') { let work = selected('work_arrangements'); if (event.target.value === 'any' && event.target.checked) work = ['any']; else work = work.filter((v) => v !== 'any'); wizard.work_arrangements = work; } collectWizardFromInputs(); syncInputs(); updateDirty(); }); form.addEventListener('input', () => { collectWizardFromInputs(); updateDirty(); }); elements.next.addEventListener('click', () => { if (validateStep(currentStep)) setStep(Math.min(3, currentStep + 1)); }); elements.back.addEventListener('click', () => setStep(Math.max(0, currentStep - 1))); elements.reset.addEventListener('click', () => { envelope = JobPreferencesStore.readEnvelope(); if (!envelope) return; wizard = normalizeWizard(envelope.wizard); activePreferences = envelope.preferences; baselineWizard = JSON.stringify(wizard); baselinePreferences = editablePreferenceSnapshot(activePreferences); renderOptions(); populateAdvanced(activePreferences); updateDirty(); }); form.addEventListener('submit', (event) => { event.preventDefault(); save(); }); updateDirty();
+}
+
+function initTransientTrackingForms() {
+  document.querySelectorAll('form[data-transient-tracking-form]').forEach((form) => {
+    const select = form.querySelector('select[name="tracking_status"]');
+    const button = form.querySelector('button[type="submit"]');
+    const syncButton = () => { if (button && select) button.disabled = !select.value; };
+    syncButton();
+    select?.addEventListener('change', syncButton);
+    form.addEventListener('submit', () => {
+      if (select && select.value) {
+        const hidden = document.createElement('input');
+        hidden.type = 'hidden';
+        hidden.name = 'tracking_status';
+        hidden.value = select.value;
+        form.appendChild(hidden);
+        select.disabled = true;
+      }
+      if (button) {
+        button.disabled = true;
+        button.textContent = 'Saving…';
+      }
+      form.setAttribute('aria-busy', 'true');
+      form.closest('tr, article')?.setAttribute('aria-busy', 'true');
+    });
+  });
 }
 
 document.addEventListener('submit', (event) => { const form = event.target; if (!(form instanceof HTMLFormElement) || form.dataset.requiresJobPreferencesSubmit !== 'true') return; const preferences = JobPreferencesStore.read(); if (!preferences) { event.preventDefault(); JobPreferencesStore.redirectToSetup(); return; } let input = form.querySelector('input[name="job_preferences_json"]'); if (!input) { input = document.createElement('input'); input.type = 'hidden'; input.name = 'job_preferences_json'; form.appendChild(input); } input.value = JSON.stringify(preferences); });

--- a/app/web/static/styles.css
+++ b/app/web/static/styles.css
@@ -97,11 +97,20 @@ tbody tr:hover { background: #fafbfc; }
 .badge--danger { color: var(--danger-600); background: var(--danger-50); }
 .badge--info { color: var(--info-600); background: var(--info-50); }
 .badge--neutral { color: var(--text-secondary); background: var(--bg-surface-subtle); }
+.badge-temporary, .badge-temporary:hover { color: var(--warning-600); background: var(--warning-50); border: 1px solid #fde68a; }
+.button-primary { background: var(--brand-600); border-color: var(--brand-600); color: white; }
+.button-primary:hover { background: var(--brand-700); }
+.button-secondary { background: white; border-color: var(--border-strong); }
+.button[disabled], button[disabled], select[disabled] { cursor: not-allowed; opacity: .6; }
 .alert { padding: 16px 18px; }
 .alert--info { border-color: #bae6fd; background: var(--info-50); }
 .alert--success { border-color: #bbf7d0; background: var(--success-50); }
 .alert--warning { border-color: #fde68a; background: var(--warning-50); }
 .alert--danger { border-color: #fecaca; background: var(--danger-50); }
+.alert-info { border-color: #bae6fd; background: var(--info-50); }
+.alert-success { border-color: #bbf7d0; background: var(--success-50); }
+.alert-warning { border-color: #fde68a; background: var(--warning-50); }
+.alert-danger, .alert-error { border-color: #fecaca; background: var(--danger-50); }
 .alert__title { font-weight: 600; margin-bottom: 4px; }
 .empty-state { padding: 40px 24px; text-align: center; display: grid; gap: 12px; place-items: center; }
 .empty-state__icon { width: 48px; height: 48px; border-radius: 14px; display: grid; place-items: center; background: var(--brand-50); color: var(--brand-700); }
@@ -115,6 +124,16 @@ tbody tr:hover { background: #fafbfc; }
 .list-group h3 { margin-bottom: 10px; }
 .reminder-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--border-default); }
 .hidden { display: none !important; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.temporary-results-callout { display: grid; gap: 6px; }
+.temporary-results-callout h2, .temporary-results-callout p { margin: 0; }
+.row-transient { background: var(--warning-50); }
+.row-transient:hover { background: #fff7dc; }
+.job-card-transient { border-color: #fde68a; background: var(--warning-50); }
+.tracking-form { display: flex; gap: 8px; align-items: center; }
+.tracking-form select { min-width: 150px; }
+.tracking-form-transient[aria-busy="true"] { opacity: .85; }
+.badge-stack { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
 .job-preferences-header { align-items: flex-start; }
 .preference-status { display: flex; flex-direction: column; gap: 6px; align-items: flex-end; }
 .preference-status p { margin: 0; }

--- a/app/web/templates/includes/macros.html
+++ b/app/web/templates/includes/macros.html
@@ -10,6 +10,11 @@
   {% endif %}
 {%- endmacro %}
 
+{% macro temporary_badge() -%}
+  <span class="badge badge-temporary" title="Temporary untracked ingestion result">Temporary</span>
+  <span class="sr-only">This is a temporary untracked ingestion result. Track it to save it.</span>
+{%- endmacro %}
+
 {% macro page_header(title, description='', actions='') -%}
   <section class="page-header">
     <div>
@@ -37,24 +42,27 @@
 {%- endmacro %}
 
 {% macro keep_form(job, next_url) -%}
-  <form method="post" action="/jobs/{{ job.id }}/keep" class="inline-form">
-    <input type="hidden" name="next" value="{{ next_url }}">
-    <button class="button button-secondary" type="submit" {% if job.tracking_status %}disabled{% endif %}>
-      {% if job.tracking_status %}Already tracked{% else %}Save / Keep Job{% endif %}
-    </button>
-  </form>
+  {% if not job.is_transient|default(false) %}
+    <form method="post" action="/jobs/{{ job.id }}/keep" class="inline-form">
+      <input type="hidden" name="next" value="{{ next_url }}">
+      <button class="button button-secondary" type="submit" {% if job.tracking_status %}disabled{% endif %}>
+        {% if job.tracking_status %}Already tracked{% else %}Save / Keep Job{% endif %}
+      </button>
+    </form>
+  {% endif %}
 {%- endmacro %}
 
 {% macro tracking_form(job, next_url, statuses, compact=False) -%}
-  <form method="post" action="/jobs/{{ job.id }}/tracking-status" class="tracking-form{% if compact %} tracking-form-compact{% endif %}" data-auto-submit>
+  {% set is_transient = job.is_transient|default(false) %}
+  <form method="post" action="{% if is_transient %}/ingestion/transient-jobs/{{ job.transient_job_id }}/tracking-status{% else %}/jobs/{{ job.id }}/tracking-status{% endif %}" class="tracking-form{% if compact %} tracking-form-compact{% endif %}{% if is_transient %} tracking-form-transient{% endif %}" data-auto-submit{% if is_transient %} data-transient-tracking-form{% endif %}>
     <input type="hidden" name="next" value="{{ next_url }}">
     <label class="sr-only" for="tracking-status-{{ job.id }}">Tracking status for {{ job.title }}</label>
-    <select id="tracking-status-{{ job.id }}" name="tracking_status">
+    <select id="tracking-status-{{ job.id }}" name="tracking_status" {% if is_transient %}required{% endif %}>
       <option value="">Select status</option>
       {% for status in statuses %}
         <option value="{{ status }}" {% if job.tracking_status == status %}selected{% endif %}>{{ status|title }}</option>
       {% endfor %}
     </select>
-    <button class="button button-secondary" type="submit">Update</button>
+    <button class="button {% if is_transient %}button-primary{% else %}button-secondary{% endif %}" type="submit">{% if is_transient %}Track job{% else %}Update{% endif %}</button>
   </form>
 {%- endmacro %}

--- a/app/web/templates/jobs/list.html
+++ b/app/web/templates/jobs/list.html
@@ -4,7 +4,7 @@
 {% block title %}Jobs · Job Intelligence Platform{% endblock %}
 
 {% block content %}
-  {{ ui.page_header('Jobs', 'Triage ingested jobs by automated bucket, tracking status, source, and search.') }}
+  {{ ui.page_header('Jobs', 'Review tracked jobs and temporary results from the latest ingestion run by automated bucket, tracking status, source, and search.') }}
 
   <section class="panel">
     <form method="get" class="filters-form" data-clean-empty-query="true">
@@ -54,9 +54,22 @@
     </form>
   </section>
 
+  {% if transient_count %}
+    <section class="callout callout-warning temporary-results-callout" aria-labelledby="temporary-results-title">
+      <h2 id="temporary-results-title">Temporary ingestion results</h2>
+      <p>Untracked jobs from the latest ingestion run are only available during this app session. Track a job to save it. Running ingestion again replaces this temporary list.</p>
+    </section>
+  {% endif %}
+
   {% if jobs %}
     <section class="panel jobs-table-panel">
-      <p class="results-summary">{{ jobs|length }} actionable job(s) found. Automated bucket, tracking status, and source health remain separate in this view.</p>
+      <p class="results-summary">
+        {% if transient_count %}
+          {{ jobs|length }} jobs shown: {{ persisted_count }} tracked, {{ transient_count }} temporary from the latest ingestion run.
+        {% else %}
+          {{ jobs|length }} actionable job(s) found. Automated bucket, tracking status, and source health remain separate in this view.
+        {% endif %}
+      </p>
       <div class="table-scroll">
         <table>
           <thead>
@@ -72,20 +85,20 @@
           </thead>
           <tbody>
             {% for job in jobs %}
-              <tr class="{% if job.bucket == 'rejected' %}row-muted{% endif %}">
+              <tr class="{% if job.bucket == 'rejected' %}row-muted{% endif %}{% if job.is_transient %} row-transient{% endif %}"{% if job.is_transient %} aria-busy="false"{% endif %}>
                 <td>
-                  <a href="/jobs/{{ job.id }}"><strong>{{ job.title }}</strong></a>
+                  <a href="{{ job.detail_href }}"><strong>{{ job.title }}</strong></a>
                   <div class="cell-subtitle">{{ job.company_name }} · {{ job.source_name }}{% if job.source_deleted %} <span class="badge badge-muted">Deleted source</span>{% endif %}</div>
                   {% if job.location_text %}<div class="cell-subtitle">{{ job.location_text }}</div>{% endif %}
                 </td>
                 <td>{{ ui.badge('bucket', job.bucket) }}</td>
-                <td>{{ ui.badge('tracking', job.tracking_status) }}</td>
+                <td>{% if job.is_transient %}{{ ui.temporary_badge() }}{% else %}{{ ui.badge('tracking', job.tracking_status) }}{% endif %}</td>
                 <td>{{ job.score if job.score is not none else '—' }}</td>
                 <td class="reason-cell">{{ job.reason_summary }}</td>
                 <td>{{ format_dt(job.last_seen_at) }}</td>
                 <td>
                   <div class="actions-stack">
-                    <a class="button button-secondary" href="/jobs/{{ job.id }}">View</a>
+                    <a class="button button-secondary" href="{{ job.detail_href }}">View</a>
                     {{ ui.keep_form(job, request.url.path ~ ('?' ~ request.url.query if request.url.query else '')) }}
                     {{ ui.tracking_form(job, request.url.path ~ ('?' ~ request.url.query if request.url.query else ''), tracking_statuses, True) }}
                   </div>
@@ -99,18 +112,19 @@
 
     <section class="mobile-card-list">
       {% for job in jobs %}
-        <article class="job-card {% if job.bucket == 'rejected' %}job-card-muted{% endif %}">
+        <article class="job-card {% if job.bucket == 'rejected' %}job-card-muted{% endif %}{% if job.is_transient %} job-card-transient{% endif %}"{% if job.is_transient %} aria-busy="false"{% endif %}>
           <div class="job-card__header">
             <div>
-              <h2><a href="/jobs/{{ job.id }}">{{ job.title }}</a></h2>
+              <h2><a href="{{ job.detail_href }}">{{ job.title }}</a></h2>
               <p class="muted">{{ job.company_name }} · {{ job.source_name }}{% if job.source_deleted %} <span class="badge badge-muted">Deleted source</span>{% endif %}</p>
             </div>
-            <div class="badge-stack">{{ ui.badge('bucket', job.bucket) }} {{ ui.badge('tracking', job.tracking_status) }}</div>
+            <div class="badge-stack">{% if job.is_transient %}{{ ui.temporary_badge() }}{% endif %} {{ ui.badge('bucket', job.bucket) }} {% if not job.is_transient %}{{ ui.badge('tracking', job.tracking_status) }}{% endif %}</div>
           </div>
+          {% if job.is_transient %}<p class="muted">Temporary result. Track it to save it before running ingestion again or restarting the app.</p>{% endif %}
           <p>{{ job.reason_summary }}</p>
           <p class="muted">Score: {{ job.score if job.score is not none else '—' }} · {{ format_dt(job.last_seen_at) }}</p>
           <div class="button-row button-row-wrap">
-            <a class="button button-secondary" href="/jobs/{{ job.id }}">View</a>
+            <a class="button button-secondary" href="{{ job.detail_href }}">View</a>
             {{ ui.keep_form(job, request.url.path ~ ('?' ~ request.url.query if request.url.query else '')) }}
           </div>
           {{ ui.tracking_form(job, request.url.path ~ ('?' ~ request.url.query if request.url.query else ''), tracking_statuses) }}

--- a/app/web/templates/jobs/transient_detail.html
+++ b/app/web/templates/jobs/transient_detail.html
@@ -1,0 +1,111 @@
+{% extends 'base.html' %}
+{% import 'includes/macros.html' as ui %}
+
+{% block title %}{% if job %}{{ job.title }} · Temporary Job{% else %}Temporary job unavailable{% endif %} · Job Intelligence Platform{% endblock %}
+
+{% block content %}
+  {% if not job %}
+    {{ ui.page_header('Temporary job unavailable', 'This temporary result is no longer available. Run ingestion again or track a currently visible result.') }}
+    <div class="alert alert-danger" role="alert">This temporary result is no longer available. Run ingestion again or track a currently visible result.</div>
+    <p><a class="button button-secondary" href="/jobs">Back to Jobs</a></p>
+  {% else %}
+    {{ ui.page_header(job.title, (job.company_name or 'Unknown company') ~ ' · Temporary ingestion result. Track it to save it.') }}
+
+    <section class="callout callout-warning temporary-results-callout" aria-labelledby="temporary-detail-title">
+      <h2 id="temporary-detail-title">Temporary ingestion result</h2>
+      <p>This job is only available during this app session. Track it to save it. Running ingestion again replaces temporary results.</p>
+    </section>
+
+    <div class="detail-layout">
+      <div class="detail-main">
+        <section class="panel">
+          <div class="job-summary-grid">
+            <div>
+              <p class="eyebrow">Automated classification</p>
+              <div class="badge-stack">{{ ui.temporary_badge() }} {{ ui.badge('bucket', job.classification.bucket) }}</div>
+            </div>
+            <div>
+              <p class="eyebrow">Score</p>
+              <p class="score-display">{{ job.classification.final_score if job.classification.final_score is not none else '—' }}</p>
+            </div>
+            <div>
+              <p class="eyebrow">Location</p>
+              <p>{{ job.location_text or 'Not provided' }}</p>
+            </div>
+            <div>
+              <p class="eyebrow">Source</p>
+              <p>{{ source.name if source else 'Source #' ~ job.source_id }}</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="panel">
+          <h2>Decision summary</h2>
+          <p>{{ job.classification.decision_reason_summary }}</p>
+          <ul class="meta-list">
+            <li><strong>Bucket:</strong> {{ job.classification.bucket|title }}</li>
+            <li><strong>Final score:</strong> {{ job.classification.final_score }}</li>
+            <li><strong>Sponsorship state:</strong> {{ job.classification.sponsorship_state|replace('_', ' ')|title }}</li>
+            <li><strong>Captured:</strong> {{ format_dt(job.created_at) }}</li>
+          </ul>
+        </section>
+
+        <section class="panel">
+          <h2>Matched rules</h2>
+          {% if matched_rules %}
+            <ul class="rule-list">
+              {% for rule in matched_rules %}
+                <li class="rule-item">
+                  <div class="rule-item__header"><strong>{{ rule.rule_key|replace('_', ' ')|title }}</strong><span class="rule-score">+{{ rule.score_delta }}</span></div>
+                  <p>{{ rule.explanation_text }}</p>
+                  {% if rule.evidence_snippet %}<blockquote>{{ rule.evidence_snippet }}</blockquote>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="muted">No positive rule evidence available.</p>
+          {% endif %}
+        </section>
+
+        <section class="panel">
+          <h2>Rejected rules / negative signals</h2>
+          {% if negative_rules %}
+            <ul class="rule-list">
+              {% for rule in negative_rules %}
+                <li class="rule-item rule-item-negative">
+                  <div class="rule-item__header"><strong>{{ rule.rule_key|replace('_', ' ')|title }}</strong><span class="rule-score">{{ rule.score_delta }}</span></div>
+                  <p>{{ rule.explanation_text }}</p>
+                  {% if rule.evidence_snippet %}<blockquote>{{ rule.evidence_snippet }}</blockquote>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="muted">No negative rules available for this temporary result.</p>
+          {% endif %}
+        </section>
+
+        <section class="panel">
+          <h2>Description excerpt</h2>
+          <div class="prose-block">{{ job.description_text or 'No description text captured.' }}</div>
+        </section>
+      </div>
+
+      <aside class="detail-sidebar">
+        <section class="panel">
+          <h2>Track to save</h2>
+          <form method="post" action="/ingestion/transient-jobs/{{ job.transient_job_id }}/tracking-status" class="tracking-form tracking-form-transient" data-transient-tracking-form>
+            <input type="hidden" name="next" value="/jobs">
+            <label class="sr-only" for="tracking-status-{{ job.transient_job_id }}">Tracking status for {{ job.title }}</label>
+            <select id="tracking-status-{{ job.transient_job_id }}" name="tracking_status" required>
+              <option value="">Select status</option>
+              {% for status in tracking_statuses %}<option value="{{ status }}">{{ status|title }}</option>{% endfor %}
+            </select>
+            <button class="button button-primary" type="submit">Track job</button>
+          </form>
+          <p class="muted">Tracking this job saves it and moves future actions to the normal persisted job page.</p>
+          <a class="button button-secondary" href="{{ job.job_url }}" target="_blank" rel="noreferrer">Open source posting</a>
+        </section>
+      </aside>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/docs/architecture/transient_untracked_ingestion_jobs_technical_design.md
+++ b/docs/architecture/transient_untracked_ingestion_jobs_technical_design.md
@@ -1,0 +1,685 @@
+# Technical Design
+
+## 1. Feature Overview
+
+Change ingestion so newly discovered untracked jobs are not persisted. A job is tracked only when `tracking_status IS NOT NULL`; `manual_keep` must not influence persistence or cleanup eligibility. Untracked ingestion results remain in runtime memory for review until the next ingestion refresh or process restart. When the user tracks a transient job, the backend persists the job, source link, latest classification result, and ingestion metadata so it becomes a normal tracked database job.
+
+Product spec: `docs/product/transient_untracked_ingestion_jobs_product_spec.md`.
+
+## 2. Product Requirements Summary
+
+- Do not insert DB rows for newly ingested jobs with `tracking_status IS NULL`.
+- Do not insert source-link, classification-result, or ingestion-metadata rows solely for newly ingested untracked jobs.
+- Preserve updates for ingestion results matching existing tracked jobs.
+- Keep untracked ingestion results reviewable only in current runtime/app state.
+- Refresh transient results on each ingestion run and lose them on restart.
+- Persist a transient job and related artifacts when any non-null tracking status is assigned.
+- Remove existing DB jobs where `tracking_status IS NULL`, including dependent records as applicable.
+- Cleanup must be idempotent and must not delete tracked jobs regardless of `manual_keep`.
+
+## 3. Requirement-to-Architecture Mapping
+
+| Requirement / AC | Architectural responsibility |
+| --- | --- |
+| FR1-FR4, AC-01, AC-02, AC-07 | `IngestionOrchestrator` separates matched tracked persistence from new untracked transient capture. |
+| FR5-FR6, AC-03-AC-05 | New in-memory transient ingestion registry stores latest untracked result set and replaces it per ingestion run. |
+| FR7, AC-06 | Existing DB upsert/classification path remains only for jobs matched to persisted tracked jobs. |
+| FR8-FR9, AC-07-AC-09 | Persistence and cleanup predicates use only `tracking_status IS NULL/IS NOT NULL`; never `manual_keep`. |
+| FR10-FR12, AC-10-AC-12 | Tracking service/API gains transient-job tracking path that persists all required artifacts atomically. |
+| FR13-FR16, AC-13-AC-15 | Alembic data migration/domain cleanup deletes existing untracked jobs and dependents safely and repeatably. |
+
+## 4. Technical Scope
+
+### Current Technical Scope
+
+- Refactor ingestion persistence gating in `app/domain/ingestion.py`.
+- Add runtime-only transient result storage and schemas.
+- Expose current transient ingestion results to API/HTML surfaces needed for review.
+- Add transient tracking endpoint/service path.
+- Add idempotent cleanup migration for existing untracked jobs and dependent records.
+- Add/adjust tests for ingestion, cleanup, transient state, and tracking from transient state.
+
+### Out of Scope
+
+- Changing adapter fetch behavior, classification rules, scoring, buckets, or tracking status values.
+- Persisting transient results in DB, files, browser storage, Redis, or cache with restart survival.
+- Multi-user/session isolation beyond current single-user local app model.
+- Archive/restore for deleted untracked rows.
+- Redesigning job review UI beyond transient result visibility and tracking actions.
+
+### Future Technical Considerations
+
+- Optional expiring local cache for untracked results.
+- Retention policies or analytics for reviewed-but-untracked jobs.
+- More robust multi-session ownership if the app becomes multi-user.
+
+## 5. Architecture Overview
+
+### Current-state flow and affected files/modules
+
+Current ingestion in `app/domain/ingestion.py`:
+
+1. `IngestionOrchestrator.run_source()` creates and flushes a persisted `SourceRun`.
+2. Adapter returns `AdapterFetchResult.jobs` (`app/adapters/base/contracts.py`).
+3. For every candidate, `_upsert_job()` inserts or updates `JobPosting`, then inserts/updates `JobSourceLink`.
+4. `ClassificationService.classify_job()` writes `JobDecision` and `JobDecisionRule` rows and updates `JobPosting.latest_*`.
+5. `SourceRun.jobs_created_count`, `jobs_updated_count`, and `jobs_unchanged_count` count all candidates, including untracked jobs.
+
+Current tracking in `app/domain/tracking.py` assumes a persisted `JobPosting` exists and updates `/jobs/{job_id}/keep` or `/jobs/{job_id}/tracking-status` in `app/web/routes.py`.
+
+Current DB models in `app/persistence/models.py` include:
+
+- `JobPosting.tracking_status` nullable.
+- `JobPosting.manual_keep` boolean.
+- Dependents: `JobSourceLink`, `JobDecision`, `JobDecisionRule`, `JobTrackingEvent`, `Reminder`, `DigestItem`.
+- `SourceRun` stores ingestion run metadata.
+
+### Proposed high-level flow
+
+1. Ingestion fetches candidates as today.
+2. For each candidate, compute matching keys (`normalized_url`, `canonical_key`, and source/external ID link match).
+3. If candidate matches an existing persisted job where `tracking_status IS NOT NULL`, update that job/source link/classification using current behavior.
+4. If candidate does not match a tracked persisted job, do not create DB job/source-link/classification rows. Build a transient result containing the normalized candidate, source/run attribution, matching keys, raw payload, and a non-persisted classification snapshot.
+5. Replace the runtime transient result set for the source/run with the latest untracked results.
+6. API/UI reads transient results from memory.
+7. When user assigns a non-null tracking status to a transient result, persist job, source link, classification decision/rules, tracking event, and update source-run counters in one DB transaction.
+
+## 6. System Components
+
+### `IngestionOrchestrator` (`app/domain/ingestion.py`)
+
+Responsibilities:
+
+- Maintain existing adapter validation, source-run creation, warnings, source health, and commit behavior.
+- Replace candidate loop with a tracked-match branch and transient branch.
+- Use `tracking_status.is_not(None)` as the only persistence-eligible existing-job predicate for matched updates.
+- Return `SourceRun` as today; optionally attach non-persisted summary counts through response/schema if needed.
+
+Implementation guidance:
+
+- Do not pass transient candidates into current `classify_job()` because it writes DB rows.
+- Introduce a classification preview method (see Classification component) to produce the same bucket/score/rule outcome without persistence.
+- Preserve existing `_upsert_job()` behavior for tracked jobs, but guard lookup results so untracked persisted rows are not updated during the migration window.
+
+### Transient ingestion registry (new module, recommended `app/domain/transient_ingestion.py`)
+
+Responsibilities:
+
+- Runtime-only storage for latest untracked ingestion results.
+- Thread-safe access because source batch execution uses `ThreadPoolExecutor`.
+- Replace result set for a source on every completed ingestion for that source.
+- Remove or mark consumed a transient result when it is persisted through tracking.
+
+Recommended storage shape:
+
+- Process-global registry object using `threading.RLock`.
+- Primary key: opaque `transient_job_id` (`uuid4` string) generated per current runtime result.
+- Indexes: by `source_id`, `source_run_id`, and `transient_job_id`.
+- No DB persistence and no startup hydration.
+
+### `ClassificationService` (`app/domain/classification.py`)
+
+Responsibilities:
+
+- Preserve `classify_job(job, preferences)` for persisted jobs.
+- Add a persistence-neutral classification method that accepts job-like candidate data and returns a decision snapshot with rules.
+- Reuse the same rule logic to avoid drift between transient preview and persisted classification.
+
+Recommended internal contract:
+
+- Extract rule evaluation into a pure method returning bucket, score, sponsorship state, summary, and rule list.
+- `classify_job()` persists the pure result for a `JobPosting`.
+- Transient ingestion stores the pure result snapshot.
+
+### Tracking service (`app/domain/tracking.py`)
+
+Responsibilities:
+
+- Preserve existing tracking for persisted jobs.
+- Add a `track_transient_job(transient_job_id, tracking_status, note_text)` path.
+- Validate `tracking_status in VALID_TRACKING_STATUSES`.
+- Persist all related records atomically and emit a tracking event.
+
+### Web/API routes (`app/web/routes.py`) and schemas (`app/schemas.py`)
+
+Responsibilities:
+
+- Keep existing persisted job routes unchanged for persisted jobs.
+- Add read route(s) for transient ingestion results.
+- Add route to track a transient result.
+- For HTML, provide a review surface or augment current source/detail/jobs surfaces so users can see and track transient results.
+
+### Database cleanup/migration
+
+Responsibilities:
+
+- Delete existing `JobPosting` rows where `tracking_status IS NULL`.
+- Delete dependent rows for those jobs first, including classification rules through decisions.
+- Be safe to run repeatedly.
+- Never use `manual_keep` in delete predicates.
+
+## 7. Data Models
+
+### Existing persisted entity: `JobPosting`
+
+#### Purpose
+
+Durable record for tracked jobs only after this feature.
+
+#### Primary Key
+
+`id` integer DB primary key.
+
+#### Fields
+
+Existing fields remain unchanged. Persistence eligibility is determined by `tracking_status`:
+
+- `tracking_status: str | None` — `NULL` means untracked and should not be present for new ingestion-created rows; non-null means tracked.
+- `manual_keep: bool` — not a persistence or cleanup rule.
+
+#### Ownership Model
+
+Single-user local database.
+
+#### Lifecycle
+
+- Created during transient tracking, or updated during ingestion when a tracked persisted match exists.
+- Existing untracked rows are deleted by migration/cleanup.
+- Future ingestion must not create untracked rows.
+
+### Existing persisted entity: `JobSourceLink`
+
+#### Purpose
+
+Durable source attribution for persisted tracked jobs.
+
+#### Primary Key
+
+`id` integer DB primary key.
+
+#### Fields
+
+Existing fields remain unchanged.
+
+#### Ownership Model
+
+Scoped to a persisted `job_posting_id` and `source_id`.
+
+#### Lifecycle
+
+- Created/updated during tracked-job ingestion updates.
+- Created when a transient job is tracked.
+- Deleted for untracked cleanup targets.
+
+### Existing persisted entity: `JobDecision` / `JobDecisionRule`
+
+#### Purpose
+
+Durable classification result for persisted tracked jobs.
+
+#### Lifecycle
+
+- Created by `ClassificationService.classify_job()` for persisted jobs.
+- Created from transient classification snapshot when a transient job is tracked, or recomputed with the same preferences if the snapshot is unavailable in memory.
+- Deleted for untracked cleanup targets.
+
+### Existing persisted entity: `SourceRun`
+
+#### Purpose
+
+Durable ingestion run metadata and source health/audit record.
+
+#### Lifecycle
+
+- Still created for every ingestion run, even if all fetched jobs are transient.
+- `jobs_fetched_count` remains total adapter candidates.
+- `jobs_created_count` should count persisted job creations only. New untracked transient discoveries should not inflate persisted-created count.
+- If a transient job is tracked later, update the originating run metadata only if downstream UI relies on `jobs_created_count`; otherwise record linkage via `JobSourceLink.source_run_id` and do not mutate historical ingestion counters. Preferred: leave run counters as ingestion-time persisted effects and document transient count separately if added.
+
+### New runtime entity: `TransientIngestionJob`
+
+#### Purpose
+
+Reviewable, non-durable representation of an untracked ingestion result.
+
+#### Primary Key
+
+`transient_job_id: str` generated UUID. This ID is valid only for the current process and current registry contents.
+
+#### Fields
+
+- `transient_job_id: str`
+- `source_id: int`
+- `source_run_id: int`
+- `external_job_id: str | None`
+- `canonical_key: str`
+- `normalized_job_url: str | None`
+- Candidate fields matching `NormalizedJobCandidate` (`title`, `company_name`, `job_url`, `location_text`, `employment_type`, `remote_type`, `description_text`, `description_html`, `sponsorship_text`, `posted_at`, `raw_payload`)
+- `classification: TransientClassificationSnapshot`
+- `first_seen_at: datetime` and `last_seen_at: datetime` within runtime state
+- `created_at: datetime`
+
+#### Ownership Model
+
+Single process, single-user runtime state. Not user-scoped unless future auth is added.
+
+#### Lifecycle
+
+- Created during ingestion for new/untracked candidates.
+- Replaced when ingestion runs again for the same source. For batch ingestion, each source refreshes its own set.
+- Deleted/consumed when tracked.
+- Lost on app restart.
+
+### New runtime entity: `TransientClassificationSnapshot`
+
+#### Purpose
+
+Non-durable classification preview for a transient job.
+
+#### Fields
+
+- `decision_version: str`
+- `bucket: str`
+- `final_score: int`
+- `sponsorship_state: str`
+- `decision_reason_summary: str`
+- `rules: list[RuleResult-like objects]`
+
+## 8. API Contracts
+
+Existing persisted-job endpoints remain unchanged:
+
+- `GET /jobs`
+- `GET /jobs/{job_id}`
+- `POST /jobs/{job_id}/keep`
+- `POST /jobs/{job_id}/tracking-status`
+
+### Endpoint: GET /ingestion/transient-jobs
+
+#### Purpose
+
+Return current runtime untracked ingestion results for review.
+
+#### Authentication / Authorization
+
+No auth today; follows existing local single-user route behavior. If auth is added later, require the same owner/session as ingestion.
+
+#### Request Parameters
+
+- Query `source_id: int | None` — optional filter.
+
+#### Request Body
+
+None.
+
+#### Response Body
+
+```json
+{
+  "items": [
+    {
+      "transient_job_id": "uuid",
+      "source_id": 1,
+      "source_run_id": 10,
+      "title": "Software Engineer",
+      "company_name": "Example Co",
+      "job_url": "https://example.com/job/1",
+      "location_text": "Remote",
+      "employment_type": "Full-time",
+      "remote_type": "remote",
+      "posted_at": null,
+      "latest_bucket": "matched",
+      "latest_score": 42,
+      "tracking_status": null,
+      "created_at": "2026-05-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+#### Success Status Codes
+
+- `200 OK`
+
+#### Error Status Codes
+
+- `422 Unprocessable Entity` for invalid `source_id` query value.
+
+#### Validation Rules
+
+- `source_id`, if provided, must parse as integer.
+
+#### Side Effects
+
+None.
+
+#### Idempotency / Duplicate Handling
+
+Read-only. Returned set reflects latest in-memory registry state.
+
+### Endpoint: GET /ingestion/transient-jobs/{transient_job_id}
+
+#### Purpose
+
+Return full current runtime details for one transient job, including description and classification rules.
+
+#### Authentication / Authorization
+
+Same as existing local job detail routes.
+
+#### Request Parameters
+
+- Path `transient_job_id: str`.
+
+#### Request Body
+
+None.
+
+#### Response Body
+
+Same shape as `JobDetailResponse` where possible, but with `id` replaced by `transient_job_id`, `tracking_status: null`, source-link attribution from runtime state, and classification snapshot without persisted decision IDs.
+
+#### Success Status Codes
+
+- `200 OK`
+
+#### Error Status Codes
+
+- `404 Not Found` if the transient ID is absent, consumed, refreshed away, or lost after restart.
+
+#### Validation Rules
+
+- Treat malformed/unknown IDs as not found; do not query DB by this ID.
+
+#### Side Effects
+
+None.
+
+#### Idempotency / Duplicate Handling
+
+Read-only.
+
+### Endpoint: POST /ingestion/transient-jobs/{transient_job_id}/tracking-status
+
+#### Purpose
+
+Assign a non-null tracking status to a transient job and persist it with related artifacts.
+
+#### Authentication / Authorization
+
+Same as persisted tracking routes. Verify the transient ID exists in runtime state.
+
+#### Request Parameters
+
+- Path `transient_job_id: str`.
+- For HTML form submissions: optional `next` URL.
+
+#### Request Body
+
+```json
+{
+  "tracking_status": "saved",
+  "note_text": "optional note"
+}
+```
+
+#### Response Body
+
+On JSON success, return the persisted `JobResponse` plus `persisted_job_id` if not already obvious.
+
+#### Success Status Codes
+
+- `201 Created` when a new persisted job is created from transient state.
+- `200 OK` if duplicate handling finds an already-persisted tracked job and updates tracking/status/link safely.
+
+#### Error Status Codes
+
+- `400 Bad Request` for invalid tracking status.
+- `404 Not Found` if transient result is no longer available.
+- `409 Conflict` if the transient job matches a persisted untracked row during migration window or another concurrent request consumes it; response should instruct refresh.
+
+#### Validation Rules
+
+- `tracking_status` is required and must be one of `VALID_TRACKING_STATUSES`.
+- Null/empty tracking status is invalid for this endpoint.
+- Do not accept or use `manual_keep` as a persistence signal.
+
+#### Side Effects
+
+- Inserts/updates `JobPosting` with non-null `tracking_status`.
+- Inserts `JobSourceLink` using transient source/run/raw payload metadata.
+- Inserts current `JobDecision` and `JobDecisionRule` rows from classification snapshot or recomputation.
+- Inserts `JobTrackingEvent`.
+- Removes/consumes transient registry entry.
+- Commits transaction.
+
+#### Idempotency / Duplicate Handling
+
+- Use DB matching by source/external ID, normalized URL, and canonical key before insert.
+- If a tracked persisted job already exists, update it rather than creating a duplicate, then consume transient entry.
+- If a repeated request uses an already-consumed transient ID, return `404` or `409`; do not create duplicate rows.
+
+## 9. Frontend Impact
+
+### Components Affected
+
+- Source run trigger flow in `app/web/routes.py` and source templates, because run completion should lead to visible transient review results.
+- Jobs review UI templates (`app/web/templates/jobs/list.html`, `app/web/templates/jobs/detail.html`) or a new transient-results template.
+- Shared macros for tracking/keep forms if reused for transient IDs.
+
+### API Integration
+
+- Fetch/list transient results from `GET /ingestion/transient-jobs` for API clients.
+- Submit tracking from transient cards/details to `POST /ingestion/transient-jobs/{transient_job_id}/tracking-status`.
+- Existing `/jobs` APIs should continue to return persisted jobs only unless explicitly enhanced with a separate transient section. Do not mix integer DB IDs and transient UUIDs in the same `id` field without a discriminator.
+
+### UI States
+
+- Loading: current app is mostly server-rendered; display normal page load/submit behavior.
+- Empty: “No current transient ingestion results. Run ingestion to discover new jobs.”
+- Error: transient job no longer available due to refresh/restart; prompt user to rerun ingestion.
+- Consumed: after successful tracking, redirect to `/jobs/{persisted_job_id}` or back to review list with success message.
+
+## 10. Backend Logic
+
+### Responsibilities
+
+- Gate DB writes for job/source-link/classification rows by tracked status or existing tracked match.
+- Maintain source-run audit rows for ingestion executions.
+- Store untracked candidate artifacts in runtime memory only.
+- Persist transient artifacts atomically when tracking occurs.
+- Clean existing untracked DB rows.
+
+### Validation Flow
+
+Ingestion candidate:
+
+1. Normalize URL and compute canonical key.
+2. Look for source-link match by `(source_id, external_job_id)`.
+3. Resolve linked job if present.
+4. Look for direct `JobPosting` match by normalized URL or canonical key.
+5. Treat as persistable update only if matched job exists and `tracking_status IS NOT NULL`.
+6. Otherwise build transient record.
+
+Tracking transient job:
+
+1. Validate status is non-null and in `VALID_TRACKING_STATUSES`.
+2. Load transient record by ID under registry lock or consume reservation.
+3. In DB transaction, re-run matching against persisted tracked jobs to avoid duplicates.
+4. Insert/update `JobPosting` with `tracking_status` set.
+5. Insert/update `JobSourceLink`.
+6. Persist classification result/rules.
+7. Insert `JobTrackingEvent`.
+8. Commit and consume registry entry.
+
+### Business Rules
+
+- `tracking_status IS NULL` means untracked.
+- `tracking_status IS NOT NULL` means tracked.
+- `manual_keep` is ignored for persistence, retention, and cleanup.
+- New untracked ingestion candidates must not create durable job, source-link, decision/rule, or job-specific ingestion metadata rows.
+- Existing tracked jobs matched by ingestion must continue to update.
+
+### Persistence Flow
+
+#### Ingestion for tracked match
+
+- Use existing `_upsert_job()` path with a tracked-only lookup predicate.
+- Classify persisted job using existing `ClassificationService.classify_job()`.
+- Count created/updated/unchanged as persisted effects.
+
+#### Ingestion for new/untracked result
+
+- Do not call `session.add(JobPosting(...))`.
+- Do not create `JobSourceLink`.
+- Do not call DB-persisting `classify_job()`.
+- Store `TransientIngestionJob` in registry.
+- Include total fetched count in `SourceRun.jobs_fetched_count`.
+
+#### Tracking transient result
+
+- Create `JobPosting` with all fields from transient candidate, `first_seen_at/last_seen_at/last_ingested_at` from transient run timestamps/current time, and `tracking_status` from request.
+- Create `JobSourceLink` with `source_run_id` from transient record.
+- Persist decision/rules and update `latest_bucket`, `latest_score`, `latest_decision_id`.
+- Insert `JobTrackingEvent(event_type="status_change" or "save" for `saved`; choose one convention and test it).`
+
+### Error Handling
+
+- Ingestion failure behavior remains: mark `SourceRun` failed and update source health.
+- Transient registry failures should not partially commit DB job records because no DB job writes occur for transient candidates.
+- Tracking transaction rollback must leave transient entry available unless it was already consumed after commit.
+- Concurrent tracking attempts for the same transient ID must not create duplicates.
+
+## 11. File Structure
+
+Expected implementation touch points:
+
+- `app/domain/ingestion.py` — split tracked persistence from transient capture.
+- `app/domain/transient_ingestion.py` — new runtime registry and dataclasses.
+- `app/domain/classification.py` — pure classification result extraction.
+- `app/domain/tracking.py` — transient tracking/persistence method.
+- `app/schemas.py` — transient list/detail response schemas and optional track response schema.
+- `app/web/routes.py` — transient read/track routes and HTML handling.
+- `app/web/templates/...` — transient review UI or augment existing pages.
+- `app/persistence/models.py` — no schema changes expected.
+- `alembic/versions/<next_revision>_cleanup_untracked_jobs.py` — idempotent cleanup migration.
+- `tests/unit/...`, `tests/api/...`, `tests/integration/...` — coverage described below.
+
+## 12. Security
+
+- Authentication/authorization follows existing single-user local app behavior.
+- Do not expose raw payload details in list responses unless already exposed elsewhere; full detail can include source attribution needed for review.
+- Validate transient IDs as opaque strings; never interpolate into SQL.
+- Validate tracking statuses against `VALID_TRACKING_STATUSES`.
+- Do not accept client-provided candidate fields when tracking transient jobs; persist only server-held runtime data.
+- Avoid open redirect issues for `next` by continuing existing redirect handling patterns; consider limiting `next` to local paths if touched.
+
+## 13. Reliability
+
+- Registry must be thread-safe because batch source runs execute concurrently.
+- Runtime state loss on restart is intentional and required.
+- Replace transient source results only after adapter fetch/classification succeeds. On failed ingestion, prefer leaving previous current runtime set untouched or clearing it only if product confirms; requirement says refresh when ingestion triggers again according to latest output, so on successful zero/new run clear/replace. Document and test failed-run behavior.
+- Tracking persistence must be atomic. Consume transient entry only after commit.
+- Log ingestion counts: fetched, persisted created/updated/unchanged, transient captured.
+- Add monitoring/logging fields via standard logger; no new operational dependency.
+- Performance: in-memory storage can grow with latest ingestion output. Since this is local single-user and refreshed per run, no external cache is needed. Consider a simple max-size guard only if existing adapter outputs are unbounded; not required by spec.
+
+## 14. Dependencies
+
+- SQLAlchemy session/model layer.
+- Existing adapter contracts and registry.
+- Existing classification rules/preferences.
+- Existing tracking statuses.
+- Existing Alembic migration process and schema guard.
+- Existing source batch executor/threading behavior.
+
+## 15. Assumptions
+
+- The app remains single-user/local as stated in the product spec.
+- Existing `SourceRun` rows may remain durable for all ingestion runs; the prohibition on ingestion metadata rows applies to job-specific artifacts for newly untracked jobs, not the source-run audit row itself.
+- Transient result review can be provided by either a new route/template or an augmented existing jobs/source page, as long as IDs are clearly distinguished from persisted job IDs.
+
+## Technical Assumptions Requiring Confirmation
+
+- Failed ingestion run behavior for previous transient results: recommended behavior is to keep the last successful runtime set if fetch fails, and replace/clear only on successful ingestion completion.
+- Whether `SourceRun.jobs_created_count` should be incremented when a transient job is later tracked. Recommended behavior is no; it should represent ingestion-time DB effects only.
+
+## 16. Risks / Open Questions
+
+- Current `ClassificationService` writes directly to DB; refactor must avoid rule drift between pure and persisted paths.
+- Existing untracked rows may have `DigestItem`, `Reminder`, or `JobTrackingEvent` dependents even though untracked; cleanup must account for all FK dependents before deleting jobs.
+- DB FKs do not show cascade rules in models; migration must delete children explicitly.
+- Batch ingestion concurrency can cause registry replacement races if two runs for the same source overlap. Existing batch prevents concurrent batches, but single-source route may still be manually triggered concurrently unless guarded elsewhere.
+- Transient IDs become invalid after restart/refresh; UI must handle this gracefully.
+
+## 17. Implementation Notes
+
+### Data cleanup / migration approach
+
+Create a new Alembic revision after `20260429_0004`.
+
+Upgrade steps:
+
+1. Select `target_job_ids = SELECT id FROM job_postings WHERE tracking_status IS NULL`.
+2. Select `decision_ids = SELECT id FROM job_decisions WHERE job_posting_id IN target_job_ids`.
+3. Delete in child-to-parent order:
+   - `job_decision_rules` where `job_decision_id IN decision_ids`
+   - `job_decisions` where `job_posting_id IN target_job_ids`
+   - `job_tracking_events` where `job_posting_id IN target_job_ids`
+   - `reminders` where `job_posting_id IN target_job_ids`
+   - `digest_items` where `job_posting_id IN target_job_ids`
+   - `job_source_links` where `job_posting_id IN target_job_ids`
+   - `job_postings` where `id IN target_job_ids AND tracking_status IS NULL`
+4. Do not filter by or preserve `manual_keep`.
+5. Make no-op successful when `target_job_ids` is empty.
+
+Downgrade:
+
+- Cannot restore deleted untracked rows. Downgrade should be a no-op with a comment explaining irreversible data cleanup.
+
+### Backend implementation guidance
+
+- Introduce a helper result type from `_resolve_persisted_tracked_match()` instead of overloading `_upsert_job()` with transient behavior.
+- Keep DB session flushes only in the persisted branch.
+- Build transient records from adapter candidate plus computed keys before any DB object is created.
+- For duplicate candidates in one ingestion run, registry should dedupe by `(source_id, external_job_id)` when external ID exists, else normalized URL/canonical key. Keep the last candidate from the latest run.
+- For tracking from transient state, perform DB matching again inside the transaction to handle races with another ingestion/tracking action.
+- If matching finds an existing tracked job, update source link and tracking status rather than inserting a duplicate.
+
+### Frontend/API impact guidance
+
+- Existing `/jobs` should remain a persisted jobs view unless explicitly given a separate “current ingestion results” section.
+- Use a discriminator in templates/API: `is_transient: true` or separate endpoints to avoid integer-vs-UUID confusion.
+- Existing keep forms post to `/jobs/{job_id}/keep`; transient cards must post to the new transient tracking endpoint instead.
+
+### Test strategy hooks
+
+Unit tests:
+
+- `IngestionOrchestrator` does not create `JobPosting`, `JobSourceLink`, `JobDecision`, or `JobDecisionRule` for new untracked candidates.
+- Existing tracked match is updated and classified.
+- `manual_keep=True` with `tracking_status=None` is treated as untracked in cleanup.
+- Transient registry replaces source result set on subsequent successful run and clears on successful zero-job run.
+- Registry is thread-safe for concurrent source writes.
+- `TrackingService.track_transient_job()` persists job/link/decision/rules/event atomically.
+
+API/integration tests:
+
+- `POST /sources/{source_id}/run` followed by DB assertions: fetched count set, no untracked job rows.
+- `GET /ingestion/transient-jobs` returns current transient results.
+- Tracking a transient job returns created persisted job and survives app/session restart via DB.
+- Unknown/expired transient ID returns 404.
+- Batch ingestion stores transient results without cross-source overwrites.
+
+Migration tests:
+
+- Existing untracked rows and all dependents are deleted.
+- Existing tracked rows survive regardless of `manual_keep`.
+- Running cleanup twice succeeds and deletes nothing extra.
+
+### Rollback considerations
+
+- Code rollback after migration cannot restore deleted untracked rows. This is acceptable per product scope but should be noted in release notes.
+- If rollback is required before migration, revert code to old persistence behavior and do not run cleanup revision.
+- If rollback is required after migration, tracked jobs remain intact; old code may resume persisting new untracked jobs unless the migration/code change is re-applied.
+- The cleanup migration downgrade should not attempt restoration.

--- a/docs/backend/transient_untracked_ingestion_jobs_implementation_plan.md
+++ b/docs/backend/transient_untracked_ingestion_jobs_implementation_plan.md
@@ -3,6 +3,8 @@
 ## 1. Feature Overview
 Implement backend/data-layer support for transient untracked ingestion jobs so only jobs with non-null `tracking_status` are persisted.
 
+This remediation pass fixes QA-blocking full-suite failures caused by stale regression tests and in-memory SQLite test harness isolation after the transient untracked ingestion behavior change.
+
 ## 2. Technical Scope
 - Gate ingestion persistence to existing tracked job matches only.
 - Store new untracked ingestion candidates in a process-local transient registry.
@@ -10,11 +12,17 @@ Implement backend/data-layer support for transient untracked ingestion jobs so o
 - Add transient list/detail/tracking API paths.
 - Persist transient jobs and dependent records when a valid non-null tracking status is assigned.
 - Add cleanup migration for existing untracked persisted jobs and dependents.
+- Update stale tests that expected ingestion-created untracked jobs to be available from persisted `/jobs` JSON.
+- Ensure source-delete background cleanup tests use the shared test session instead of production `SessionLocal` under in-memory SQLite.
+- Update UI shell tests to use the repository `client` fixture and seed required test data.
+- Stabilize batch concurrency validation so it measures executor concurrency without threaded in-memory SQLite session contention.
 
 ## 3. Source Inputs
 - `docs/architecture/transient_untracked_ingestion_jobs_technical_design.md`
 - `docs/product/transient_untracked_ingestion_jobs_product_spec.md`
 - `docs/qa/transient_untracked_ingestion_jobs_test_plan.md`
+- `docs/qa/transient_untracked_ingestion_jobs_test_report.md`
+- `docs/bugs/transient_untracked_ingestion_jobs_full_suite_failures_bug_report.md`
 - `docs/release/transient_untracked_ingestion_jobs_issue.md`
 
 ## 4. API Contracts Affected
@@ -23,10 +31,14 @@ Implement backend/data-layer support for transient untracked ingestion jobs so o
 - `POST /ingestion/transient-jobs/{transient_job_id}/tracking-status` accepts `tracking_status` and optional `note_text`; returns `201` for newly persisted jobs, `200` for tracked duplicates, `400` invalid status, `404` missing transient ID, `409` legacy untracked DB conflict.
 - Existing persisted job endpoints remain unchanged.
 
+No API contract changes in the remediation pass.
+
 ## 5. Data Models / Storage Affected
 - No schema model changes.
 - Runtime-only `TransientIngestionJob` registry added; not durable.
 - Alembic cleanup deletes `job_postings.tracking_status IS NULL` and dependent `job_source_links`, `job_decisions`, `job_decision_rules`, `job_tracking_events`, `reminders`, and `digest_items`.
+
+No data model or storage changes in the remediation pass.
 
 ## 6. Files Expected to Change
 - `app/domain/ingestion.py`
@@ -37,6 +49,11 @@ Implement backend/data-layer support for transient untracked ingestion jobs so o
 - `app/web/routes.py`
 - `alembic/versions/20260501_0005_cleanup_untracked_jobs.py`
 - Backend tests and fixtures.
+- `tests/conftest.py` — shared test-session cleanup hook for background source delete tasks.
+- `tests/integration/test_html_views.py` — update ingestion helpers to explicitly track transient jobs before persisted job assertions.
+- `tests/ui/test_source_edit_delete_ui_qa.py` — update stale persisted-job setup.
+- `tests/ui/test_saas_dashboard_ui_revamp.py` — use shared client fixture and seed required shell data.
+- `tests/unit/test_source_batch_run_qa_validation.py` — avoid threaded in-memory SQLite DB access in concurrency-only assertion.
 
 ## 7. Security / Authorization Considerations
 Existing app has local single-user behavior. Transient IDs are opaque strings and never used for DB lookup. Tracking validates status server-side and persists only server-held transient data, not client-provided job fields.
@@ -47,8 +64,12 @@ No new dependencies. Uses existing SQLAlchemy, FastAPI, Alembic, classification,
 ## 9. Assumptions
 - Failed ingestion keeps the last successful transient set because replacement occurs only after successful adapter/classification processing.
 - `SourceRun.jobs_created_count` remains an ingestion-time persisted-created count and is not incremented when transient jobs are later tracked.
+- Source-delete API/UI tests that do not assert cleanup side effects may safely execute cleanup through the fixture session; source cleanup domain behavior remains covered by dedicated unit tests.
+- The batch concurrency QA test is intended to validate the `MAX_CONCURRENCY=5` executor contract, not SQLAlchemy/SQLite threading behavior.
 
 ## 10. Validation Plan
 - `python -m pytest tests/unit/test_transient_ingestion_jobs.py`
 - `python -m pytest tests/integration/test_api_flow.py`
 - Targeted migration/import validation as needed.
+- `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest` for the full suite if feasible.
+- At minimum, run all previously failing tests plus transient feature tests from the QA report.

--- a/docs/backend/transient_untracked_ingestion_jobs_implementation_plan.md
+++ b/docs/backend/transient_untracked_ingestion_jobs_implementation_plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan
+
+## 1. Feature Overview
+Implement backend/data-layer support for transient untracked ingestion jobs so only jobs with non-null `tracking_status` are persisted.
+
+## 2. Technical Scope
+- Gate ingestion persistence to existing tracked job matches only.
+- Store new untracked ingestion candidates in a process-local transient registry.
+- Add persistence-neutral classification previews.
+- Add transient list/detail/tracking API paths.
+- Persist transient jobs and dependent records when a valid non-null tracking status is assigned.
+- Add cleanup migration for existing untracked persisted jobs and dependents.
+
+## 3. Source Inputs
+- `docs/architecture/transient_untracked_ingestion_jobs_technical_design.md`
+- `docs/product/transient_untracked_ingestion_jobs_product_spec.md`
+- `docs/qa/transient_untracked_ingestion_jobs_test_plan.md`
+- `docs/release/transient_untracked_ingestion_jobs_issue.md`
+
+## 4. API Contracts Affected
+- `GET /ingestion/transient-jobs?source_id=<int>` returns `{ "items": [...] }` with current runtime transient jobs.
+- `GET /ingestion/transient-jobs/{transient_job_id}` returns transient detail or `404`.
+- `POST /ingestion/transient-jobs/{transient_job_id}/tracking-status` accepts `tracking_status` and optional `note_text`; returns `201` for newly persisted jobs, `200` for tracked duplicates, `400` invalid status, `404` missing transient ID, `409` legacy untracked DB conflict.
+- Existing persisted job endpoints remain unchanged.
+
+## 5. Data Models / Storage Affected
+- No schema model changes.
+- Runtime-only `TransientIngestionJob` registry added; not durable.
+- Alembic cleanup deletes `job_postings.tracking_status IS NULL` and dependent `job_source_links`, `job_decisions`, `job_decision_rules`, `job_tracking_events`, `reminders`, and `digest_items`.
+
+## 6. Files Expected to Change
+- `app/domain/ingestion.py`
+- `app/domain/classification.py`
+- `app/domain/transient_ingestion.py`
+- `app/domain/tracking.py`
+- `app/schemas.py`
+- `app/web/routes.py`
+- `alembic/versions/20260501_0005_cleanup_untracked_jobs.py`
+- Backend tests and fixtures.
+
+## 7. Security / Authorization Considerations
+Existing app has local single-user behavior. Transient IDs are opaque strings and never used for DB lookup. Tracking validates status server-side and persists only server-held transient data, not client-provided job fields.
+
+## 8. Dependencies / Constraints
+No new dependencies. Uses existing SQLAlchemy, FastAPI, Alembic, classification, and tracking conventions.
+
+## 9. Assumptions
+- Failed ingestion keeps the last successful transient set because replacement occurs only after successful adapter/classification processing.
+- `SourceRun.jobs_created_count` remains an ingestion-time persisted-created count and is not incremented when transient jobs are later tracked.
+
+## 10. Validation Plan
+- `python -m pytest tests/unit/test_transient_ingestion_jobs.py`
+- `python -m pytest tests/integration/test_api_flow.py`
+- Targeted migration/import validation as needed.

--- a/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
+++ b/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
@@ -1,0 +1,65 @@
+# Implementation Report
+
+## 1. Summary of Changes
+Implemented backend/data-layer support for transient untracked ingestion jobs. Ingestion now persists only existing tracked matches, stores newly discovered untracked jobs in runtime memory, exposes transient API endpoints, and persists transient jobs plus related artifacts when tracked.
+
+## 2. Files Modified
+- `app/domain/ingestion.py` — split tracked-match persistence from transient capture and added ingestion logging.
+- `app/domain/classification.py` — extracted persistence-neutral classification snapshots and reused them for persisted decisions.
+- `app/domain/transient_ingestion.py` — added thread-safe runtime transient registry and dataclasses.
+- `app/domain/tracking.py` — added transient tracking persistence flow for job/source link/decision/rules/event.
+- `app/schemas.py` — added transient list response schemas.
+- `app/web/routes.py` — added transient list/detail/tracking routes.
+- `alembic/versions/20260501_0005_cleanup_untracked_jobs.py` — added idempotent cleanup migration for untracked jobs and dependents.
+- `tests/conftest.py` — clears transient registry between tests.
+- `tests/unit/test_transient_ingestion_jobs.py` — added transient ingestion and tracking coverage.
+- `tests/integration/test_api_flow.py` — updated ingestion flow expectations to track transient jobs before persisted-job operations.
+- `docs/backend/transient_untracked_ingestion_jobs_implementation_plan.md` — implementation plan.
+
+## 3. API Contract Implementation
+Added:
+- `GET /ingestion/transient-jobs` with optional integer `source_id` filter.
+- `GET /ingestion/transient-jobs/{transient_job_id}` returning runtime detail or `404`.
+- `POST /ingestion/transient-jobs/{transient_job_id}/tracking-status` returning `201` for new persistence, `200` for duplicate tracked match, `400` invalid status, `404` missing transient ID, and `409` legacy untracked conflict.
+
+Existing persisted job endpoints remain unchanged.
+
+## 4. Data / Persistence Implementation
+No schema changes. Added cleanup migration for `tracking_status IS NULL` jobs and dependent rows. New ingestion of unmatched jobs creates only `SourceRun`; no `JobPosting`, `JobSourceLink`, `JobDecision`, or `JobDecisionRule` rows are created for transient candidates.
+
+## 5. Key Logic Implemented
+- Tracked = `tracking_status IS NOT NULL`; `manual_keep` is not used for persistence gating.
+- Existing tracked matches are updated and classified through the persisted path.
+- Newly discovered untracked candidates are classified with a persistence-neutral preview and stored in the transient registry.
+- Registry replaces per-source results on successful ingestion, deduping by source/external ID, normalized URL, or canonical key.
+- Tracking a transient job re-runs DB matching, persists or updates the tracked job, writes source link and classification records, emits tracking event, commits, then consumes the transient entry.
+
+## 6. Security / Authorization Implemented
+Follows existing local single-user routing. Transient IDs are opaque runtime IDs. Tracking validates status server-side and ignores any client-provided job data beyond status/note.
+
+## 7. Error Handling Implemented
+- Invalid transient tracking status raises `400`.
+- Missing/expired transient IDs raise `404`.
+- Legacy persisted untracked DB matches during transient tracking raise `409`.
+- Tracking transaction rolls back on exceptions and consumes the transient entry only after commit.
+
+## 8. Observability / Logging
+Ingestion logs fetched, persisted created/updated/unchanged, and transient capture counts.
+
+## 9. Assumptions Made
+- Failed ingestion leaves the previous successful transient set unchanged because registry replacement happens only after successful candidate processing.
+- `SourceRun.jobs_created_count` remains ingestion-time persisted effects only; later transient tracking does not mutate run counters.
+
+## 10. Validation Performed
+- `python -m pytest tests/unit/test_transient_ingestion_jobs.py tests/integration/test_api_flow.py` — failed: `python` command unavailable.
+- `python3 -m pytest tests/unit/test_transient_ingestion_jobs.py tests/integration/test_api_flow.py` — failed: `pytest` is not installed in the environment.
+- `python3 -m compileall app tests` — passed; application and test Python files compiled successfully.
+- `python3 -m compileall alembic/versions/20260501_0005_cleanup_untracked_jobs.py` — passed.
+- Backend import validation attempted with `python3`; blocked because runtime dependency `sqlalchemy` is not installed in the environment.
+
+## 11. Known Limitations / Follow-Ups
+- Full pytest execution could not be completed due to missing local test dependencies.
+- UI templates were not changed in this backend-focused pass; transient API support is present for UI integration.
+
+## 12. Commit Status
+Pending commit.

--- a/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
+++ b/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
@@ -62,4 +62,4 @@ Ingestion logs fetched, persisted created/updated/unchanged, and transient captu
 - UI templates were not changed in this backend-focused pass; transient API support is present for UI integration.
 
 ## 12. Commit Status
-Pending commit.
+Committed backend implementation in `2e16944` (`feat(backend): implement transient untracked ingestion jobs`).

--- a/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
+++ b/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
@@ -87,4 +87,4 @@ No logging or monitoring changes were made in the remediation pass.
 - Full suite is green locally. Remaining warnings are existing Alembic deprecation warnings in schema guard tests.
 
 ## 12. Commit Status
-Original backend implementation committed in `2e16944` (`feat(backend): implement transient untracked ingestion jobs`). Remediation commit pending at report update time.
+Original backend implementation committed in `2e16944` (`feat(backend): implement transient untracked ingestion jobs`). Remediation committed in `11dccf0` (`test(backend): remediate transient ingestion suite failures`).

--- a/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
+++ b/docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
@@ -3,6 +3,8 @@
 ## 1. Summary of Changes
 Implemented backend/data-layer support for transient untracked ingestion jobs. Ingestion now persists only existing tracked matches, stores newly discovered untracked jobs in runtime memory, exposes transient API endpoints, and persists transient jobs plus related artifacts when tracked.
 
+Remediated QA-blocking full-suite failures by updating stale tests/fixtures to align with transient untracked ingestion behavior and by stabilizing in-memory SQLite test harness boundaries.
+
 ## 2. Files Modified
 - `app/domain/ingestion.py` — split tracked-match persistence from transient capture and added ingestion logging.
 - `app/domain/classification.py` — extracted persistence-neutral classification snapshots and reused them for persisted decisions.
@@ -15,6 +17,11 @@ Implemented backend/data-layer support for transient untracked ingestion jobs. I
 - `tests/unit/test_transient_ingestion_jobs.py` — added transient ingestion and tracking coverage.
 - `tests/integration/test_api_flow.py` — updated ingestion flow expectations to track transient jobs before persisted-job operations.
 - `docs/backend/transient_untracked_ingestion_jobs_implementation_plan.md` — implementation plan.
+- `tests/conftest.py` — routes source-delete background cleanup through the shared fixture session during client tests so in-memory SQLite schema/data are visible.
+- `tests/integration/test_html_views.py` — tracks transient jobs before persisted `/jobs` JSON and persisted tracking-route assertions.
+- `tests/ui/test_source_edit_delete_ui_qa.py` — tracks transient jobs before source-delete UI assertions that need a persisted job.
+- `tests/ui/test_saas_dashboard_ui_revamp.py` — uses the shared `client` fixture instead of a module-level `TestClient(app)` and seeds required persisted job/source data.
+- `tests/unit/test_source_batch_run_qa_validation.py` — keeps the concurrency assertion but avoids threaded in-memory SQLite session access by faking per-source execution at the executor seam.
 
 ## 3. API Contract Implementation
 Added:
@@ -24,8 +31,12 @@ Added:
 
 Existing persisted job endpoints remain unchanged.
 
+No API contract changes were made in the remediation pass.
+
 ## 4. Data / Persistence Implementation
 No schema changes. Added cleanup migration for `tracking_status IS NULL` jobs and dependent rows. New ingestion of unmatched jobs creates only `SourceRun`; no `JobPosting`, `JobSourceLink`, `JobDecision`, or `JobDecisionRule` rows are created for transient candidates.
+
+No data model or storage changes were made in the remediation pass.
 
 ## 5. Key Logic Implemented
 - Tracked = `tracking_status IS NOT NULL`; `manual_keep` is not used for persistence gating.
@@ -33,9 +44,14 @@ No schema changes. Added cleanup migration for `tracking_status IS NULL` jobs an
 - Newly discovered untracked candidates are classified with a persistence-neutral preview and stored in the transient registry.
 - Registry replaces per-source results on successful ingestion, deduping by source/external ID, normalized URL, or canonical key.
 - Tracking a transient job re-runs DB matching, persists or updates the tracked job, writes source link and classification records, emits tracking event, commits, then consumes the transient entry.
+- Stale regression helpers now explicitly track transient jobs before asserting persisted job list/detail/tracking behavior.
+- UI shell tests now receive normal test dependency overrides and schema setup via the repository fixture.
+- The batch executor concurrency test now validates the five-worker cap without relying on unsafe threaded access to one in-memory SQLite connection.
 
 ## 6. Security / Authorization Implemented
 Follows existing local single-user routing. Transient IDs are opaque runtime IDs. Tracking validates status server-side and ignores any client-provided job data beyond status/note.
+
+Remediation changes are test/fixture-only and do not alter authentication, authorization, or production input handling.
 
 ## 7. Error Handling Implemented
 - Invalid transient tracking status raises `400`.
@@ -43,12 +59,18 @@ Follows existing local single-user routing. Transient IDs are opaque runtime IDs
 - Legacy persisted untracked DB matches during transient tracking raise `409`.
 - Tracking transaction rolls back on exceptions and consumes the transient entry only after commit.
 
+No production error handling changes were made in the remediation pass.
+
 ## 8. Observability / Logging
 Ingestion logs fetched, persisted created/updated/unchanged, and transient capture counts.
+
+No logging or monitoring changes were made in the remediation pass.
 
 ## 9. Assumptions Made
 - Failed ingestion leaves the previous successful transient set unchanged because registry replacement happens only after successful candidate processing.
 - `SourceRun.jobs_created_count` remains ingestion-time persisted effects only; later transient tracking does not mutate run counters.
+- Source-delete API/UI tests that do not assert cleanup side effects may safely execute cleanup through the fixture session; source cleanup domain behavior remains covered by dedicated unit tests.
+- The batch concurrency QA test is intended to validate the executor concurrency limit, not SQLite/threading behavior.
 
 ## 10. Validation Performed
 - `python -m pytest tests/unit/test_transient_ingestion_jobs.py tests/integration/test_api_flow.py` — failed: `python` command unavailable.
@@ -56,10 +78,13 @@ Ingestion logs fetched, persisted created/updated/unchanged, and transient captu
 - `python3 -m compileall app tests` — passed; application and test Python files compiled successfully.
 - `python3 -m compileall alembic/versions/20260501_0005_cleanup_untracked_jobs.py` — passed.
 - Backend import validation attempted with `python3`; blocked because runtime dependency `sqlalchemy` is not installed in the environment.
+- `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest tests/integration/test_html_views.py tests/ui/test_source_edit_delete_ui_qa.py tests/ui/test_saas_dashboard_ui_revamp.py tests/api/test_source_edit_delete_qa.py tests/integration/test_api_flow.py::test_source_patch_delete_and_delete_impact_flow tests/integration/test_api_flow.py::test_deleted_sources_are_removed_from_html_filters_and_inactive_sources_cannot_run tests/integration/test_source_edit_delete_html.py::test_source_delete_html_flow_hides_deleted_source_from_management_surfaces tests/unit/test_source_batch_run_qa_validation.py::test_batch_executor_never_exceeds_five_concurrent_source_runs` — passed: `23 passed in 0.64s`.
+- `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest tests/unit/test_transient_ingestion_jobs.py tests/api/test_transient_untracked_ingestion_jobs_qa.py tests/integration/test_transient_untracked_cleanup_migration_qa.py tests/ui/test_transient_ingestion_jobs_ui.py tests/ui/test_hide_rejected_job_openings_ui.py` — passed: `15 passed in 0.38s`.
+- `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest` — passed: `130 passed, 4 warnings in 3.22s`.
+- `python3 -m compileall app tests` — passed.
 
 ## 11. Known Limitations / Follow-Ups
-- Full pytest execution could not be completed due to missing local test dependencies.
-- UI templates were not changed in this backend-focused pass; transient API support is present for UI integration.
+- Full suite is green locally. Remaining warnings are existing Alembic deprecation warnings in schema guard tests.
 
 ## 12. Commit Status
-Committed backend implementation in `2e16944` (`feat(backend): implement transient untracked ingestion jobs`).
+Original backend implementation committed in `2e16944` (`feat(backend): implement transient untracked ingestion jobs`). Remediation commit pending at report update time.

--- a/docs/bugs/transient_untracked_ingestion_jobs_full_suite_failures_bug_report.md
+++ b/docs/bugs/transient_untracked_ingestion_jobs_full_suite_failures_bug_report.md
@@ -1,0 +1,319 @@
+# Bug Report
+
+## 1. Summary
+
+Full regression validation for `feature/transient_untracked_ingestion_jobs` is blocked by three failure groups: stale tests that still expect ingestion to persist untracked jobs, SQLite in-memory session/thread isolation in source-delete/background-cleanup and batch-executor tests, and UI shell tests that instantiate the app without the repository test DB fixture.
+
+## 2. Investigation Context
+
+- Source of report: QA full-suite regression.
+- Branch: `feature/transient_untracked_ingestion_jobs`.
+- Related feature/workflow: transient untracked ingestion jobs.
+- QA report: `docs/qa/transient_untracked_ingestion_jobs_test_report.md`.
+- Failing QA command: `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest`.
+- Reproduction performed locally on 2026-05-01:
+  - Full suite reproduced 17 failures, 113 passed, 4 warnings.
+  - Isolated batch executor test reproduced the 18th QA-reported failure.
+
+## 3. Observed Symptoms
+
+### Group A: tests still expect newly ingested untracked jobs in persisted `/jobs` JSON
+
+Affected tests observed in full-suite output:
+
+- `tests/integration/test_html_views.py::test_dashboard_and_jobs_html_render`
+- `tests/integration/test_html_views.py::test_html_forms_redirect_for_source_and_tracking`
+- `tests/integration/test_html_views.py::test_jobs_html_treats_empty_source_filter_as_unset`
+- `tests/ui/test_source_edit_delete_ui_qa.py::test_source_delete_confirmation_explains_async_cleanup_and_retention`
+- `tests/ui/test_source_edit_delete_ui_qa.py::test_deleted_source_non_retained_job_uses_normal_not_found`
+
+Exact failure shape:
+
+- `IndexError: list index out of range` at `client.get("/jobs").json()[0]`.
+- Examples:
+  - `tests/integration/test_html_views.py:48`
+  - `tests/integration/test_html_views.py:76`
+  - `tests/ui/test_source_edit_delete_ui_qa.py:74`
+  - `tests/ui/test_source_edit_delete_ui_qa.py:195`
+
+Expected by old tests: ingestion creates a persisted job row immediately, so `/jobs` JSON contains at least one item.
+
+Expected by current feature spec: new untracked ingestion results are transient runtime data only and are not returned by persisted JSON `/jobs` until the user tracks them.
+
+### Group B: source delete tests fail when background cleanup opens a different in-memory SQLite session
+
+Affected tests observed in full-suite output:
+
+- `tests/api/test_source_edit_delete_qa.py::test_deleted_and_nonexistent_source_endpoints_return_not_found`
+- `tests/integration/test_api_flow.py::test_source_patch_delete_and_delete_impact_flow`
+- `tests/integration/test_api_flow.py::test_deleted_sources_are_removed_from_html_filters_and_inactive_sources_cannot_run`
+- `tests/integration/test_source_edit_delete_html.py::test_source_delete_html_flow_hides_deleted_source_from_management_surfaces`
+
+Exact failure excerpt:
+
+```text
+sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: sources
+[SQL: SELECT sources.id AS sources_id, ... FROM sources WHERE sources.id = ?]
+[parameters: (1,)]
+```
+
+Stack path:
+
+```text
+app/web/routes.py:845 enqueue_source_delete_cleanup(background_tasks, source.id)
+app/web/routes.py:440 background_tasks.add_task(run_source_delete_cleanup, source_id)
+app/domain/source_cleanup.py:156 run_source_delete_cleanup
+app/domain/source_cleanup.py:157 from app.persistence.db import SessionLocal
+app/domain/source_cleanup.py:159 with SessionLocal() as session
+app/domain/source_cleanup.py:160 SourceDeleteCleanupService(session).cleanup_source(source_id)
+app/domain/source_cleanup.py:42 source = self.session.get(Source, source_id)
+```
+
+### Group C: global UI shell tests use app `SessionLocal` without test schema/fixtures
+
+Affected tests observed in full-suite output:
+
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_dashboard_renders_html_shell`
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_jobs_index_renders_management_table_ui`
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_job_detail_renders_html_detail_view`
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_sources_index_renders_management_table_ui`
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_detail_renders_html_detail_view`
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_create_validation_uses_html_error_state`
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_source_health_renders_in_shared_shell`
+- `tests/ui/test_saas_dashboard_ui_revamp.py::test_tracking_page_renders_in_shared_shell`
+
+Exact failure shape:
+
+- HTML shell requests return `500 Internal Server Error` instead of expected `200` or `400`.
+- `tests/ui/test_saas_dashboard_ui_revamp.py:7` defines `client = TestClient(app, raise_server_exceptions=False)` at module scope.
+- These tests do not use the repository `client` fixture in `tests/conftest.py`, so they do not get `Base.metadata.create_all(engine)` or `app.dependency_overrides[get_session_dependency]`.
+
+### Group D: isolated batch executor test marks successful fake runs as failed under threaded in-memory SQLite
+
+Affected test:
+
+- `tests/unit/test_source_batch_run_qa_validation.py::test_batch_executor_never_exceeds_five_concurrent_source_runs`
+
+Isolated reproduction:
+
+```text
+assert status.status == "completed"
+E AssertionError: assert 'completed_with_failures' == 'completed'
+```
+
+Captured root exception before the failed status:
+
+```text
+ERROR app.domain.source_batch_runs:source_batch_runs.py:405 source batch attempt raised
+sqlalchemy.exc.InterfaceError: (sqlite3.InterfaceError) bad parameter or other API misuse
+[SQL: SELECT sources.id AS sources_id, ... FROM sources WHERE sources.id = ?]
+[parameters: (4,)]
+```
+
+Failure point:
+
+```text
+app/domain/source_batch_runs.py:366 with self.session_factory() as session
+app/domain/source_batch_runs.py:367 source = session.get(Source, source_ref.source_id)
+```
+
+## 4. Evidence Collected
+
+Files inspected:
+
+- `docs/qa/transient_untracked_ingestion_jobs_test_report.md`
+- `docs/product/transient_untracked_ingestion_jobs_product_spec.md`
+- `tests/conftest.py`
+- `tests/integration/test_html_views.py`
+- `tests/ui/test_source_edit_delete_ui_qa.py`
+- `tests/ui/test_saas_dashboard_ui_revamp.py`
+- `tests/api/test_source_edit_delete_qa.py`
+- `tests/integration/test_api_flow.py`
+- `tests/integration/test_source_edit_delete_html.py`
+- `tests/unit/test_source_batch_run_qa_validation.py`
+- `app/domain/ingestion.py`
+- `app/domain/tracking.py`
+- `app/domain/source_cleanup.py`
+- `app/domain/source_batch_runs.py`
+- `app/persistence/db.py`
+- `app/web/routes.py`
+
+Key evidence:
+
+- Product spec requires no DB persistence for newly ingested untracked jobs: `docs/product/transient_untracked_ingestion_jobs_product_spec.md:69-83`, especially FR 3-4 and 10-12.
+- Ingestion implementation matches that rule: `app/domain/ingestion.py:41-54` resolves only persisted tracked matches; otherwise appends candidates to `transient_jobs`; `app/domain/ingestion.py:54` replaces runtime registry results.
+- JSON `/jobs` remains persisted-only: `app/web/routes.py:985-990` returns `jobs` before HTML transient-card merge.
+- HTML `/jobs` merges transient cards only for HTML responses: `app/web/routes.py:992-1000`.
+- Test DB fixture creates a per-test StaticPool in-memory DB and overrides only request dependency injection: `tests/conftest.py:24-49`.
+- Source cleanup bypasses the request dependency override and imports production `SessionLocal`: `app/domain/source_cleanup.py:156-160`.
+- App `SessionLocal` is bound once to `app.persistence.db.engine`: `app/persistence/db.py:17-19`; for `sqlite+pysqlite:///:memory:` it does not create schema by itself.
+- UI shell tests bypass the fixture: `tests/ui/test_saas_dashboard_ui_revamp.py:7`.
+- Batch executor test shares the test session bind across multiple worker sessions/threads: `tests/unit/test_source_batch_run_qa_validation.py:95-99`; helper `build_session_factory_from_session` binds new sessions to `session.get_bind()`: `app/domain/source_batch_runs.py:436-437`.
+
+## 5. Execution Path / Failure Trace
+
+### Group A
+
+1. Test creates a source and runs ingestion.
+2. `IngestionOrchestrator.run_source` receives one new candidate.
+3. `_resolve_persisted_tracked_match` finds no persisted job with non-null `tracking_status`.
+4. Candidate is added to `transient_ingestion_registry`, not persisted.
+5. Test calls JSON `/jobs`; route returns only persisted DB jobs.
+6. Empty list causes `json()[0]` `IndexError`.
+
+### Group B
+
+1. Test uses fixture-backed session with schema created in `tests/conftest.py`.
+2. Delete endpoint soft-deletes the source using the fixture session.
+3. Response background task calls `run_source_delete_cleanup`.
+4. Cleanup opens `app.persistence.db.SessionLocal`, not the fixture session/dependency override.
+5. With `DATABASE_URL=sqlite+pysqlite:///:memory:`, that session points at a different in-memory DB/connection without the test-created schema.
+6. Querying `sources` raises `no such table: sources`.
+
+### Group C
+
+1. Module-level `TestClient(app, raise_server_exceptions=False)` sends requests without the `client` fixture.
+2. No test schema is created for app `SessionLocal`; no dependency override is installed.
+3. Routes query app DB through normal dependency wiring.
+4. Under in-memory `DATABASE_URL`, schema is absent, so requests return 500.
+
+### Group D
+
+1. Test creates a StaticPool in-memory DB fixture session and 12 sources.
+2. Batch executor runs up to five worker threads.
+3. `build_session_factory_from_session(session)` creates new sessions bound to the same test bind.
+4. Multiple worker sessions concurrently call `session.get(Source, ...)` against SQLite in-memory/shared connection state.
+5. SQLite raises `InterfaceError: bad parameter or other API misuse` in at least one worker.
+6. `_run_source_with_retries` catches the exception, retries, and eventually records source failure(s).
+7. Registry marks batch `completed_with_failures`.
+
+## 6. Failure Classification
+
+| Group | Primary classification | QA/product disposition | Severity | Routing |
+| --- | --- | --- | --- | --- |
+| A: persisted `/jobs` expectations | Test Bug | Stale test expectations after approved feature behavior change | High for CI health; not a product defect | QA test update |
+| B: background cleanup `SessionLocal` with in-memory DB | Environment / Configuration Issue | Test infrastructure issue exposed by background task/session boundary | High for CI health | QA test update with backend guidance |
+| C: global UI client without fixture DB | Environment / Configuration Issue | Test infrastructure issue; fixture bypass | High for CI health | QA test update |
+| D: batch executor threaded SQLite `InterfaceError` | Environment / Configuration Issue | Test infrastructure issue in threaded in-memory SQLite harness | Medium for CI health | QA test update with backend guidance |
+
+## 7. Root Cause Analysis
+
+### Group A: Confirmed Root Cause
+
+Immediate failure point: tests index into an empty JSON `/jobs` list.
+
+Underlying root cause: affected tests encode pre-feature behavior where ingestion persisted all fetched jobs. The current product spec and implementation intentionally keep new untracked ingestion results transient and exclude them from persisted JSON `/jobs`.
+
+Supporting evidence:
+
+- Spec: `docs/product/transient_untracked_ingestion_jobs_product_spec.md:71-79`.
+- Implementation: `app/domain/ingestion.py:41-54` and `app/web/routes.py:985-990`.
+- Failing assertions/indexing: `tests/integration/test_html_views.py:48`, `tests/integration/test_html_views.py:76`, `tests/ui/test_source_edit_delete_ui_qa.py:74`, `tests/ui/test_source_edit_delete_ui_qa.py:195`.
+
+### Group B: Confirmed Root Cause
+
+Immediate failure point: background cleanup queries `sources` in a DB connection without schema.
+
+Underlying root cause: `run_source_delete_cleanup` opens production `SessionLocal` instead of using the fixture-overridden request session. In-memory SQLite DBs are connection/engine scoped, so the cleanup session does not see `Base.metadata.create_all(engine)` from `tests/conftest.py`.
+
+Supporting evidence:
+
+- Fixture setup: `tests/conftest.py:24-49`.
+- Cleanup session path: `app/domain/source_cleanup.py:156-160`.
+- Error: `sqlite3.OperationalError: no such table: sources` at `app/domain/source_cleanup.py:42`.
+
+### Group C: Confirmed Root Cause
+
+Immediate failure point: HTML shell tests receive 500 responses.
+
+Underlying root cause: `tests/ui/test_saas_dashboard_ui_revamp.py` creates a module-level client without the repository `client` fixture, so test DB schema and dependency overrides are not applied under in-memory DB configuration.
+
+Supporting evidence:
+
+- Global client: `tests/ui/test_saas_dashboard_ui_revamp.py:7`.
+- Fixture it bypasses: `tests/conftest.py:42-49`.
+- Observed failures: 500 responses across dashboard/jobs/sources/source-health/tracking endpoints.
+
+### Group D: Most Likely Root Cause
+
+Immediate failure point: batch status is `completed_with_failures` after source worker exceptions.
+
+Underlying root cause: threaded test harness opens multiple sessions against a SQLite in-memory/StaticPool bind derived from one fixture session. Concurrent worker DB reads raise SQLite `InterfaceError`, which the executor records as source failures.
+
+Supporting evidence:
+
+- Test uses threaded executor with shared bind: `tests/unit/test_source_batch_run_qa_validation.py:95-99` and `app/domain/source_batch_runs.py:436-437`.
+- Isolated reproduction captured `sqlite3.InterfaceError: bad parameter or other API misuse` at `app/domain/source_batch_runs.py:367`.
+- Executor converts worker failures into failed source results and final `completed_with_failures`: `app/domain/source_batch_runs.py:403-420` and `app/domain/source_batch_runs.py:125-130`.
+
+## 8. Confidence Level
+
+High overall.
+
+- Groups A, B, and C are confirmed by direct code paths plus reproduced error messages.
+- Group D is high-confidence but labeled “Most Likely” because the failure is concurrency/environment-sensitive; the captured exception directly explains the observed `completed_with_failures`, but production behavior with a non-in-memory DB was not validated here.
+
+## 9. Recommended Fix
+
+### Group A
+
+- Likely owner: QA test update.
+- Files: `tests/integration/test_html_views.py`, `tests/ui/test_source_edit_delete_ui_qa.py`, and any helper that seeds a job via ingestion then immediately reads JSON `/jobs`.
+- Expected correction: update fixtures to either:
+  - track the transient job through `/ingestion/transient-jobs/{id}/tracking-status` before asserting persisted `/jobs`/detail behavior, or
+  - assert transient HTML/API behavior where the scenario is intended to cover untracked ingestion results.
+- Constraint: do not restore persistence of untracked ingestion jobs; that would violate the feature spec.
+
+### Group B
+
+- Likely owner: QA test update with backend guidance.
+- Files: source-delete tests listed above; possible shared fixture support in `tests/conftest.py`.
+- Expected correction: ensure background cleanup uses a test-visible session/engine when tests execute under in-memory SQLite. Options include monkeypatching `app.web.routes.run_source_delete_cleanup` for tests that do not validate cleanup, using a file-backed SQLite DB for background-task tests, or introducing an injectable cleanup session factory in test configuration.
+- Constraint: production cleanup opening its own `SessionLocal` is appropriate for an async/background task; avoid changing production behavior solely to satisfy in-memory test isolation unless introducing a clean injectable seam.
+
+### Group C
+
+- Likely owner: QA test update.
+- File: `tests/ui/test_saas_dashboard_ui_revamp.py`.
+- Expected correction: remove module-level `TestClient(app, raise_server_exceptions=False)` and use the repository `client` fixture, or create schema and dependency overrides equivalent to `tests/conftest.py`.
+
+### Group D
+
+- Likely owner: QA test update with backend guidance.
+- File: `tests/unit/test_source_batch_run_qa_validation.py`; optionally fixture/session factory helper.
+- Expected correction: avoid threaded SQLite in-memory shared-connection misuse. Prefer a file-backed SQLite test DB for this concurrency test, a thread-safe per-worker engine/session factory, or monkeypatch `_run_source_with_retries`/source lookup if the test only intends to validate max concurrency.
+- Constraint: do not change `SourceBatchExecutor` retry/failure marking unless a backend reproduction proves the same failure with production-like DB configuration.
+
+## 10. Suggested Validation Steps
+
+After remediation:
+
+1. Re-run targeted feature validation from QA report:
+   - `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest tests/unit/test_transient_ingestion_jobs.py tests/api/test_transient_untracked_ingestion_jobs_qa.py tests/integration/test_transient_untracked_cleanup_migration_qa.py tests/ui/test_transient_ingestion_jobs_ui.py tests/ui/test_hide_rejected_job_openings_ui.py`
+2. Re-run stale expectation tests after updating their setup:
+   - `tests/integration/test_html_views.py`
+   - `tests/ui/test_source_edit_delete_ui_qa.py`
+3. Re-run source delete/background cleanup tests:
+   - `tests/api/test_source_edit_delete_qa.py`
+   - `tests/integration/test_api_flow.py::test_source_patch_delete_and_delete_impact_flow`
+   - `tests/integration/test_api_flow.py::test_deleted_sources_are_removed_from_html_filters_and_inactive_sources_cannot_run`
+   - `tests/integration/test_source_edit_delete_html.py::test_source_delete_html_flow_hides_deleted_source_from_management_surfaces`
+4. Re-run UI shell test module after fixture correction:
+   - `tests/ui/test_saas_dashboard_ui_revamp.py`
+5. Re-run isolated batch concurrency test repeatedly after test-harness correction:
+   - `tests/unit/test_source_batch_run_qa_validation.py::test_batch_executor_never_exceeds_five_concurrent_source_runs`
+6. Re-run full suite:
+   - `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest`
+
+Expected result: full suite green with no restoration of persisted untracked ingestion jobs.
+
+## 11. Open Questions / Missing Evidence
+
+- Why the local full-suite rerun reported 17 failures while QA reported 18: the batch executor failure reproduced reliably in isolation but was not included as failed in the local full-suite summary. This suggests ordering or concurrency sensitivity in that test.
+- No production-like file-backed/PostgreSQL run was performed for the batch executor. Needed only if backend wants to rule out a production concurrency defect.
+
+## 12. Final Investigator Decision
+
+Ready for developer fix.
+
+Primary remediation should be routed to QA test updates/test infrastructure, not production feature implementation. No evidence currently requires changing the transient untracked ingestion production behavior.

--- a/docs/frontend/transient_untracked_ingestion_jobs_implementation_plan.md
+++ b/docs/frontend/transient_untracked_ingestion_jobs_implementation_plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan
+
+## 1. Feature Overview
+Expose backend transient untracked ingestion jobs on the existing Jobs review surface, clearly mark them as temporary, and allow users to assign a non-null tracking status to save them as persisted tracked jobs.
+
+## 2. Technical Scope
+- Augment `/jobs` HTML rendering with persisted tracked/actionable jobs plus current transient ingestion jobs from the runtime registry.
+- Keep JSON `/jobs` behavior persisted-only; transient API endpoints remain separate.
+- Add a runtime-safe transient detail route for HTML review.
+- Submit transient tracking forms to `POST /ingestion/transient-jobs/{transient_job_id}/tracking-status`.
+- Add progressive enhancement for saving/loading state without requiring JavaScript.
+
+## 3. UI/UX Inputs
+- Jobs page must show a Temporary ingestion results callout only when transient results are present.
+- Results summary must distinguish tracked and temporary counts.
+- Transient rows/cards must show visible `Temporary` text and screen-reader clarification.
+- Transient details must not link to persisted `/jobs/{job_id}` until after tracking succeeds.
+- Tracking controls must include accessible labels and saving feedback.
+
+## 4. Files Expected to Change
+- `app/web/routes.py`
+- `app/web/templates/includes/macros.html`
+- `app/web/templates/jobs/list.html`
+- `app/web/templates/jobs/transient_detail.html`
+- `app/web/static/styles.css`
+- `app/web/static/app.js`
+- `tests/ui/test_transient_ingestion_jobs_ui.py`
+- `docs/frontend/transient_untracked_ingestion_jobs_implementation_report.md`
+
+## 5. Dependencies / Constraints
+- Backend transient registry and tracking APIs are available on the current branch.
+- Transient data is runtime-only and must not be read from persisted untracked rows.
+- Existing persisted job tracking and keep behavior must remain unchanged.
+- No new primary navigation item is allowed.
+
+## 6. Assumptions
+- `/jobs` filters should apply to transient results where equivalent fields exist; a non-empty tracking status filter excludes transient results because their tracking status is null.
+- Failed ingestion refresh behavior is backend-owned; UI displays current registry contents and existing flash copy.
+
+## 7. Validation Plan
+- Add UI tests for mixed persisted/transient jobs, temporary callout/badge/count summary, runtime-safe links, and transient tracking form action/labels.
+- Run focused UI/integration tests plus the existing transient unit tests.
+- Run the full pytest suite if time/environment allows.

--- a/docs/frontend/transient_untracked_ingestion_jobs_implementation_report.md
+++ b/docs/frontend/transient_untracked_ingestion_jobs_implementation_report.md
@@ -1,0 +1,45 @@
+# Implementation Report
+
+## 1. Summary of Changes
+- Added transient ingestion jobs to the `/jobs` HTML review surface alongside persisted jobs.
+- Added visible temporary callout, `Temporary` badges, accessible screen-reader copy, and count summary separating tracked versus temporary results.
+- Added runtime-safe transient detail pages at `/jobs/transient/{transient_job_id}`.
+- Wired transient tracking forms to `POST /ingestion/transient-jobs/{transient_job_id}/tracking-status` with progressive saving-state enhancement.
+- Added source-run success copy that references temporary untracked results when available.
+
+## 2. Files Modified
+- `app/web/routes.py`
+- `app/templates/jobs/list.html`
+- `app/templates/jobs/transient_detail.html`
+- `app/templates/macros/ui.html`
+- `app/static/css/app.css`
+- `app/static/js/app.js`
+- Mirrored duplicate template/static changes under `app/web/...` for repository consistency.
+- `tests/ui/test_transient_ingestion_jobs_ui.py`
+- `docs/frontend/transient_untracked_ingestion_jobs_implementation_plan.md`
+
+## 3. UI Behavior Implemented
+- `/jobs` displays persisted jobs and current runtime transient ingestion jobs for HTML requests.
+- JSON `/jobs` remains persisted-only; transient API endpoints remain separate.
+- Transient rows link to `/jobs/transient/{transient_job_id}`, not `/jobs/{id}`.
+- Transient tracking forms require a non-empty tracking status and submit to the new backend transient tracking endpoint.
+- JavaScript disables the transient status select/button on submit, sets `aria-busy="true"`, and changes button text to `Saving…`.
+- Missing transient details render a clear unavailable message with `404` status.
+
+## 4. Assumptions Made
+- Existing `/jobs` filters apply to transient results where equivalent fields exist.
+- Non-empty tracking-status filters exclude transient jobs because transient jobs have no tracking status until saved.
+- Existing duplicate template/static trees should remain synchronized.
+
+## 5. Validation Performed
+- Passed: `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest tests/ui/test_transient_ingestion_jobs_ui.py tests/unit/test_transient_ingestion_jobs.py`
+- Passed: `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest tests/ui/test_transient_ingestion_jobs_ui.py tests/unit/test_transient_ingestion_jobs.py tests/ui/test_hide_rejected_job_openings_ui.py`
+- Full suite attempted with `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest`; result: 108 passed, 18 failed. Failures are existing/stale-test or environment-style regressions unrelated to the UI change, primarily tests still expecting ingestion-created untracked jobs in `/jobs` JSON and background cleanup tests using a separate empty in-memory DB connection.
+- Initial `pytest`/`python -m pytest` commands could not run because global `pytest`/`python` were unavailable; validation used `uv run`.
+
+## 6. Known Limitations / Follow-Ups
+- Full-suite failures require upstream test updates for the new transient-only ingestion behavior and/or test DB configuration cleanup.
+- The app has duplicate active/legacy template and static directories; changes were mirrored to reduce drift.
+
+## 7. Commit Status
+- Included in the frontend implementation commit for this work.

--- a/docs/product/transient_untracked_ingestion_jobs_product_spec.md
+++ b/docs/product/transient_untracked_ingestion_jobs_product_spec.md
@@ -1,0 +1,149 @@
+# Product Specification
+
+## 1. Feature Overview
+
+Change ingestion persistence behavior so jobs returned by ingestion are persisted to the local database only when they are tracked.
+
+Untracked ingestion results must remain available only as transient runtime/app-state data for the current session or current ingestion result set. They must not be written to the local database and must not survive an app restart. Existing untracked database jobs must be removed from persistent storage.
+
+When a transient untracked job is later tracked by the user, the system must persist the job and its related ingestion artifacts at that moment.
+
+## 2. Problem Statement
+
+The current ingestion flow persists all returned jobs, including jobs the user has not chosen to track. This causes the local database to accumulate untracked jobs, related source links, classification data, and ingestion metadata that may never become part of the user's active job-search workflow.
+
+This creates unnecessary persistent data growth, makes database state less representative of intentional user tracking decisions, and allows untracked ingestion results to survive app restarts even though they should only represent the latest discovered opportunities.
+
+## 3. User Persona / Target User
+
+- Primary user: the single-user job seeker operating the app locally/self-hosted.
+- Usage context: the user runs ingestion, reviews returned jobs, and chooses which jobs to track for ongoing application workflow management.
+
+## 4. User Stories
+
+- As a job seeker, I want newly ingested untracked jobs to be visible for review without being permanently stored, so that my database contains only intentional tracked jobs.
+- As a job seeker, I want an ingested job that I decide to track to be saved with its context, so that I can manage it after the current ingestion cycle.
+- As a job seeker, I want already tracked jobs to continue updating during ingestion, so that tracked opportunities stay current.
+- As a job seeker, I want old untracked persisted jobs removed, so that the app state is consistent with the new persistence rule.
+
+## 5. Goals / Success Criteria
+
+- Ingestion no longer persists jobs whose `tracking_status` is `NULL`.
+- `manual_keep` is not used to determine whether a job is persisted.
+- Jobs with any non-null `tracking_status` continue to be persisted and updated.
+- Existing database jobs with `tracking_status IS NULL` are removed, including related source links and classification data as applicable.
+- Transient untracked ingestion results remain visible only in current runtime/app state until ingestion runs again or the app restarts.
+- When a transient job is tracked, the system persists the job, source link, classification result, and ingestion metadata to the database at that moment.
+
+## 6. Feature Scope
+
+### In Scope
+
+- Change ingestion behavior so untracked returned jobs are not inserted into the local database.
+- Preserve current update behavior for returned jobs that match already tracked database jobs.
+- Maintain transient visibility of untracked ingestion results in current runtime/app state.
+- Replace or refresh transient untracked ingestion results when ingestion triggers again.
+- Persist a transient job and its required related records when the user assigns a non-null tracking status.
+- Clean up existing persisted jobs where `tracking_status IS NULL`.
+- Clean up dependent records for removed untracked jobs where those records are owned by or only valid with the removed job.
+
+### Out of Scope
+
+- Changing available tracking status values.
+- Changing classification rules, scoring, or bucket assignment logic.
+- Changing source adapters or external ingestion fetch behavior.
+- Using `manual_keep` as a persistence rule.
+- Adding multi-user behavior or cloud synchronization.
+- Adding an archive/restore flow for removed untracked jobs.
+- Preserving transient untracked jobs across app restart.
+- Redesigning the job review UI beyond changes required to support transient results.
+
+### Future Considerations
+
+- User-configurable retention policies for untracked jobs.
+- Optional local cache with explicit expiration for untracked ingestion results.
+- Analytics comparing transient reviewed jobs versus tracked jobs.
+
+## 7. Functional Requirements
+
+1. The system must define a tracked job as any job with `tracking_status IS NOT NULL`.
+2. The system must define an untracked job as any job with `tracking_status IS NULL`.
+3. During ingestion, the system must not create a persisted job record for a newly returned job when that job has no non-null `tracking_status`.
+4. During ingestion, the system must not create persisted source-link, classification-result, or ingestion-metadata records for newly returned untracked jobs.
+5. During ingestion, newly returned untracked jobs must remain available in current runtime/app state for user review until ingestion triggers again or the app restarts.
+6. When ingestion triggers again, the system must refresh the transient untracked result set according to the latest ingestion output rather than relying on previously persisted untracked jobs.
+7. If ingestion returns a job that matches an already tracked database job, the system must update the existing tracked job and source link according to current update behavior.
+8. The system must not use `manual_keep` to decide whether a job is persisted, retained, or cleaned up.
+9. A job with `manual_keep = true` and `tracking_status IS NULL` must be treated as untracked for persistence and cleanup.
+10. When the user assigns a non-null `tracking_status` to a transient job, the system must persist the job record at that moment.
+11. When the user tracks a transient job, the system must also persist the job's source link, latest classification result, and ingestion metadata required to represent the job as a normal tracked database job.
+12. Once persisted through tracking, the job must behave like any other tracked job in job lists, detail views, source attribution, classifications, and future ingestion updates.
+13. The system must remove existing database jobs where `tracking_status IS NULL` as part of this feature's data cleanup.
+14. Cleanup must remove or safely delete related source links and classification data for removed untracked jobs as applicable to prevent orphaned or invalid records.
+15. Cleanup must not delete jobs where `tracking_status IS NOT NULL`, regardless of `manual_keep` value.
+16. Cleanup must be safe to run more than once without deleting tracked jobs or failing because previously targeted untracked records were already removed.
+
+## 8. Acceptance Criteria
+
+- AC-01: Given ingestion returns a new job with `tracking_status IS NULL`, when ingestion completes, then no job row for that new untracked job exists in the local database.
+- AC-02: Given ingestion returns a new job with `tracking_status IS NULL`, when ingestion completes, then no persisted source-link, classification-result, or ingestion-metadata rows are created solely for that untracked job.
+- AC-03: Given ingestion returns new untracked jobs, when the user views current ingestion results before another ingestion run or app restart, then those untracked jobs are visible from current runtime/app state.
+- AC-04: Given transient untracked jobs are visible in current runtime/app state, when ingestion triggers again, then the transient untracked result set is refreshed from the latest ingestion output.
+- AC-05: Given transient untracked jobs are visible in current runtime/app state, when the app restarts, then those untracked jobs are no longer visible unless returned by a subsequent ingestion run.
+- AC-06: Given ingestion returns a job matching an existing database job where `tracking_status IS NOT NULL`, when ingestion completes, then the existing tracked job and source link are updated using the same behavior as before this feature.
+- AC-07: Given ingestion returns a new job with `manual_keep = true` and `tracking_status IS NULL`, when ingestion completes, then the job is not persisted to the local database.
+- AC-08: Given an existing database job has `manual_keep = true` and `tracking_status IS NULL`, when data cleanup runs, then that job is removed because `manual_keep` does not determine persistence.
+- AC-09: Given an existing database job has `tracking_status IS NOT NULL`, when data cleanup runs, then that job is not removed due to this cleanup regardless of its `manual_keep` value.
+- AC-10: Given a transient untracked job is visible to the user, when the user assigns any non-null `tracking_status`, then the job is persisted to the local database.
+- AC-11: Given a transient job is tracked, when persistence completes, then the related source link, latest classification result, and ingestion metadata are persisted with the job.
+- AC-12: Given a transient job has been tracked and persisted, when the user restarts the app, then the job remains available as a tracked job.
+- AC-13: Given existing database jobs with `tracking_status IS NULL`, when cleanup completes, then those job records no longer exist in the local database.
+- AC-14: Given cleanup removes an untracked database job, when cleanup completes, then related source links and classification records that are only applicable to that removed job are also removed or otherwise cannot remain as orphaned data.
+- AC-15: Given cleanup is run more than once, when the later run executes, then it completes without deleting tracked jobs and without requiring already removed untracked jobs to exist.
+
+## 9. Edge Cases
+
+- Ingestion returns zero jobs.
+- Ingestion returns only new untracked jobs.
+- Ingestion returns a mix of new untracked jobs and jobs matching existing tracked records.
+- Ingestion returns the same job from multiple sources before the user tracks it.
+- A transient job is tracked after another ingestion run has refreshed the transient result set.
+- A transient job is tracked while source-link or classification data is available only in runtime/app state.
+- Existing persisted job has `tracking_status IS NULL` and `manual_keep = true`.
+- Existing persisted job has `tracking_status IS NOT NULL` and `manual_keep = false` or `NULL`.
+- Existing untracked job has related source links, classification results, ingestion metadata, or other dependent records.
+- Cleanup is interrupted after deleting some untracked jobs but before all related records are removed.
+- Cleanup runs when there are no untracked database jobs.
+- App restarts after ingestion but before the user tracks a transient job.
+
+## 10. Constraints
+
+- Technical constraints:
+  - Local database persistence eligibility is determined by `tracking_status`, not `manual_keep`.
+  - `tracking_status IS NULL` means untracked.
+  - `tracking_status IS NOT NULL` means tracked.
+  - Transient untracked results must be held outside durable local database storage.
+  - Tracking a transient job must have enough runtime/app-state data to create normal persisted job, source-link, classification, and ingestion metadata records.
+- UX constraints:
+  - Untracked ingestion results must remain reviewable after ingestion completes within the current runtime/app state.
+  - Users must not see untracked jobs from previous app runs unless those jobs were tracked or returned again by ingestion.
+- Business rules:
+  - `manual_keep` must not preserve or persist an otherwise untracked job.
+  - Existing tracked-job update behavior must be preserved.
+
+## 11. Dependencies
+
+- Existing ingestion flow and source adapter outputs.
+- Existing job matching/deduplication logic used to identify returned jobs that correspond to tracked database jobs.
+- Existing job persistence schema for jobs, source links, classifications, and ingestion metadata.
+- Existing tracking-status update flow.
+- Existing job list/review surfaces that display current ingestion results.
+- Database cleanup or migration mechanism capable of deleting existing untracked jobs and related dependent records safely.
+
+## 12. Assumptions
+
+- No assumptions requiring confirmation. The persistence rule is fully determined by `tracking_status` nullability.
+
+## 13. Open Questions
+
+- None.

--- a/docs/qa/transient_untracked_ingestion_jobs_test_plan.md
+++ b/docs/qa/transient_untracked_ingestion_jobs_test_plan.md
@@ -1,0 +1,470 @@
+# Test Plan
+
+## 1. Feature Overview
+
+Feature: transient untracked ingestion jobs.
+
+Branch/context: `feature/transient_untracked_ingestion_jobs`.
+
+Goal: ingestion must persist only tracked jobs, where tracked means `tracking_status IS NOT NULL`. Newly ingested untracked jobs (`tracking_status IS NULL`) must remain visible only through current runtime/app state, must not create durable job-specific records, must be replaced on subsequent ingestion, and must disappear after application restart. If the user assigns any valid non-null tracking status to a transient job, the system must persist that job and its related source link, classification result/rules, ingestion/source-run attribution, and tracking metadata as a normal tracked job.
+
+Primary validation references:
+
+- Product spec: `docs/product/transient_untracked_ingestion_jobs_product_spec.md`
+- Technical design: `docs/architecture/transient_untracked_ingestion_jobs_technical_design.md`
+- UI/UX spec: `docs/uiux/transient_untracked_ingestion_jobs_design_spec.md`
+
+In-scope validation surfaces:
+
+- Ingestion domain behavior
+- Runtime transient ingestion registry
+- Classification preview versus persisted classification
+- Tracking service transient-to-persisted flow
+- API routes for transient list/detail/tracking
+- Jobs/source UI behavior for temporary results
+- Alembic/data cleanup of existing untracked persisted jobs and dependents
+- Restart/runtime-state behavior
+- Regression of existing tracked job update and persisted job routes
+
+Out of scope for this plan:
+
+- Changes to source adapter fetch logic
+- Changes to classification scoring/rules except persistence-neutral preview parity
+- New tracking status values
+- Multi-user/session synchronization
+- Recovery/archive of deleted untracked jobs
+
+## 2. Acceptance Criteria Mapping
+
+| AC | Requirement summary | Test coverage |
+| --- | --- | --- |
+| AC-01 | New `tracking_status IS NULL` ingestion result creates no `job_postings` row | Unit ingestion test, API run integration test, DB before/after assertion |
+| AC-02 | New untracked result creates no job-specific source-link/classification/metadata rows | Unit ingestion test, API run integration test, DB assertions for `job_source_links`, `job_decisions`, `job_decision_rules`, job-specific ingestion linkage |
+| AC-03 | New untracked results are visible from current runtime/app state before refresh/restart | API `GET /ingestion/transient-jobs`, UI `/jobs` temporary result test |
+| AC-04 | Subsequent ingestion refreshes transient result set from latest output | Registry unit test, API/UI two-run integration test |
+| AC-05 | App restart removes transient untracked visibility | Restart integration test, API/UI post-restart assertions |
+| AC-06 | Existing tracked persisted job matched during ingestion is updated normally | Unit and integration tests for tracked match update, source link update, classification persistence |
+| AC-07 | `manual_keep=true` and `tracking_status IS NULL` new result is not persisted | Unit/API ingestion test with manual_keep true candidate |
+| AC-08 | Existing persisted `manual_keep=true`, `tracking_status IS NULL` job is cleaned up | Migration/cleanup test |
+| AC-09 | Existing `tracking_status IS NOT NULL` job survives cleanup regardless of `manual_keep` | Migration/cleanup test with `manual_keep=true/false/null` tracked variants |
+| AC-10 | Assigning any non-null tracking status to transient job persists job | API/UI tracking test, DB assertion |
+| AC-11 | Tracking transient persists source link, latest classification result, and ingestion metadata | Tracking integration test, transactional DB assertions |
+| AC-12 | Transient job tracked and persisted survives restart as tracked job | End-to-end track then restart test |
+| AC-13 | Cleanup removes existing DB jobs where `tracking_status IS NULL` | Migration/cleanup DB test |
+| AC-14 | Cleanup removes dependent records or prevents orphans for removed untracked jobs | Migration/cleanup DB referential integrity test |
+| AC-15 | Cleanup is idempotent and does not delete tracked jobs on repeat run | Migration/cleanup double-run test |
+
+## 3. Test Scenarios
+
+### Unit Tests Expected
+
+Recommended location: `tests/unit/` or existing project unit test structure.
+
+1. **Ingestion skips DB persistence for new untracked candidate**
+   - Maps to: AC-01, AC-02
+   - Purpose: verify the ingestion orchestrator sends unmatched `tracking_status=None` candidates to runtime registry only.
+   - Input: enabled source, adapter result with one normalized job candidate and no existing tracked match.
+   - Expected output: no `JobPosting`, `JobSourceLink`, `JobDecision`, or `JobDecisionRule` is added/flushed for the candidate; transient registry receives one item; `SourceRun.jobs_fetched_count` reflects fetched candidate.
+   - Validation logic: inspect DB row counts before/after and registry contents.
+
+2. **`manual_keep` is ignored for new untracked persistence**
+   - Maps to: AC-07
+   - Input: candidate/runtime metadata representing `manual_keep=true`, `tracking_status=None`.
+   - Expected output: no persisted job-specific records; transient item is created.
+   - Validation logic: DB count remains unchanged for job/link/decision tables.
+
+3. **Existing tracked match follows persisted update path**
+   - Maps to: AC-06
+   - Input: existing `JobPosting` with non-null `tracking_status`; adapter candidate matching by source/external ID, normalized URL, or canonical key.
+   - Expected output: existing job fields/source link/classification are updated; no duplicate job is inserted; no transient item is created for that matched tracked candidate.
+   - Validation logic: same job ID remains; updated title/company/url/timestamps/classification fields match latest candidate; link metadata updated.
+
+4. **Existing untracked persisted match is not treated as tracked during migration window**
+   - Maps to: AC-01, AC-13
+   - Input: existing `JobPosting.tracking_status=None`, candidate matching it.
+   - Expected output: orchestrator must not update or preserve the untracked persisted row as a tracked job; candidate is transient or cleanup removes row depending on execution path.
+   - Validation logic: no tracked update branch invocation; no new dependent rows for that untracked row.
+
+5. **Transient registry replaces source result set on successful subsequent run**
+   - Maps to: AC-04
+   - Input: source 1 first run has jobs A/B, second successful run has job C.
+   - Expected output: registry for source 1 contains C only; A/B IDs return absent.
+   - Validation logic: registry list/detail lookup by old IDs fails; new ID succeeds.
+
+6. **Transient registry clears/replaces on successful zero-job run**
+   - Maps to: AC-04 and edge case zero jobs
+   - Input: source with existing transient results; successful adapter result with zero jobs.
+   - Expected output: no transient results remain for that source.
+   - Validation logic: registry count for source is zero.
+
+7. **Transient registry source isolation and thread safety**
+   - Maps to: AC-03, AC-04
+   - Input: concurrent writes/replacements for different source IDs and overlapping reads.
+   - Expected output: no cross-source overwrites; no race exceptions; each source returns only its latest set.
+   - Validation logic: assert per-source item sets after concurrent operations.
+
+8. **Classification preview is persistence-neutral and parity-safe**
+   - Maps to: AC-02, AC-11
+   - Input: candidate data and preference/rule setup.
+   - Expected output: preview returns bucket/score/sponsorship/rules without creating DB decision/rule rows; equivalent persisted classification yields same outcome when transient is tracked.
+   - Validation logic: DB decision/rule counts unchanged after preview; compare preview snapshot fields to persisted decision fields after tracking.
+
+9. **Tracking service persists transient atomically**
+   - Maps to: AC-10, AC-11
+   - Input: valid transient ID, valid non-null tracking status, optional note.
+   - Expected output: creates/updates `JobPosting`, `JobSourceLink`, `JobDecision`, `JobDecisionRule`, `JobTrackingEvent` in one transaction and consumes transient entry only after commit.
+   - Validation logic: all records exist after success; induced DB failure rolls back all records and leaves transient entry available.
+
+10. **Tracking service rejects null/empty/invalid status**
+    - Maps to: negative coverage for AC-10
+    - Input: transient ID with `tracking_status` null, empty string, or unsupported value.
+    - Expected output: validation error; no DB records created; transient item remains available.
+    - Validation logic: assert error type/status and unchanged DB counts.
+
+11. **Duplicate/concurrent transient tracking does not create duplicate jobs**
+    - Maps to: AC-10, AC-11 and technical duplicate handling
+    - Input: two tracking requests for same transient ID or two transient records matching the same canonical key/source external ID.
+    - Expected output: one persisted tracked job; second request returns 404/409 or updates existing tracked match safely per contract.
+    - Validation logic: unique persisted job count by canonical key/source external ID equals one.
+
+### Integration and API Tests Expected
+
+Recommended location: `tests/api/` and/or existing integration test structure.
+
+1. **POST ingestion run with only untracked jobs**
+   - Maps to: AC-01, AC-02, AC-03
+   - Steps:
+     1. Seed active source and preferences.
+     2. Mock adapter to return two new untracked jobs.
+     3. Capture DB counts for `job_postings`, `job_source_links`, `job_decisions`, `job_decision_rules`, `source_runs`.
+     4. `POST /sources/{source_id}/run` or configured run endpoint.
+     5. Query DB and `GET /ingestion/transient-jobs`.
+   - Expected:
+     - `source_runs` increases by one.
+     - Job/link/decision/rule counts do not increase for untracked candidates.
+     - transient API returns two items with `tracking_status: null` and runtime IDs.
+
+2. **Transient list filtering by source**
+   - Maps to: AC-03
+   - Steps: run ingestion for source 1 and source 2, then call `GET /ingestion/transient-jobs?source_id=<id>`.
+   - Expected: each response contains only matching source items; invalid non-integer `source_id` returns `422`.
+
+3. **Transient detail endpoint behavior**
+   - Maps to: AC-03
+   - Steps: call `GET /ingestion/transient-jobs/{transient_job_id}` for a current item and for malformed/unknown IDs.
+   - Expected: current item returns details/classification snapshot/source attribution; unknown, malformed, consumed, refreshed-away IDs return `404` and do not query persisted job by that ID.
+
+4. **Tracking transient via API persists all required records**
+   - Maps to: AC-10, AC-11, AC-12
+   - Steps:
+     1. Run ingestion to create transient job.
+     2. `POST /ingestion/transient-jobs/{id}/tracking-status` with each representative valid non-null status, at minimum `saved` plus one other valid status if available.
+     3. Query DB.
+     4. Call persisted job detail endpoint.
+   - Expected:
+     - API returns `201 Created` for new persisted job or documented `200 OK` for duplicate tracked match.
+     - `job_postings.tracking_status` equals submitted status and is non-null.
+     - `job_source_links` contains source ID, external job ID/raw payload/source run attribution as applicable.
+     - `job_decisions` and `job_decision_rules` exist and match latest classification snapshot or recomputation.
+     - `job_tracking_events` exists for the status change/save event.
+     - transient ID is consumed and no longer returned in transient list/detail.
+
+5. **Tracking transient invalid request handling**
+   - Maps to: negative coverage AC-10
+   - Steps: submit null/empty/invalid `tracking_status`, unknown transient ID, and repeated request after consumption.
+   - Expected: `400` for invalid status; `404` for absent/consumed transient ID or `409` if implementation uses conflict for concurrent consumption; no duplicate persisted records.
+
+6. **Mixed ingestion: new untracked plus existing tracked match**
+   - Maps to: AC-01, AC-02, AC-03, AC-06
+   - Steps: seed one tracked persisted job with source link; mock adapter returns matching job with updated data and one new untracked job.
+   - Expected: tracked job is updated/classified; one transient item exists for new untracked job; no untracked job row exists.
+
+7. **Subsequent ingestion refreshes transient API results**
+   - Maps to: AC-04
+   - Steps: first run returns A/B; second successful run returns C; query transient API after each run.
+   - Expected: after second run, A/B IDs return `404`; list contains C only for that source.
+
+8. **Restart clears transient state but preserves tracked converted job**
+   - Maps to: AC-05, AC-12
+   - Steps:
+     1. Run ingestion and capture transient ID A.
+     2. Restart app/test process or instantiate a fresh app with same DB and empty runtime registry.
+     3. Assert A is absent from transient API/UI.
+     4. Repeat by tracking transient B before restart, then restart.
+   - Expected: untracked A is gone after restart; tracked B remains available through `/jobs` and `/jobs/{job_id}`.
+
+9. **SourceRun counter semantics**
+   - Maps to: AC-01, AC-02 and design assumptions
+   - Steps: run ingestion with only transient untracked candidates, with only tracked updates, and with mixed results.
+   - Expected: `jobs_fetched_count` reflects adapter candidates; `jobs_created_count` counts persisted creations only and is not inflated by transient untracked discoveries; update/unchanged counts apply only to persisted tracked effects unless implementation explicitly documents separate transient counts.
+
+10. **Batch ingestion cross-source behavior**
+    - Maps to: AC-03, AC-04, regression
+    - Steps: run batch ingestion for multiple sources with transient results.
+    - Expected: transient results are present for each source; later per-source run replaces only that source's transient set and does not erase other sources unless batch semantics intentionally replace all completed source sets.
+
+### UI Tests Expected
+
+Recommended location: `tests/ui/`.
+
+1. **Jobs page displays transient results as temporary**
+   - Maps to: AC-03 and UI spec
+   - Steps: run ingestion with untracked results; navigate to `/jobs`.
+   - Expected: page displays current transient jobs; informational callout appears with temporary-session copy; each transient row/card has visible `Temporary` badge and screen-reader text; count summary distinguishes tracked and temporary counts.
+
+2. **Persisted tracked jobs are visually distinct from transient jobs**
+   - Maps to: AC-06
+   - Steps: seed tracked job and transient job; navigate to `/jobs`.
+   - Expected: tracked job has normal tracking badge/status and no `Temporary` badge; transient job has temporary labeling and tracking action.
+
+3. **Transient tracking UI converts row/card to persisted job**
+   - Maps to: AC-10, AC-11, AC-12
+   - Steps: select valid non-empty status on transient row/card and submit.
+   - Expected: saving state disables controls and uses `Saving…`/`aria-busy`; success shows “Job tracked and saved.”; temporary badge removed; detail link changes to `/jobs/{persisted_job_id}`; persisted job appears after page reload/restart.
+
+4. **Transient detail navigation is runtime-safe**
+   - Maps to: AC-03, AC-05
+   - Steps: click details for transient item if implemented.
+   - Expected: UI uses transient detail route or inline details, not `/jobs/{integer_db_id}`; after refresh/restart/consumption unavailable detail shows clear error and prompt to rerun ingestion.
+
+5. **Refresh/restart removes stale temporary UI**
+   - Maps to: AC-04, AC-05
+   - Steps: view transient results, run ingestion again with different results, then restart app.
+   - Expected: previous temporary rows disappear after refresh; after restart no stale temporary rows or old persisted untracked rows appear.
+
+6. **Accessibility and responsive behavior**
+   - Maps to: UI accessibility requirements
+   - Expected: tracking select labels include job title; errors use `role="alert"`; temporary status is visible text, not color-only; keyboard order reaches title/details/source link/select/submit; mobile card shows temporary badge and full-width tracking controls when constrained.
+
+### Migration/Cleanup Tests Expected
+
+Recommended location: migration test suite or `tests/integration/`.
+
+1. **Cleanup removes existing untracked jobs and dependents**
+   - Maps to: AC-08, AC-13, AC-14
+   - Seed:
+     - `job_postings` row with `tracking_status=NULL`, `manual_keep=true`.
+     - related `job_source_links`, `job_decisions`, `job_decision_rules`, `job_tracking_events`, `reminders`, `digest_items` where schema supports them.
+   - Expected after migration/cleanup: target job row removed; dependent rows removed; no orphaned rows remain.
+
+2. **Cleanup preserves tracked jobs regardless of manual_keep**
+   - Maps to: AC-09, AC-15
+   - Seed tracked jobs with `tracking_status IS NOT NULL` and `manual_keep=true`, `false`, and `NULL` if nullable.
+   - Expected: all tracked jobs and their dependents remain after cleanup.
+
+3. **Cleanup is idempotent**
+   - Maps to: AC-15
+   - Steps: run cleanup/migration twice against same DB.
+   - Expected: second run succeeds as no-op for previously deleted records; tracked rows unchanged; no FK errors.
+
+4. **Cleanup with no untracked jobs succeeds**
+   - Maps to: AC-15 and edge coverage
+   - Expected: migration completes without error and without modifying tracked rows.
+
+5. **Interrupted/partial cleanup recovery**
+   - Maps to: edge case
+   - Seed partial state such as missing decision rows but remaining rules impossible/possible per FK settings, or some child tables already deleted.
+   - Expected: cleanup completes without relying on every child record existing and leaves no orphaned records.
+
+### Regression Tests Expected
+
+1. Existing `/jobs`, `/jobs/{job_id}`, `/jobs/{job_id}/tracking-status`, and `/jobs/{job_id}/keep` continue to work for persisted tracked jobs.
+2. Existing source run success/failure behavior and source health updates remain intact.
+3. Existing classification persistence for tracked jobs is unchanged.
+4. Existing filters/sorting on `/jobs` still apply correctly to persisted tracked jobs and do not accidentally expose deleted/untracked DB rows.
+5. Existing source adapters and adapter validation behavior remain unchanged.
+6. Existing deduplication/matching for tracked persisted jobs does not create duplicate rows.
+7. Existing database migrations can upgrade from the previous head revision to the new cleanup revision.
+
+## 4. Edge Cases
+
+1. Ingestion returns zero jobs: no job rows created, transient set for that source is empty, UI shows no temporary callout.
+2. Ingestion returns only new untracked jobs: DB has no job-specific inserts; UI/API shows temporary results.
+3. Ingestion returns a mix of new untracked and existing tracked matches: tracked jobs update, untracked are transient only.
+4. Same job appears from multiple sources before tracking: implementation dedupes or displays source labels clearly; tracking creates one persisted job when matched by canonical/source rules.
+5. Same source returns duplicate candidate within one run: registry should dedupe by source/external ID, normalized URL, or canonical key per design; no duplicate persisted rows.
+6. User attempts to track a transient job after another ingestion run refreshed it away: API returns `404` or `409`; UI shows “temporary result no longer available” copy; no DB write.
+7. User attempts to track after app restart: transient ID unavailable; no DB write.
+8. User submits empty/null/invalid tracking status: request rejected; transient item remains; no DB write.
+9. User/client includes `manual_keep=true` while tracking transient: manual_keep must not be accepted as persistence signal; persistence depends only on valid non-null tracking status.
+10. Existing untracked job has `manual_keep=true`: cleanup deletes it.
+11. Existing tracked job has `manual_keep=false` or null: cleanup preserves it.
+12. Existing untracked job has source links/classification/reminder/digest/tracking-event dependents: cleanup deletes children first or uses safe cascade with no orphans.
+13. Ingestion failure after previous transient results exist: validate documented behavior. Preferred design says failed run does not replace last successful transient set; if implementation clears on failure, UI must show corresponding failure copy. This behavior must be explicitly documented before QA sign-off.
+14. Tracking transaction fails midway: rollback leaves no partial persisted job/link/decision/event and transient item remains available for retry.
+15. Concurrent requests track the same transient ID: at most one persisted job; second request receives conflict/not found and no duplicate records.
+16. Batch source runs occur concurrently: registry access is thread-safe and source result sets do not overwrite each other incorrectly.
+17. Restart after tracking succeeds but before UI reload: persisted job is present; transient registry absence does not lose tracked job.
+
+## 5. Test Types Covered
+
+- **Unit:** ingestion persistence gating, tracked matching, transient registry replacement/source isolation/thread safety, classification preview, tracking service validation/atomicity, manual_keep predicate exclusion.
+- **Integration:** source run endpoint plus DB assertions, transient API list/detail/tracking, DB transaction behavior, restart with same DB and fresh runtime registry, batch source behavior.
+- **API:** `GET /ingestion/transient-jobs`, `GET /ingestion/transient-jobs/{transient_job_id}`, `POST /ingestion/transient-jobs/{transient_job_id}/tracking-status`, existing persisted job endpoints regression, validation/error status codes.
+- **UI:** `/jobs` mixed persisted/transient display, temporary callout/badge/counts, transient detail behavior, tracking form states and success/error messages, restart/refresh stale-state handling, accessibility/responsive checks.
+- **Migration/Cleanup:** Alembic upgrade cleanup, dependent deletion, idempotency, tracked preservation, no-orphan assertions.
+- **Regression:** existing tracked job lifecycle, source ingestion health/run history, classification, persisted job list/detail/tracking/keep, migration chain.
+- **Negative:** invalid status, unknown/expired transient ID, malformed source filter, concurrent duplicate tracking, ingestion failure behavior, invalid manual_keep assumptions.
+
+## 6. Coverage Justification
+
+This plan covers all validated requirements by validating both absence and presence conditions:
+
+- Absence of durable records for newly ingested untracked jobs is proven through direct DB before/after assertions across job, source-link, classification, and job-specific metadata tables.
+- Presence of transient visibility is proven through API and UI tests that read only runtime state, then verify replacement on new ingestion and loss after restart.
+- Tracked-job continuity is protected through matched-update tests and persisted endpoint regressions.
+- The `manual_keep` non-rule is tested in both new ingestion and cleanup paths so it cannot accidentally preserve or persist untracked jobs.
+- Cleanup safety is tested with child dependents, tracked preservation, no-target runs, and repeated execution to protect production/local upgrade scenarios.
+- Tracking from transient state is validated transactionally, including persistence of all related artifacts and survival after restart.
+- UI tests verify that users can distinguish temporary versus persisted records and that user-facing copy does not imply untracked durability.
+
+## 7. DB Assertion Matrix
+
+Use table names from `app/persistence/models.py`; adjust only if implementation names differ.
+
+### Before Ingestion
+
+- Capture counts and relevant rows for:
+  - `job_postings`
+  - `job_source_links`
+  - `job_decisions`
+  - `job_decision_rules`
+  - `job_tracking_events`
+  - `source_runs`
+  - `reminders`
+  - `digest_items`
+- Seed at least:
+  - one existing tracked job with `tracking_status IS NOT NULL`
+  - one existing untracked job with `tracking_status IS NULL`, including `manual_keep=true`, for cleanup-specific tests
+  - dependent records for cleanup targets
+
+### After Ingestion of New Untracked Jobs
+
+- Assert no `job_postings` row exists by candidate normalized URL, canonical key, source external ID, company/title unique test marker.
+- Assert no `job_source_links` row exists for candidate source/external ID unless linked to an already tracked job.
+- Assert no `job_decisions` or `job_decision_rules` rows exist for the candidate.
+- Assert no job-specific ingestion metadata rows exist solely for the candidate.
+- Assert `source_runs` row exists for the ingestion execution and `jobs_fetched_count` reflects adapter candidates.
+- Assert persisted-created counters do not count transient untracked candidates.
+
+### After Ingestion of Existing Tracked Match
+
+- Assert same `job_postings.id` remains.
+- Assert fields expected to update have latest values.
+- Assert `tracking_status` remains non-null unless deliberately changed by existing behavior.
+- Assert `job_source_links` updated/inserted for tracked job as pre-feature behavior requires.
+- Assert latest classification fields and decision/rule rows are updated/persisted.
+- Assert no transient duplicate appears for the matched tracked job.
+
+### After Tracking a Transient Job
+
+- Assert one persisted `job_postings` row exists for the transient candidate.
+- Assert `tracking_status IS NOT NULL` and equals submitted valid status.
+- Assert `job_source_links.job_posting_id` points to persisted job and includes source/run/external/raw metadata where applicable.
+- Assert `job_decisions.job_posting_id` points to persisted job.
+- Assert `job_decision_rules.job_decision_id` points to persisted decision.
+- Assert `job_postings.latest_decision_id/latest_bucket/latest_score` reference persisted classification outcome.
+- Assert `job_tracking_events.job_posting_id` exists for the tracking action.
+- Assert transient registry no longer returns the consumed ID.
+- Assert repeated tracking of the same ID does not create additional `job_postings` rows.
+
+### After Cleanup/Migration
+
+- Assert all `job_postings.tracking_status IS NULL` rows seeded for cleanup are gone.
+- Assert tracked jobs with any `manual_keep` value remain.
+- Assert no orphaned rows remain in:
+  - `job_source_links`
+  - `job_decisions`
+  - `job_decision_rules`
+  - `job_tracking_events`
+  - `reminders`
+  - `digest_items`
+- Assert second cleanup/migration execution succeeds and row counts remain stable.
+
+## 8. Cleanup/Migration Validation
+
+Minimum implementation-ready cleanup test data set:
+
+| Seed case | tracking_status | manual_keep | Dependents | Expected cleanup result |
+| --- | --- | --- | --- | --- |
+| Untracked kept legacy job | `NULL` | `true` | link, decision, rules, event, reminder, digest item | job and owned dependents removed |
+| Untracked normal legacy job | `NULL` | `false` | link and decision | job and owned dependents removed |
+| Tracked saved job | `saved` or equivalent valid status | `true` | link, decision, rules | all records preserved |
+| Tracked non-kept job | non-null valid status | `false` or `NULL` | link | all records preserved |
+| No-target DB | no `NULL` statuses | any | any | cleanup no-op success |
+
+Validation requirements:
+
+- Run migration through the same Alembic mechanism used by the app, not only direct helper invocation.
+- Confirm upgrade from the prior revision to the cleanup revision.
+- Confirm cleanup predicates do not reference `manual_keep` as a retention rule.
+- Confirm downgrade behavior is documented as no-op/irreversible data cleanup if applicable.
+- Confirm cleanup can be re-run or the migration logic is otherwise idempotent in test harness.
+
+## 9. Restart and Runtime-State Behavior Validation
+
+Restart validation must prove transient data is not durable.
+
+Required approach:
+
+1. Start app/test client with clean runtime registry and persistent test DB.
+2. Run ingestion with new untracked jobs.
+3. Confirm DB has no job-specific rows for those jobs.
+4. Confirm transient API/UI shows current temporary jobs.
+5. Simulate restart by creating a new app process/application instance with the same DB and a fresh runtime registry. If the test framework cannot launch a subprocess, explicitly reinitialize the registry and app dependency container in a way equivalent to process startup and document the limitation.
+6. Confirm transient API returns empty/no previous jobs and detail for old transient ID returns `404`.
+7. Confirm `/jobs` does not show previous transient jobs or fallback persisted untracked jobs.
+8. Repeat with a transient job tracked before restart; confirm it appears after restart as a normal persisted tracked job with no `Temporary` badge.
+
+Required evidence:
+
+- Test logs showing pre-restart transient ID(s), post-restart transient API response, and persisted DB row state.
+- UI screenshot or HTML assertion showing no stale temporary result after restart.
+- DB query output proving tracked converted job survived restart.
+
+## 10. Required Evidence for QA Sign-Off
+
+QA sign-off must not be granted without the following evidence captured in the final test report:
+
+1. **Automated test execution output**
+   - Exact commands run.
+   - Full pass/fail summary.
+   - Any skipped tests with justification.
+
+2. **Acceptance criteria traceability**
+   - Matrix showing AC-01 through AC-15 mapped to executed tests and outcomes.
+
+3. **DB assertion evidence**
+   - Before/after row counts and targeted row queries for ingestion-only, tracking, and cleanup scenarios.
+   - Proof that no untracked candidate rows or dependents were persisted.
+   - Proof that tracked converted jobs and existing tracked matched jobs persisted correctly.
+
+4. **API evidence**
+   - Request/response status codes and bodies for transient list/detail/tracking success and failure paths.
+   - Evidence for invalid status, unknown/expired ID, and invalid source filter.
+
+5. **UI evidence**
+   - Screenshots or saved HTML/test assertions for `/jobs` showing temporary callout, `Temporary` badge, count summary, tracking form, success/error handling, and absence after restart/refresh.
+   - Accessibility assertions for labels, alert roles, visible non-color-only temporary state, and keyboard-reachable controls.
+
+6. **Migration evidence**
+   - Alembic upgrade logs.
+   - Cleanup before/after DB queries.
+   - Idempotency/double-run result.
+   - No-orphan query results.
+
+7. **Restart evidence**
+   - Logs proving runtime registry is empty after restart while DB remains unchanged for untracked candidates.
+   - Proof tracked transient conversion survives restart.
+
+8. **Regression evidence**
+   - Existing persisted job, source ingestion, classification, tracking status, and keep-route tests passed.
+
+9. **Failure classification if any test fails**
+   - Each failure must be classified as Application Bug, Test Bug, Environment Issue, or Flaky Test.
+   - Include root cause hypothesis, reproduction steps, logs/error messages, and severity.
+
+QA decision rule:
+
+- Approve only if all critical AC-mapped tests pass, cleanup is proven safe/idempotent, no blocking defects remain, and evidence proves untracked jobs are transient-only while tracked jobs persist and update correctly.
+- Do not approve if any AC-01, AC-02, AC-05, AC-10, AC-11, AC-13, AC-14, or AC-15 validation fails or is unexecuted without approved exception.

--- a/docs/qa/transient_untracked_ingestion_jobs_test_report.md
+++ b/docs/qa/transient_untracked_ingestion_jobs_test_report.md
@@ -1,0 +1,118 @@
+# Test Report
+
+## 1. Execution Summary
+
+- Feature: transient untracked ingestion jobs
+- Branch: `feature/transient_untracked_ingestion_jobs`
+- QA date: 2026-05-01
+- QA decision: **APPROVED**
+- Feature-specific targeted validation: **15 passed, 0 failed**
+- Remediated prior regression-failure scope: **38 passed, 0 failed**
+- Full-suite regression validation: **130 passed, 0 failed, 4 warnings**
+- Compile validation: **PASS**
+
+QA independently re-ran the transient feature suite, the prior failure/remediation regression scope, the full pytest suite, and Python compile validation after regression-test remediation. The previously blocking full-suite failures are resolved.
+
+Supplemental QA validation scripts included in the executed suite:
+
+- `tests/api/test_transient_untracked_ingestion_jobs_qa.py`
+- `tests/integration/test_transient_untracked_cleanup_migration_qa.py`
+
+## 2. Detailed Results
+
+| Command | Result | Evidence |
+| --- | --- | --- |
+| `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest tests/unit/test_transient_ingestion_jobs.py tests/api/test_transient_untracked_ingestion_jobs_qa.py tests/integration/test_transient_untracked_cleanup_migration_qa.py tests/ui/test_transient_ingestion_jobs_ui.py tests/ui/test_hide_rejected_job_openings_ui.py` | PASS | `15 passed in 0.37s` |
+| `python3 -m compileall app tests` | PASS | Application and test files compiled successfully; no compile errors emitted |
+| `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest tests/api/test_source_edit_delete_qa.py tests/integration/test_api_flow.py tests/integration/test_html_views.py tests/integration/test_source_edit_delete_html.py tests/ui/test_saas_dashboard_ui_revamp.py tests/ui/test_source_edit_delete_ui_qa.py tests/unit/test_source_batch_run_qa_validation.py` | PASS | `38 passed in 0.94s` |
+| `DATABASE_URL=sqlite+pysqlite:///:memory: PYTHONPATH=. uv run pytest` | PASS | `130 passed, 4 warnings in 3.05s` |
+
+### Feature-Specific Coverage Executed
+
+- Ingestion skips DB persistence for new untracked candidates.
+- Source-link, classification, and decision-rule records are not created for untracked ingestion-only candidates.
+- Transient API list/detail exposes runtime-only untracked jobs.
+- Invalid transient tracking status returns `400`, creates no DB rows, and leaves transient item available.
+- Subsequent ingestion refreshes the per-source transient set and expires prior transient IDs.
+- Simulated restart/registry clear removes untracked transient visibility without DB fallback.
+- Tracking a transient job via API persists `JobPosting`, `JobSourceLink`, `JobDecision`, `JobDecisionRule`, `JobTrackingEvent`, and source-run linkage.
+- Tracked transient job remains persisted after registry clear.
+- Existing tracked match updates without transient duplicate.
+- Cleanup migration deletes `tracking_status IS NULL` jobs, including `manual_keep=true`, removes dependents, preserves tracked jobs, and is idempotent.
+- UI renders temporary callout/badge, runtime-safe transient detail route, and transient tracking form.
+- Hide-rejected UI regression remains passing.
+
+### Remediation Regression Scope Executed
+
+- Stale persisted-job expectations after ingestion remediation.
+- Source delete/background cleanup test-session remediation.
+- UI shell fixture remediation.
+- Batch source-run concurrency stabilization.
+
+## 3. Failed Tests
+
+No failed tests in the executed validation scope.
+
+Full-suite warning evidence:
+
+- `tests/unit/test_schema_guard.py` emitted four Alembic `DeprecationWarning` warnings: `No path_separator found in configuration; falling back to legacy splitting on spaces, commas, and colons for prepend_sys_path.`
+- Classification: non-blocking environment/dependency deprecation warning; no test failure and no observed feature impact.
+
+## 4. Failure Classification
+
+No unresolved failures remain.
+
+Previously reported failure groups are closed by re-run evidence:
+
+| Prior failure group | Current result | QA disposition |
+| --- | --- | --- |
+| Stale tests expecting newly ingested untracked jobs in persisted `/jobs` JSON | PASS in remediation scope and full suite | Closed as remediated Test Bug |
+| Source-delete background cleanup using isolated in-memory DB session | PASS in remediation scope and full suite | Closed as remediated Environment/Test Infrastructure Issue |
+| UI shell tests bypassing repository `client` fixture | PASS in remediation scope and full suite | Closed as remediated Environment/Test Infrastructure Issue |
+| Batch executor threaded SQLite contention | PASS in remediation scope and full suite | Closed as remediated Environment/Test Infrastructure Issue |
+
+## 5. Observations
+
+- The feature-specific transient validation remains green after regression-test remediation.
+- The full regression suite is now green under the requested in-memory SQLite execution configuration.
+- The runtime registry restart simulation validates the intended non-durable behavior for untracked ingestion results.
+- The cleanup migration remains idempotent and preserves tracked jobs regardless of `manual_keep` value.
+- No flaky behavior was observed across the re-run commands.
+
+## 6. Regression Check
+
+Confirmed unchanged/passing behaviors:
+
+- Existing tracked job update path during ingestion still persists updates and source-link data.
+- Persisted tracked job detail route remains available after transient tracking persistence.
+- Source edit/delete API and HTML flows pass after remediation.
+- Shared UI shell routes pass using the repository test fixture.
+- Source batch run concurrency regression test passes.
+- Existing hide-rejected job UI regression test remains passing.
+- Python compile check passes for `app` and `tests`.
+
+## 7. Acceptance Criteria Outcome
+
+| AC | Outcome | Evidence |
+| --- | --- | --- |
+| AC-01 | PASS | Unit/API tests assert no `JobPosting` row after new untracked ingestion. |
+| AC-02 | PASS | Unit/API tests assert no `JobSourceLink`, `JobDecision`, or `JobDecisionRule` rows for ingestion-only untracked candidates. |
+| AC-03 | PASS | Transient API and UI tests show runtime-visible temporary jobs. |
+| AC-04 | PASS | API test verifies second ingestion replaces prior transient set and old ID returns `404`; registry unit coverage validates replacement semantics. |
+| AC-05 | PASS | API test clears runtime registry to simulate restart; transient list is empty and detail returns `404` with no DB fallback. |
+| AC-06 | PASS | API/unit tests verify existing tracked match updates and creates no transient duplicate. |
+| AC-07 | PASS | Ingestion persistence rule is validated for untracked candidates; cleanup/manual_keep tests confirm `manual_keep=true` does not preserve untracked persistence. |
+| AC-08 | PASS | Cleanup QA test deletes existing `manual_keep=true`, `tracking_status NULL` job. |
+| AC-09 | PASS | Cleanup QA test preserves tracked jobs regardless of `manual_keep`. |
+| AC-10 | PASS | API test tracks transient with non-null status and persists job. |
+| AC-11 | PASS | API test verifies source link, decision, decision rule, event, and source-run linkage are persisted. |
+| AC-12 | PASS | API test clears registry after tracking and verifies persisted job remains accessible through `/jobs/{job_id}`. |
+| AC-13 | PASS | Cleanup QA test verifies untracked job rows are removed. |
+| AC-14 | PASS | Cleanup QA test verifies no orphaned source-link/classification/event/reminder/digest rows remain for removed jobs. |
+| AC-15 | PASS | Cleanup QA test runs migration upgrade twice without deleting tracked jobs or failing. |
+
+## 8. QA Decision
+
+[QA SIGN-OFF APPROVED]
+
+Approval basis: all critical feature tests passed, prior blocking regression failures are remediated, full-suite regression passed, compile validation passed, and no unresolved failures or blocking defects remain.

--- a/docs/release/transient_untracked_ingestion_jobs_issue.md
+++ b/docs/release/transient_untracked_ingestion_jobs_issue.md
@@ -1,0 +1,77 @@
+# GitHub Issue
+
+## 1. Feature Name
+
+Transient untracked ingestion jobs
+
+## 2. Problem Summary
+
+The current ingestion flow persists all returned jobs, including jobs the user has not chosen to track. This causes durable local database growth from untracked jobs and related artifacts that should only represent temporary review results. Ingestion should persist only tracked jobs where `tracking_status IS NOT NULL`; newly ingested untracked jobs should remain runtime-only until the user assigns a non-null tracking status.
+
+## 3. Linked Planning Documents
+- Product Spec: `docs/product/transient_untracked_ingestion_jobs_product_spec.md`
+- Technical Design: `docs/architecture/transient_untracked_ingestion_jobs_technical_design.md`
+- UI/UX Spec: `docs/uiux/transient_untracked_ingestion_jobs_design_spec.md`
+- QA Test Plan: `docs/qa/transient_untracked_ingestion_jobs_test_plan.md`
+
+## 4. Scope Summary
+- In scope
+  - Prevent new ingestion results with `tracking_status IS NULL` from being persisted to job, source-link, classification, or ingestion metadata tables.
+  - Keep untracked ingestion results visible only in current runtime/app state until refresh or restart.
+  - Preserve existing update behavior for ingestion results matching tracked persisted jobs.
+  - Persist a transient job and required related artifacts when the user assigns a non-null tracking status.
+  - Remove existing persisted jobs where `tracking_status IS NULL` and safely clean up dependent records.
+- Out of scope
+  - Changing source adapter fetch behavior, classification rules, scoring, bucket logic, or tracking status values.
+  - Using `manual_keep` as a persistence or cleanup rule.
+  - Preserving transient untracked jobs across app restart.
+  - Adding archive/restore, multi-user synchronization, or broader job review UI redesign.
+
+## 5. Implementation Notes
+- Frontend expectations
+  - Show transient untracked ingestion results alongside persisted tracked jobs where needed for review.
+  - Clearly label transient rows/cards with a `Temporary` badge and helper copy explaining restart/refresh behavior.
+  - Provide tracking actions that persist transient jobs and then transition UI controls/links to normal persisted job behavior.
+- Backend expectations
+  - Gate durable persistence on `tracking_status IS NOT NULL`, not `manual_keep`.
+  - Add runtime-only transient ingestion storage that refreshes per ingestion run and is not hydrated on startup.
+  - Add a transient tracking path that atomically persists the job, source link, classification snapshot/rules, ingestion attribution, and tracking metadata.
+  - Add idempotent cleanup/migration for existing untracked persisted jobs and dependent records.
+- Dependencies or blockers
+  - Existing ingestion orchestration, matching/deduplication, classification, tracking, route/schema, and database migration mechanisms.
+  - Runtime state must retain enough source/classification data to persist a transient job later in the same app session.
+
+## 6. QA Section
+- Planned test coverage
+  - Unit coverage for ingestion persistence gating, transient registry replacement/thread safety, classification preview neutrality, transient tracking, and cleanup idempotency.
+  - API/integration coverage for ingestion runs, transient list/detail, tracking transient jobs, mixed tracked/untracked ingestion, restart behavior, and source-run counter semantics.
+  - UI coverage for temporary result visibility, badges/callouts, tracking actions, detail link behavior, and accessibility states.
+  - Migration/database coverage for deleting untracked persisted jobs and preventing orphaned dependent records.
+- Acceptance criteria mapping
+  - AC-01 through AC-02: verify new untracked ingestion results create no durable job-specific records.
+  - AC-03 through AC-05: verify transient runtime visibility, refresh, and restart loss.
+  - AC-06: verify existing tracked matches continue to update normally.
+  - AC-07 through AC-09: verify `manual_keep` does not affect persistence or cleanup and tracked rows survive cleanup.
+  - AC-10 through AC-12: verify tracking a transient job persists all required records and survives restart.
+  - AC-13 through AC-15: verify untracked cleanup removes target rows/dependents and is repeatable.
+- Key edge cases
+  - Zero-job ingestion, only untracked jobs, mixed untracked and tracked matches, duplicate sources/matches, stale transient IDs, concurrent tracking, cleanup interruption, and restart before tracking.
+- Test types expected
+  - Unit, API/integration, end-to-end/UI, accessibility, migration/data-integrity, concurrency, and regression tests.
+
+## 7. Risks / Open Questions
+
+- Runtime-only transient storage can lose reviewable jobs on restart by design; UI copy must make this clear.
+- Concurrent ingestion or tracking could create stale transient IDs or duplicate persistence attempts if not guarded.
+- Cleanup must avoid orphaned dependent records and must never delete tracked jobs.
+- Source-run counter semantics for transient-only discoveries should be documented and validated.
+- No open product questions are identified in the current planning documents.
+
+## 8. Definition of Done
+
+- Newly ingested untracked jobs are not persisted and remain visible only as current runtime/app-state results.
+- Existing tracked jobs continue to update through ingestion without regression.
+- Tracking a transient job persists the job and required related artifacts atomically as a normal tracked job.
+- Existing persisted untracked jobs and owned dependent records are safely cleaned up without deleting tracked jobs.
+- UI clearly distinguishes temporary results and supports tracking them into persisted jobs.
+- Planned QA coverage passes for persistence gating, transient runtime behavior, tracking conversion, cleanup, restart behavior, and regressions.

--- a/docs/release/transient_untracked_ingestion_jobs_pr.md
+++ b/docs/release/transient_untracked_ingestion_jobs_pr.md
@@ -1,0 +1,49 @@
+# Pull Request
+
+## 1. Feature Name
+
+Transient untracked ingestion jobs
+
+## 2. Summary
+
+Untracked ingestion jobs are now transient until a user explicitly tracks them, while tracked jobs continue to persist and update normally. Tracking a transient job persists the job, source linkage, classification, decision/tracking metadata, and source-run attribution; a cleanup migration removes existing persisted untracked jobs and dependent records.
+
+## 3. Related Documents
+- Product Spec: docs/product/transient_untracked_ingestion_jobs_product_spec.md
+- Technical Design: docs/architecture/transient_untracked_ingestion_jobs_technical_design.md
+- UI/UX Spec: docs/uiux/transient_untracked_ingestion_jobs_design_spec.md
+- QA Report: docs/qa/transient_untracked_ingestion_jobs_test_report.md
+- QA Test Plan: docs/qa/transient_untracked_ingestion_jobs_test_plan.md
+- Planning Issue: docs/release/transient_untracked_ingestion_jobs_issue.md
+- Bug Report: docs/bugs/transient_untracked_ingestion_jobs_full_suite_failures_bug_report.md
+- Backend Report: docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
+- Frontend Report: docs/frontend/transient_untracked_ingestion_jobs_implementation_report.md
+
+## 4. Changes Included
+- Added runtime-only transient ingestion storage for newly discovered untracked jobs.
+- Updated ingestion persistence so new untracked jobs do not create durable job/source/classification records.
+- Preserved existing tracked-job ingestion update behavior.
+- Added transient job list/detail API and UI affordances, including temporary labeling and tracking actions.
+- Added transient tracking flow that persists job, source link, classification/decision metadata, tracking event, and source-run linkage.
+- Added cleanup migration for existing persisted untracked jobs and dependent records while preserving tracked jobs.
+- Added and remediated unit, API, integration, UI, and migration regression coverage.
+
+## 5. QA Status
+- Approved: YES
+- QA sign-off: [QA SIGN-OFF APPROVED]
+- HITL validation: HITL validation successful
+
+## 6. Test Coverage
+- Full regression suite: 130 passed, 0 failed, 4 non-blocking warnings.
+- Targeted transient feature suite: 15 passed, 0 failed.
+- Prior remediation regression scope: 38 passed, 0 failed.
+- Compile validation: PASS for `app` and `tests`.
+
+## 7. Risks / Notes
+- Runtime-only transient jobs are intentionally lost on refresh/restart until tracked.
+- UI copy labels temporary jobs to reduce user confusion.
+- Cleanup migration is destructive only for persisted jobs with `tracking_status IS NULL` and owned dependents; tracked jobs are preserved.
+- Full suite warnings are Alembic deprecation warnings with no observed feature impact.
+
+## 8. Linked Issue
+- Closes #20

--- a/docs/uiux/transient_untracked_ingestion_jobs_design_spec.md
+++ b/docs/uiux/transient_untracked_ingestion_jobs_design_spec.md
@@ -1,0 +1,297 @@
+# Design Specification
+
+## 1. Feature Overview
+
+Untracked jobs returned by ingestion must be reviewable only as transient current-runtime results. They must not appear as durable database-backed jobs unless the user assigns a non-null tracking status. Once tracked, the job becomes a normal persisted job and remains available across app restart.
+
+## 2. User Goal
+
+After running ingestion, the user wants to review newly discovered jobs, understand which results are temporary, and intentionally track the jobs they want to keep for their ongoing job-search workflow.
+
+## 3. UX Rationale
+
+The existing app already uses Sources to trigger ingestion and Jobs to review classified opportunities. This design keeps that mental model while adding clear persistence status cues:
+
+- **Tracked jobs** remain normal persisted records.
+- **Transient untracked results** are presented as current ingestion results, labeled as temporary, and given an explicit tracking action.
+- The UI must not imply that untracked transient results are saved, retained, or restorable after restart.
+
+## 4. User Flow
+
+1. User runs ingestion from `/sources` or `/sources/{source_id}`.
+2. Ingestion completes.
+3. User sees success/failure feedback. On success, copy includes the count of fetched jobs and, when available, the count of temporary untracked results.
+4. User opens `/jobs` to review actionable jobs.
+5. `/jobs` shows a combined review list:
+   - persisted tracked jobs from the database;
+   - current transient untracked ingestion results from runtime/app state.
+6. User identifies transient rows/cards by a **Temporary** badge and helper copy.
+7. User may open a transient result detail view if detail data exists in runtime/app state.
+8. User assigns any non-null tracking status, for example `Saved`.
+9. UI enters saving state for that job.
+10. On success, the transient result is replaced by the persisted tracked job, the **Temporary** badge is removed, tracking status updates, and navigation uses the normal persisted job URL.
+11. If ingestion runs again before the user tracks a transient result, the transient list is replaced by the latest ingestion result set.
+12. If the app restarts before tracking, previous transient results are absent.
+
+## 5. Information Hierarchy
+
+1. **Page-level context:** Jobs page title and description must explain that the page can include temporary current-ingestion results.
+2. **Result identity:** title, company, source, location, score, and automated bucket remain primary.
+3. **Persistence status:** transient status is visually adjacent to bucket/tracking badges.
+4. **Tracking action:** assigning status is the primary conversion action for transient results.
+5. **Temporal warning:** transient helper text explains that untracked results disappear after app restart or the next ingestion run.
+6. **Operational metadata:** source/run history remains secondary and should not overtake job review actions.
+
+## 6. Layout Structure
+
+### Target Screens / Routes / Components
+
+- `/sources`
+  - Existing configured sources table.
+  - Existing per-source **Run ingestion** forms.
+  - Desired: post-run flash/message copy may reference temporary untracked results.
+- `/sources/{source_id}`
+  - Existing source detail header action **Run ingestion**.
+  - Existing run history table.
+  - Desired: latest run area may link to `/jobs` with current ingestion results visible.
+- `/jobs`
+  - Primary target screen for viewing transient untracked results.
+  - Existing filters, table view, and mobile card list must support mixed persisted and transient items.
+- Job detail surface
+  - Existing `/jobs/{job_id}` remains for persisted jobs only.
+  - Desired transient detail surface must be detail-compatible but clearly temporary. If implemented as a route, use a runtime-safe transient identifier, not a database id. If no transient detail endpoint is available, transient results should use an expandable inline details panel instead of a broken “View” link.
+- Shared components
+  - `includes/macros.html` job badge area, tracking form, keep/save action.
+  - Jobs list table rows and mobile cards.
+  - App-level flash/alert messaging in `base.html`.
+
+### Jobs List Layout
+
+- Add a page-level informational callout above results when transient results are present:
+  - Title: **Temporary ingestion results**
+  - Body: **Untracked jobs from the latest ingestion run are only available during this app session. Track a job to save it. Running ingestion again replaces this temporary list.**
+- Result rows/cards use existing layout with one additional badge in the badge stack:
+  - `Temporary` for transient untracked results.
+  - No badge for normal persisted tracked jobs.
+- The results summary must distinguish counts:
+  - Example: **12 jobs shown: 5 tracked, 7 temporary from the latest ingestion run.**
+- In desktop table, keep columns unchanged. Add the `Temporary` badge under Tracking or in the Role subtitle area to avoid adding horizontal width.
+- In mobile cards, show `Temporary` in the header badge stack before the tracking action.
+
+## 7. Components
+
+1. **Temporary ingestion callout**
+   - Type: informational callout.
+   - Shows only when at least one transient untracked result is present.
+2. **Result count summary**
+   - Text summary above table/card list.
+   - Must include transient count when non-zero.
+3. **Job row/card**
+   - Existing job display component extended with transient metadata.
+4. **Temporary badge**
+   - Label: `Temporary`.
+   - Tone: warning or neutral-warning.
+   - Adjacent screen-reader text must clarify: `Temporary untracked ingestion result`.
+5. **Tracking status form**
+   - Existing select + update button.
+   - For transient results, primary label should be `Track job` or `Save as tracked`, not `Update` alone.
+6. **View details control**
+   - Persisted jobs: link to `/jobs/{job_id}`.
+   - Transient jobs: link to transient detail route or opens inline details. Must not point to `/jobs/{job_id}` until persistence succeeds.
+7. **Flash/alert messages**
+   - Success, error, and warning copy for ingestion and tracking outcomes.
+
+## 8. Interaction Behavior
+
+### Viewing Transient Ingestion Results
+
+- **Trigger:** User completes ingestion and navigates to `/jobs`.
+- **System response:** Jobs list receives persisted tracked jobs plus current transient untracked results from runtime/app state.
+- **UI feedback:** Temporary callout appears if transient count > 0; each transient result has a `Temporary` badge.
+- **Success behavior:** User can review transient result title, company, source, bucket, score, reason summary, location, and available source link/classification evidence.
+- **Failure behavior:** If transient runtime data is unavailable, the UI shows the normal empty or filtered-empty state and must not show stale persisted untracked jobs.
+
+### Running Ingestion Again
+
+- **Trigger:** User starts another ingestion run from `/sources` or `/sources/{source_id}`.
+- **System response:** Current transient untracked result set is replaced when the new run completes.
+- **UI feedback:** Jobs page count and temporary result rows/cards reflect only the latest current-runtime result set.
+- **Success behavior:** Previously visible untracked transient results disappear unless returned again or already tracked.
+- **Failure behavior:** If ingestion fails, keep the previous transient result set only if backend/app state explicitly keeps it for the current runtime. Show alert: **Ingestion failed. Temporary results were not refreshed.** If backend clears on failure, show: **Ingestion failed. No temporary results are available from this run.**
+
+### Tracking / Saving a Transient Job
+
+- **Trigger:** User selects a non-empty tracking status and submits the tracking form for a transient result.
+- **System response:** Persist job, source link, latest classification result, and ingestion metadata; then return the persisted job representation.
+- **UI feedback while saving:**
+  - Disable that row/card tracking select and submit button.
+  - Button text: **Saving…**
+  - Row/card sets `aria-busy="true"`.
+- **Success behavior:**
+  - Remove `Temporary` badge.
+  - Show selected tracking status badge.
+  - Replace transient identifier with persisted job id for future actions.
+  - Detail link changes to `/jobs/{job_id}`.
+  - Flash/inline status: **Job tracked and saved.**
+- **Failure behavior:**
+  - Keep transient row/card visible if still present in runtime state.
+  - Re-enable controls.
+  - Show inline row error and page alert: **Job could not be saved. Try again before running ingestion again or restarting the app.**
+
+### Existing Tracked Jobs Matched During Ingestion
+
+- **Trigger:** Ingestion returns a job matching an existing persisted tracked job.
+- **System response:** Existing update behavior continues.
+- **UI feedback:** Job appears as a normal tracked job with no `Temporary` badge.
+- **Success behavior:** User can manage it through existing tracking/detail views.
+- **Failure behavior:** Existing ingestion error handling applies.
+
+## 9. Component States
+
+### Temporary Ingestion Callout
+
+- Default: visible when transient count > 0.
+- Hover: none; static component.
+- Focus: callout itself is not focusable unless used as an alert target after ingestion; if focused, use standard focus ring.
+- Active: not applicable.
+- Disabled: not applicable.
+- Loading: not shown during ingestion loading unless current transient state is known.
+- Success: shown with informational tone after successful ingestion with transient results.
+- Error: use danger alert, not info callout, when transient data cannot load.
+- Empty: hidden when transient count is 0.
+
+### Temporary Badge
+
+- Default: displays `Temporary` with warning/neutral-warning styling.
+- Hover: no tooltip required; optional `title` must duplicate visible meaning only.
+- Focus: not focusable.
+- Active: not applicable.
+- Disabled: not applicable.
+- Loading: not applicable.
+- Success: removed after tracking persistence succeeds.
+- Error: remains visible if save fails.
+- Empty: absent for persisted tracked jobs.
+
+### Tracking Status Form
+
+- Default: select shows `Select status`; submit button disabled until a non-empty status is selected, if client-side enhancement is present. Without JS, server validates empty status.
+- Hover: button uses existing secondary/primary hover styles.
+- Focus: select and button use visible `:focus-visible` outline.
+- Active: button appears pressed only during click/submission.
+- Disabled: select/button disabled while save is in progress or when job is already in a terminal UI state that cannot be changed.
+- Loading: button text `Saving…`; row/card `aria-busy="true"`.
+- Success: selected status displayed; transient badge removed; success message announced.
+- Error: inline error below form; controls re-enabled.
+- Empty: empty selection is not a valid tracking submission.
+
+### View Details Control
+
+- Default: visible when detail data or persisted detail route is available.
+- Hover: existing link/button hover state.
+- Focus: visible focus outline.
+- Active: native link/button active behavior.
+- Disabled: if transient detail is unavailable, replace control with muted text **Details unavailable for temporary result**; do not render disabled anchor.
+- Loading: if inline detail loads async, show **Loading details…** with `aria-busy="true"`.
+- Success: detail content displays.
+- Error: show **Temporary details are no longer available. Run ingestion again or track the job from the list if it is still visible.**
+- Empty: hidden when neither persisted nor transient detail is available.
+
+### Run Ingestion Button
+
+- Default: enabled for active sources.
+- Hover/focus/active: existing button behavior.
+- Disabled: disabled for inactive sources and during in-flight submission if enhanced.
+- Loading: button text may change to **Running…**; form `aria-busy="true"`.
+- Success: flash indicates ingestion completed and temporary results may be available.
+- Error: existing ingestion failure flash.
+- Empty: when run returns zero jobs, show zero-result copy.
+
+## 10. Responsive Design Rules
+
+### Desktop
+
+- Preserve existing table layout.
+- Add temporary status inside existing Role/Tracking cell to avoid new columns.
+- Temporary callout spans full content width above results.
+
+### Tablet
+
+- Preserve table scroll behavior.
+- Keep callout and filters stacked according to existing responsive rules.
+- Badge stack may wrap; do not truncate `Temporary`.
+
+### Mobile
+
+- Use existing mobile card list.
+- Place `Temporary` badge in card header badge stack.
+- Put tracking form below primary metadata with full-width select and button if space is constrained.
+- Inline errors appear immediately below the tracking form.
+
+## 11. Visual Design Tokens
+
+Use existing tokens from `app/static/css/app.css`:
+
+- Text: `--text-primary`, `--text-secondary`, `--text-tertiary`.
+- Borders: `--border-default`, `--border-strong`.
+- Warning/temporary: `--warning-50`, `--warning-600`.
+- Success saved state: `--success-50`, `--success-600`.
+- Error: `--danger-50`, `--danger-600`.
+- Focus: `--brand-600` outline.
+- Spacing/radius: existing `--radius-md`, `--radius-lg`, panel and table spacing.
+
+Copy must use plain language. Avoid “persist”, “database”, or “runtime state” in user-facing UI except developer/debug contexts. Prefer “temporary”, “saved”, and “tracked”.
+
+## 12. Accessibility Requirements
+
+- Temporary callout uses `role="status"` when inserted after ingestion completion; static server-rendered callout may be a normal section with heading.
+- Error alerts use `role="alert"`.
+- Tracking select label must include job title, e.g. **Tracking status for Senior Backend Engineer**.
+- For transient rows, include screen-reader-only text: **This is a temporary untracked ingestion result. Track it to save it.**
+- Keyboard order in each row/card: job title/details, source posting link if present, tracking select, submit button.
+- Focus after successful transient tracking:
+  - If staying on list, move focus to the success message or the updated job row heading.
+  - If redirecting to persisted detail, focus page `<h1>` on load.
+- Focus after save failure moves to inline error message.
+- Color must not be the only indicator of transient state; the visible `Temporary` text is required.
+- All button text must communicate action without relying on icon-only affordances.
+
+## 13. Edge Cases
+
+- Ingestion returns zero jobs: show success/empty copy, no temporary callout.
+- Ingestion returns only new untracked jobs: `/jobs` shows temporary results with callout; no tracked count required beyond summary.
+- Ingestion returns mixed tracked and transient jobs: show both; only transient items get `Temporary` badge.
+- Same job appears from multiple sources before tracking: display one deduplicated transient result if backend deduplicates; otherwise display source labels clearly and avoid implying persistence.
+- User tracks after another ingestion run refreshes results: if transient id is no longer valid, show error: **This temporary result is no longer available. Run ingestion again or track a currently visible result.**
+- App restarts before tracking: previous transient results are absent; do not show persisted untracked jobs.
+- Existing persisted untracked jobs removed by cleanup: they must not appear in Jobs, Tracking, source-linked job counts, or job details.
+- `manual_keep=true` with no tracking status: do not display as saved/tracked and do not use Keep copy to imply retention.
+
+## 14. Developer Handoff Notes
+
+- Do not add a new primary navigation item for transient results; use the existing Jobs review surface.
+- Persisted job detail route `/jobs/{job_id}` must remain database-backed only.
+- Transient result actions must use a runtime-safe identifier supplied by backend/app state, not a fake database id.
+- Do not render stale untracked database rows as a fallback.
+- Update user-facing copy currently saying “Save / Keep preserves…” where needed so transient jobs are tracked by assigning a non-null tracking status, not by `manual_keep` semantics.
+- Maintain progressive enhancement: server-rendered form submission must work without JavaScript; JS may improve disabled/loading states.
+- Ensure QA can distinguish transient and persisted items through visible text, not only styling.
+
+## Acceptance Criteria Mapping Relevant to UI Behavior
+
+- AC-03: `/jobs` shows current transient untracked results with `Temporary` labeling before another ingestion run or restart.
+- AC-04: After a new ingestion run, `/jobs` reflects the latest transient result set only.
+- AC-05: After app restart, previous transient untracked results are not shown.
+- AC-06: Matched existing tracked jobs appear as normal tracked jobs with no temporary badge.
+- AC-10: Assigning a non-null tracking status from a transient result shows saving feedback and converts it to a persisted tracked job on success.
+- AC-11: Success UI must only appear after persistence of related source/classification/ingestion context completes.
+- AC-12: Tracked transient jobs continue to appear after restart as normal tracked jobs.
+- AC-13/AC-14: Removed persisted untracked jobs do not appear in Jobs, details, Tracking, or source-linked job surfaces.
+
+## Explicit Non-Goals
+
+- No new tracking status values.
+- No archive, restore, or “recover temporary jobs” flow.
+- No promise that untracked transient results survive restart.
+- No redesign of classification scoring, bucket logic, source adapters, or ingestion matching.
+- No use of `manual_keep` as a persistence or retention signal.
+- No multi-user synchronization or cloud retention behavior.

--- a/tests/api/test_transient_untracked_ingestion_jobs_qa.py
+++ b/tests/api/test_transient_untracked_ingestion_jobs_qa.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.adapters.base.contracts import AdapterFetchResult, NormalizedJobCandidate
+from app.domain.ingestion import IngestionOrchestrator
+from app.domain.job_preferences import get_default_job_filter_preferences
+from app.domain.transient_ingestion import transient_ingestion_registry
+from app.persistence.models import JobDecision, JobDecisionRule, JobPosting, JobSourceLink, JobTrackingEvent, Source
+
+
+class DummyAdapter:
+    def __init__(self, jobs):
+        self.jobs = jobs
+
+    def validate_config(self, source):
+        return []
+
+    def fetch_jobs(self, source):
+        return AdapterFetchResult(jobs=self.jobs)
+
+
+class DummyRegistry:
+    def __init__(self, adapter):
+        self.adapter = adapter
+
+    def get(self, source_type, adapter_key=None):
+        return self.adapter
+
+
+def make_source(session, name="QA Transient"):
+    source = Source(
+        name=name,
+        source_type="greenhouse",
+        base_url=f"https://example.com/{name}",
+        dedupe_key=f"greenhouse:{name}",
+        is_active=True,
+    )
+    session.add(source)
+    session.commit()
+    return source
+
+
+def make_candidate(external_id="qa-1", title="QA Transient Backend Engineer", url="https://example.com/jobs/qa-1"):
+    return NormalizedJobCandidate(
+        external_job_id=external_id,
+        title=title,
+        company_name="QA Co",
+        job_url=url,
+        location_text="Remote",
+        employment_type="Full-time",
+        remote_type="remote",
+        description_text="Python backend engineer role with visa sponsorship available.",
+        description_html=None,
+        sponsorship_text="Visa sponsorship available",
+        posted_at=None,
+        raw_payload={"id": external_id, "title": title},
+    )
+
+
+def run_ingestion(session, source, jobs):
+    return IngestionOrchestrator(session, DummyRegistry(DummyAdapter(jobs))).run_source(
+        source,
+        get_default_job_filter_preferences(),
+    )
+
+
+def test_transient_api_refresh_restart_and_invalid_tracking_paths(client, session):
+    source = make_source(session)
+    first = make_candidate("qa-a", "QA Temporary A", "https://example.com/jobs/qa-a")
+    second = make_candidate("qa-b", "QA Temporary B", "https://example.com/jobs/qa-b")
+
+    run_ingestion(session, source, [first])
+    list_response = client.get("/ingestion/transient-jobs")
+    assert list_response.status_code == 200
+    first_items = list_response.json()["items"]
+    assert len(first_items) == 1
+    first_id = first_items[0]["transient_job_id"]
+    assert first_items[0]["tracking_status"] is None
+    assert client.get(f"/ingestion/transient-jobs/{first_id}").status_code == 200
+
+    invalid_response = client.post(f"/ingestion/transient-jobs/{first_id}/tracking-status", json={"tracking_status": ""})
+    assert invalid_response.status_code == 400
+    assert session.scalar(select(JobPosting).where(JobPosting.job_url == first.job_url)) is None
+    assert transient_ingestion_registry.get(first_id) is not None
+
+    run_ingestion(session, source, [second])
+    refreshed = client.get("/ingestion/transient-jobs").json()["items"]
+    assert len(refreshed) == 1
+    assert refreshed[0]["title"] == "QA Temporary B"
+    assert client.get(f"/ingestion/transient-jobs/{first_id}").status_code == 404
+
+    second_id = refreshed[0]["transient_job_id"]
+    transient_ingestion_registry.clear()
+    assert client.get("/ingestion/transient-jobs").json()["items"] == []
+    assert client.get(f"/ingestion/transient-jobs/{second_id}").status_code == 404
+    assert session.scalar(select(JobPosting).where(JobPosting.job_url == second.job_url)) is None
+
+
+def test_api_tracking_transient_persists_related_records_and_survives_registry_restart(client, session):
+    source = make_source(session)
+    candidate = make_candidate("qa-save", "QA Track Me", "https://example.com/jobs/qa-save")
+    run = run_ingestion(session, source, [candidate])
+    transient_id = client.get("/ingestion/transient-jobs").json()["items"][0]["transient_job_id"]
+
+    response = client.post(
+        f"/ingestion/transient-jobs/{transient_id}/tracking-status",
+        json={"tracking_status": "interview", "note_text": "QA validation"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    job_id = body["id"]
+    job = session.get(JobPosting, job_id)
+    assert job is not None
+    assert job.tracking_status == "interview"
+    link = session.scalar(select(JobSourceLink).where(JobSourceLink.job_posting_id == job_id))
+    assert link is not None
+    assert link.source_run_id == run.id
+    assert link.external_job_id == "qa-save"
+    decision = session.scalar(select(JobDecision).where(JobDecision.job_posting_id == job_id))
+    assert decision is not None
+    assert session.scalar(select(JobDecisionRule).where(JobDecisionRule.job_decision_id == decision.id)) is not None
+    event = session.scalar(select(JobTrackingEvent).where(JobTrackingEvent.job_posting_id == job_id))
+    assert event is not None
+    assert event.tracking_status == "interview"
+    assert client.get(f"/ingestion/transient-jobs/{transient_id}").status_code == 404
+
+    transient_ingestion_registry.clear()
+    assert session.get(JobPosting, job_id).tracking_status == "interview"
+    assert client.get(f"/jobs/{job_id}").status_code == 200
+
+
+def test_existing_tracked_match_updates_without_transient_duplicate(session):
+    source = make_source(session)
+    tracked = JobPosting(
+        canonical_key="tracked-qa",
+        primary_source_id=source.id,
+        title="Old Title",
+        company_name="QA Co",
+        job_url="https://example.com/jobs/tracked-qa",
+        normalized_job_url="https://example.com/jobs/tracked-qa",
+        description_text="Old description",
+        tracking_status="saved",
+    )
+    session.add(tracked)
+    session.commit()
+
+    updated = make_candidate("tracked-qa", "Updated Tracked Title", "https://example.com/jobs/tracked-qa")
+    run = run_ingestion(session, source, [updated])
+
+    session.refresh(tracked)
+    assert run.jobs_updated_count == 1
+    assert tracked.id is not None
+    assert tracked.title == "Updated Tracked Title"
+    assert tracked.tracking_status == "saved"
+    assert len(transient_ingestion_registry.list(source.id)) == 0
+    assert session.scalar(select(JobSourceLink).where(JobSourceLink.job_posting_id == tracked.id)) is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,9 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.main import app
+from app.domain.source_cleanup import SourceDeleteCleanupService
 from app.persistence.models import Base
+from app.web import routes as web_routes
 from app.web.routes import get_session_dependency
 from app.domain.transient_ingestion import transient_ingestion_registry
 
@@ -43,7 +45,16 @@ def client(session: Session) -> Generator[TestClient, None, None]:
     def override_session():
         yield session
 
+    original_cleanup = web_routes.run_source_delete_cleanup
+
+    def run_source_delete_cleanup_with_test_session(source_id: int) -> None:
+        SourceDeleteCleanupService(session).cleanup_source(source_id)
+
     app.dependency_overrides[get_session_dependency] = override_session
-    with TestClient(app) as test_client:
-        yield test_client
-    app.dependency_overrides.clear()
+    web_routes.run_source_delete_cleanup = run_source_delete_cleanup_with_test_session
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        web_routes.run_source_delete_cleanup = original_cleanup
+        app.dependency_overrides.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,14 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.persistence.models import Base
 from app.web.routes import get_session_dependency
+from app.domain.transient_ingestion import transient_ingestion_registry
+
+
+@pytest.fixture(autouse=True)
+def clear_transient_ingestion_registry():
+    transient_ingestion_registry.clear()
+    yield
+    transient_ingestion_registry.clear()
 
 
 @pytest.fixture

--- a/tests/integration/test_api_flow.py
+++ b/tests/integration/test_api_flow.py
@@ -57,10 +57,20 @@ def test_manual_source_ingestion_keep_tracking_digest_and_reminders(client, sess
 
     jobs_response = client.get("/jobs")
     assert jobs_response.status_code == 200
-    jobs = jobs_response.json()
-    assert len(jobs) == 1
-    assert jobs[0]["latest_bucket"] == "matched"
-    job_id = jobs[0]["id"]
+    assert jobs_response.json() == []
+
+    transient_response = client.get("/ingestion/transient-jobs")
+    assert transient_response.status_code == 200
+    transient_jobs = transient_response.json()["items"]
+    assert len(transient_jobs) == 1
+    assert transient_jobs[0]["latest_bucket"] == "matched"
+
+    track_transient_response = client.post(
+        f"/ingestion/transient-jobs/{transient_jobs[0]['transient_job_id']}/tracking-status",
+        json={"tracking_status": "saved", "note_text": "Reviewing"},
+    )
+    assert track_transient_response.status_code == 201
+    job_id = track_transient_response.json()["persisted_job_id"]
 
     keep_response = client.post(f"/jobs/{job_id}/keep")
     assert keep_response.status_code == 200
@@ -218,7 +228,12 @@ def test_jobs_api_treats_empty_source_filter_as_unset_and_keeps_integer_filterin
 
     empty_filter_response = client.get("/jobs?source_id=")
     assert empty_filter_response.status_code == 200
-    assert len(empty_filter_response.json()) == 1
+    assert len(empty_filter_response.json()) == 0
+
+    track_response = client.get(f"/ingestion/transient-jobs?source_id={source_id}")
+    transient_id = track_response.json()["items"][0]["transient_job_id"]
+    persisted_response = client.post(f"/ingestion/transient-jobs/{transient_id}/tracking-status", json={"tracking_status": "saved"})
+    assert persisted_response.status_code == 201
 
     valid_filter_response = client.get(f"/jobs?source_id={source_id}")
     assert valid_filter_response.status_code == 200

--- a/tests/integration/test_html_views.py
+++ b/tests/integration/test_html_views.py
@@ -45,6 +45,13 @@ def seed_job(client, monkeypatch):
         },
     ).json()
     client.post(f"/sources/{source['id']}/run", json={"job_preferences": job_preferences_payload()})
+    transient_jobs = client.get(f"/ingestion/transient-jobs?source_id={source['id']}").json()["items"]
+    assert len(transient_jobs) == 1
+    track_response = client.post(
+        f"/ingestion/transient-jobs/{transient_jobs[0]['transient_job_id']}/tracking-status",
+        json={"tracking_status": "saved"},
+    )
+    assert track_response.status_code == 201
     return client.get("/jobs").json()[0]
 
 
@@ -73,6 +80,13 @@ def seed_job_with_source(client, monkeypatch):
         },
     ).json()
     client.post(f"/sources/{source['id']}/run", json={"job_preferences": job_preferences_payload()})
+    transient_jobs = client.get(f"/ingestion/transient-jobs?source_id={source['id']}").json()["items"]
+    assert len(transient_jobs) == 1
+    track_response = client.post(
+        f"/ingestion/transient-jobs/{transient_jobs[0]['transient_job_id']}/tracking-status",
+        json={"tracking_status": "saved"},
+    )
+    assert track_response.status_code == 201
     job = client.get("/jobs").json()[0]
     return source, job
 

--- a/tests/integration/test_transient_untracked_cleanup_migration_qa.py
+++ b/tests/integration/test_transient_untracked_cleanup_migration_qa.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from app.persistence.models import (
+    Base,
+    Digest,
+    DigestItem,
+    JobDecision,
+    JobDecisionRule,
+    JobPosting,
+    JobSourceLink,
+    JobTrackingEvent,
+    Reminder,
+    Source,
+    SourceRun,
+)
+
+
+spec = importlib.util.spec_from_file_location(
+    "cleanup_untracked_jobs_migration",
+    Path(__file__).resolve().parents[2] / "alembic" / "versions" / "20260501_0005_cleanup_untracked_jobs.py",
+)
+cleanup_migration = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(cleanup_migration)
+
+
+def run_cleanup_upgrade(connection):
+    context = MigrationContext.configure(connection)
+    with Operations.context(context):
+        cleanup_migration.upgrade()
+
+
+def seed_job(session: Session, source: Source, *, key: str, tracking_status: str | None, manual_keep: bool) -> JobPosting:
+    job = JobPosting(
+        canonical_key=key,
+        primary_source_id=source.id,
+        title=key,
+        company_name="Cleanup Co",
+        job_url=f"https://example.com/jobs/{key}",
+        normalized_job_url=f"https://example.com/jobs/{key}",
+        description_text="cleanup validation",
+        manual_keep=manual_keep,
+        tracking_status=tracking_status,
+    )
+    session.add(job)
+    session.flush()
+    return job
+
+
+def attach_dependents(session: Session, source: Source, run: SourceRun, digest: Digest, job: JobPosting):
+    session.add(JobSourceLink(job_posting_id=job.id, source_id=source.id, source_run_id=run.id, source_job_url=job.job_url, content_hash=f"hash-{job.id}"))
+    decision = JobDecision(job_posting_id=job.id, decision_version="mvp_v1", bucket="matched", final_score=1, sponsorship_state="supported", decision_reason_summary="cleanup")
+    session.add(decision)
+    session.flush()
+    session.add(JobDecisionRule(job_decision_id=decision.id, rule_key="qa", rule_category="qa", outcome="matched", score_delta=1, explanation_text="cleanup"))
+    session.add(JobTrackingEvent(job_posting_id=job.id, event_type="save", tracking_status=job.tracking_status))
+    session.add(Reminder(job_posting_id=job.id, reminder_type="follow_up", due_at=datetime.now(UTC) + timedelta(days=1), status="pending"))
+    session.add(DigestItem(digest_id=digest.id, job_posting_id=job.id, bucket="matched", reason="cleanup"))
+
+
+def test_cleanup_migration_deletes_untracked_dependents_preserves_tracked_and_is_idempotent():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        source = Source(name="Cleanup Source", source_type="greenhouse", base_url="https://example.com", dedupe_key="cleanup", is_active=True)
+        session.add(source)
+        session.flush()
+        run = SourceRun(source_id=source.id, trigger_type="manual", status="success")
+        digest = Digest(digest_date=date(2026, 5, 1), status="generated", delivery_channel="local", content_summary="cleanup")
+        session.add_all([run, digest])
+        session.flush()
+
+        untracked_keep = seed_job(session, source, key="untracked-keep", tracking_status=None, manual_keep=True)
+        untracked_normal = seed_job(session, source, key="untracked-normal", tracking_status=None, manual_keep=False)
+        tracked_keep = seed_job(session, source, key="tracked-keep", tracking_status="saved", manual_keep=True)
+        tracked_normal = seed_job(session, source, key="tracked-normal", tracking_status="applied", manual_keep=False)
+        for job in [untracked_keep, untracked_normal, tracked_keep, tracked_normal]:
+            attach_dependents(session, source, run, digest, job)
+        session.commit()
+
+    with engine.begin() as connection:
+        run_cleanup_upgrade(connection)
+        run_cleanup_upgrade(connection)
+
+    with Session(engine) as session:
+        remaining_jobs = {job.canonical_key: job for job in session.scalars(select(JobPosting))}
+        assert set(remaining_jobs) == {"tracked-keep", "tracked-normal"}
+        assert remaining_jobs["tracked-keep"].manual_keep is True
+        assert remaining_jobs["tracked-normal"].tracking_status == "applied"
+        remaining_ids = {job.id for job in remaining_jobs.values()}
+        for model in [JobSourceLink, JobDecision, JobTrackingEvent, Reminder, DigestItem]:
+            rows = list(session.scalars(select(model)))
+            assert rows
+            assert {row.job_posting_id for row in rows} <= remaining_ids
+        remaining_decision_ids = {row.id for row in session.scalars(select(JobDecision))}
+        assert {row.job_decision_id for row in session.scalars(select(JobDecisionRule))} <= remaining_decision_ids

--- a/tests/ui/test_saas_dashboard_ui_revamp.py
+++ b/tests/ui/test_saas_dashboard_ui_revamp.py
@@ -1,11 +1,51 @@
-from fastapi.testclient import TestClient
 import re
 
-from app.main import app
+from app.persistence.models import JobPosting, Source, utcnow
 
 
-client = TestClient(app, raise_server_exceptions=False)
 HTML_HEADERS = {"accept": "text/html"}
+
+
+def seed_tracked_job(session) -> JobPosting:
+    now = utcnow()
+    source = seed_source(session)
+    job = JobPosting(
+        canonical_key="ui-shell:tracked-job",
+        primary_source_id=source.id,
+        title="UI Shell Backend Engineer",
+        company_name="Shell Co",
+        job_url="https://example.com/ui-shell-job",
+        normalized_job_url="https://example.com/ui-shell-job",
+        location_text="Remote",
+        description_text="Tracked job for UI shell detail coverage.",
+        current_state="active",
+        latest_bucket="matched",
+        latest_score=88,
+        tracking_status="saved",
+        first_seen_at=now,
+        last_seen_at=now,
+        last_ingested_at=now,
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def seed_source(session) -> Source:
+    source = Source(
+        name="UI Shell Source",
+        source_type="greenhouse",
+        base_url="https://boards.greenhouse.io/ui-shell-source",
+        external_identifier="ui-shell-source",
+        company_name="Shell Co",
+        dedupe_key="greenhouse||ui-shell-source",
+        is_active=True,
+    )
+    session.add(source)
+    session.commit()
+    session.refresh(source)
+    return source
 
 
 def _assert_html_shell(response, expected_page_key: str, expected_title: str) -> None:
@@ -19,34 +59,33 @@ def _assert_html_shell(response, expected_page_key: str, expected_title: str) ->
     assert 'src="http://testserver/static/js/app.js"' in body
 
 
-def test_dashboard_renders_html_shell() -> None:
+def test_dashboard_renders_html_shell(client) -> None:
     response = client.get("/dashboard", headers=HTML_HEADERS)
     _assert_html_shell(response, "dashboard", "Operational dashboard")
 
 
-def test_jobs_index_renders_management_table_ui() -> None:
+def test_jobs_index_renders_management_table_ui(client) -> None:
     response = client.get("/jobs", headers=HTML_HEADERS)
     _assert_html_shell(response, "jobs", "Job pipeline")
     assert 'Apply filters' in response.text
     assert 'Search title, company, or description' in response.text
 
 
-def test_job_detail_renders_html_detail_view() -> None:
-    jobs_response = client.get("/jobs")
-    assert jobs_response.status_code == 200
-    job_id = jobs_response.json()[0]["id"]
+def test_job_detail_renders_html_detail_view(client, session) -> None:
+    job_id = seed_tracked_job(session).id
     response = client.get(f"/jobs/{job_id}", headers=HTML_HEADERS)
     _assert_html_shell(response, "jobs", "Update tracking")
 
 
-def test_sources_index_renders_management_table_ui() -> None:
+def test_sources_index_renders_management_table_ui(client) -> None:
     response = client.get("/sources", headers=HTML_HEADERS)
     _assert_html_shell(response, "sources", "Source inventory")
     assert 'Add source' in response.text
     assert 'Import CSV' in response.text
 
 
-def test_source_detail_renders_html_detail_view() -> None:
+def test_source_detail_renders_html_detail_view(client, session) -> None:
+    seed_source(session)
     source_index = client.get("/sources", headers=HTML_HEADERS)
     match = re.search(r'/sources/(\d+)"', source_index.text)
     assert match, source_index.text[:1000]
@@ -55,7 +94,7 @@ def test_source_detail_renders_html_detail_view() -> None:
     _assert_html_shell(response, "sources", "Recent runs")
 
 
-def test_source_create_validation_uses_html_error_state() -> None:
+def test_source_create_validation_uses_html_error_state(client) -> None:
     response = client.post(
         "/sources",
         data={"name": "", "source_type": "greenhouse", "base_url": ""},
@@ -66,12 +105,12 @@ def test_source_create_validation_uses_html_error_state() -> None:
     assert 'Source update failed.' in response.text
 
 
-def test_source_health_renders_in_shared_shell() -> None:
+def test_source_health_renders_in_shared_shell(client) -> None:
     response = client.get("/source-health", headers=HTML_HEADERS)
     _assert_html_shell(response, "source_health", "Source health")
     assert 'Review source readiness' in response.text
 
 
-def test_tracking_page_renders_in_shared_shell() -> None:
+def test_tracking_page_renders_in_shared_shell(client) -> None:
     response = client.get("/tracking", headers=HTML_HEADERS)
     _assert_html_shell(response, "tracking", "Tracked jobs")

--- a/tests/ui/test_source_edit_delete_ui_qa.py
+++ b/tests/ui/test_source_edit_delete_ui_qa.py
@@ -35,6 +35,19 @@ def create_source(client, *, name: str, base_slug: str, is_active: bool = True):
     return response.json()
 
 
+def track_first_transient_job(client, source_id: int, *, tracking_status: str = "saved") -> int:
+    transient_response = client.get(f"/ingestion/transient-jobs?source_id={source_id}")
+    assert transient_response.status_code == 200
+    transient_jobs = transient_response.json()["items"]
+    assert len(transient_jobs) == 1
+    track_response = client.post(
+        f"/ingestion/transient-jobs/{transient_jobs[0]['transient_job_id']}/tracking-status",
+        json={"tracking_status": tracking_status},
+    )
+    assert track_response.status_code == 201
+    return track_response.json()["persisted_job_id"]
+
+
 def test_sources_html_exposes_edit_and_delete_actions_from_list_and_detail(client):
     source = create_source(client, name="List Action Source", base_slug="list-action-source")
 
@@ -69,9 +82,7 @@ def test_source_delete_confirmation_explains_async_cleanup_and_retention(client,
     run_response = client.post(f"/sources/{source['id']}/run", json={"job_preferences": job_preferences_payload()})
     assert run_response.status_code == 200
 
-    jobs_response = client.get("/jobs")
-    assert jobs_response.status_code == 200
-    job_id = jobs_response.json()[0]["id"]
+    job_id = track_first_transient_job(client, source["id"])
 
     tracking_response = client.post(
         f"/jobs/{job_id}/tracking-status",
@@ -190,9 +201,7 @@ def test_deleted_source_non_retained_job_uses_normal_not_found(client, monkeypat
     run_response = client.post(f"/sources/{source['id']}/run", json={"job_preferences": job_preferences_payload()})
     assert run_response.status_code == 200
 
-    jobs_response = client.get("/jobs")
-    assert jobs_response.status_code == 200
-    job_id = jobs_response.json()[0]["id"]
+    job_id = track_first_transient_job(client, source["id"])
 
     delete_response = client.post(
         f"/sources/{source['id']}/delete",

--- a/tests/ui/test_transient_ingestion_jobs_ui.py
+++ b/tests/ui/test_transient_ingestion_jobs_ui.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from bs4 import BeautifulSoup
+
+from app.domain.classification import ClassificationSnapshot, RuleResult
+from app.domain.transient_ingestion import TransientIngestionJob, transient_ingestion_registry
+from app.persistence.models import JobPosting, JobSourceLink, Source, SourceRun
+
+
+def seed_source_and_run(session):
+    source = Source(
+        name="Transient UI Source",
+        source_type="greenhouse",
+        base_url="https://boards.greenhouse.io/transient-ui",
+        external_identifier="transient-ui",
+        dedupe_key="transient-ui",
+        is_active=True,
+    )
+    session.add(source)
+    session.commit()
+    run = SourceRun(source_id=source.id, trigger_type="manual", status="success")
+    session.add(run)
+    session.commit()
+    return source, run
+
+
+def seed_tracked_job(session, source, run):
+    job = JobPosting(
+        canonical_key="tracked-ui-job",
+        primary_source_id=source.id,
+        title="Tracked Backend Engineer",
+        company_name="TrackedCo",
+        job_url="https://example.com/tracked-ui-job",
+        latest_bucket="matched",
+        latest_score=42,
+        current_state="active",
+        tracking_status="saved",
+    )
+    session.add(job)
+    session.flush()
+    session.add(
+        JobSourceLink(
+            job_posting_id=job.id,
+            source_id=source.id,
+            source_run_id=run.id,
+            source_job_url=job.job_url,
+            content_hash="tracked-hash",
+            is_primary=True,
+        )
+    )
+    session.commit()
+    return job
+
+
+def make_transient_job(source, run):
+    now = datetime(2026, 5, 1, 12, 0, tzinfo=UTC)
+    return TransientIngestionJob(
+        transient_job_id="temporary-ui-job-1",
+        source_id=source.id,
+        source_run_id=run.id,
+        external_job_id="temporary-1",
+        canonical_key="temporary-ui-job",
+        normalized_job_url="https://example.com/temporary-ui-job",
+        title="Temporary Python Engineer",
+        company_name="TempCo",
+        job_url="https://example.com/temporary-ui-job",
+        location_text="Remote",
+        employment_type="Full-time",
+        remote_type="remote",
+        description_text="Python backend role with visa sponsorship available.",
+        description_html=None,
+        sponsorship_text="Visa sponsorship available",
+        posted_at=None,
+        raw_payload={"id": "temporary-1"},
+        classification=ClassificationSnapshot(
+            decision_version="mvp_v1",
+            bucket="matched",
+            final_score=54,
+            sponsorship_state="supported",
+            decision_reason_summary="Role aligns with target backend preferences.",
+            rules=[
+                RuleResult(
+                    rule_key="python_backend",
+                    rule_category="role_positive",
+                    outcome="matched",
+                    score_delta=18,
+                    evidence_snippet="Python backend role",
+                    evidence_field="description_text",
+                    explanation_text="Role aligns with Python backend target.",
+                )
+            ],
+        ),
+        first_seen_at=now,
+        last_seen_at=now,
+        created_at=now,
+    )
+
+
+def parse_html(response):
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    return BeautifulSoup(response.text, "html.parser")
+
+
+def test_jobs_page_shows_mixed_persisted_and_temporary_results(client, session):
+    source, run = seed_source_and_run(session)
+    tracked = seed_tracked_job(session, source, run)
+    transient_ingestion_registry.replace_source_results(source.id, [make_transient_job(source, run)])
+
+    response = client.get("/jobs", headers={"accept": "text/html"})
+    soup = parse_html(response)
+
+    assert "Temporary ingestion results" in response.text
+    assert "2 jobs shown: 1 tracked, 1 temporary from the latest ingestion run." in response.text
+    assert "Tracked Backend Engineer" in response.text
+    assert "Temporary Python Engineer" in response.text
+    assert soup.find("span", string="Temporary") is not None
+    assert "This is a temporary untracked ingestion result. Track it to save it." in response.text
+    assert f'href="/jobs/{tracked.id}"' in response.text
+    assert 'href="/jobs/transient/temporary-ui-job-1"' in response.text
+    assert 'href="/jobs/temporary-ui-job-1"' not in response.text
+
+
+def test_transient_tracking_form_posts_to_transient_endpoint(client, session):
+    source, run = seed_source_and_run(session)
+    transient_ingestion_registry.replace_source_results(source.id, [make_transient_job(source, run)])
+
+    response = client.get("/jobs", headers={"accept": "text/html"})
+    soup = parse_html(response)
+
+    form = soup.find("form", {"action": "/ingestion/transient-jobs/temporary-ui-job-1/tracking-status"})
+    assert form is not None
+    assert form.get("data-transient-tracking-form") == ""
+    assert form.find("label", string="Tracking status for Temporary Python Engineer") is not None
+    assert form.find("button").get_text(strip=True) == "Track job"
+
+
+def test_transient_detail_uses_runtime_safe_route(client, session):
+    source, run = seed_source_and_run(session)
+    transient_ingestion_registry.replace_source_results(source.id, [make_transient_job(source, run)])
+
+    response = client.get("/jobs/transient/temporary-ui-job-1", headers={"accept": "text/html"})
+
+    assert response.status_code == 200
+    assert "Temporary ingestion result" in response.text
+    assert "Temporary Python Engineer" in response.text
+    assert "/ingestion/transient-jobs/temporary-ui-job-1/tracking-status" in response.text
+
+
+def test_missing_transient_detail_shows_unavailable_error(client):
+    response = client.get("/jobs/transient/missing", headers={"accept": "text/html"})
+
+    assert response.status_code == 404
+    assert "Temporary job unavailable" in response.text
+    assert "This temporary result is no longer available." in response.text

--- a/tests/unit/test_source_batch_run_qa_validation.py
+++ b/tests/unit/test_source_batch_run_qa_validation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass
 
 import pytest
 
@@ -15,6 +14,7 @@ from app.domain.source_batch_runs import (
     build_session_factory_from_session,
 )
 from app.persistence.models import Source
+from app.schemas import SourceBatchSourceResult
 
 
 def add_source(session, name: str, *, health_state: str = "healthy", is_active: bool = True) -> Source:
@@ -63,34 +63,33 @@ def test_batch_executor_never_exceeds_five_concurrent_source_runs(session, monke
     first_wave_ready = threading.Event()
     release_first_wave = threading.Event()
 
-    @dataclass
-    class FakeRun:
-        id: int
-        status: str = "success"
-        log_summary: str | None = None
+    def fake_run_source_with_retries(self, batch_id, source_ref, preferences):
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+            if active == 5:
+                first_wave_ready.set()
 
-    class FakeOrchestrator:
-        def __init__(self, session, registry):
-            self.session = session
+        if first_wave_ready.wait(timeout=2):
+            release_first_wave.set()
+        release_first_wave.wait(timeout=2)
 
-        def run_source(self, source, preferences, trigger_type="manual"):
-            nonlocal active, max_active
-            assert trigger_type == "batch_manual"
-            with lock:
-                active += 1
-                max_active = max(max_active, active)
-                if active == 5:
-                    first_wave_ready.set()
+        with lock:
+            active -= 1
+        self.registry.update_source_result(
+            batch_id,
+            SourceBatchSourceResult(
+                source_id=source_ref.source_id,
+                source_name=source_ref.source_name,
+                status="success",
+                attempts_used=1,
+                source_run_ids=[source_ref.source_id],
+                last_error=None,
+            ),
+        )
 
-            if first_wave_ready.wait(timeout=2):
-                release_first_wave.set()
-            release_first_wave.wait(timeout=2)
-
-            with lock:
-                active -= 1
-            return FakeRun(id=source.id)
-
-    monkeypatch.setattr("app.domain.source_batch_runs.IngestionOrchestrator", FakeOrchestrator)
+    monkeypatch.setattr(SourceBatchExecutor, "_run_source_with_retries", fake_run_source_with_retries)
 
     SourceBatchExecutor(
         adapter_registry,

--- a/tests/unit/test_transient_ingestion_jobs.py
+++ b/tests/unit/test_transient_ingestion_jobs.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.adapters.base.contracts import AdapterFetchResult, NormalizedJobCandidate
+from app.domain.ingestion import IngestionOrchestrator
+from app.domain.job_preferences import get_default_job_filter_preferences
+from app.domain.transient_ingestion import transient_ingestion_registry
+from app.persistence.models import JobDecision, JobPosting, JobSourceLink, Source
+
+
+class DummyAdapter:
+    def __init__(self, jobs):
+        self.jobs = jobs
+
+    def validate_config(self, source):
+        return []
+
+    def fetch_jobs(self, source):
+        return AdapterFetchResult(jobs=self.jobs)
+
+
+class DummyRegistry:
+    def __init__(self, adapter):
+        self.adapter = adapter
+
+    def get(self, source_type, adapter_key=None):
+        return self.adapter
+
+
+def make_source(session, name="Example"):
+    source = Source(
+        name=name,
+        source_type="greenhouse",
+        base_url=f"https://example.com/{name}",
+        dedupe_key=f"greenhouse:{name}",
+        is_active=True,
+    )
+    session.add(source)
+    session.commit()
+    return source
+
+
+def make_candidate(external_id="1", title="Senior Python Backend Engineer", url="https://example.com/jobs/1"):
+    return NormalizedJobCandidate(
+        external_job_id=external_id,
+        title=title,
+        company_name="Example",
+        job_url=url,
+        location_text="Remote",
+        employment_type="Full-time",
+        remote_type="remote",
+        description_text="Python backend engineer role. Visa sponsorship available.",
+        description_html=None,
+        sponsorship_text="Visa sponsorship available",
+        posted_at=None,
+        raw_payload={"id": external_id},
+    )
+
+
+def test_ingestion_stores_new_untracked_jobs_transiently_without_job_specific_db_records(session):
+    source = make_source(session)
+    candidate = make_candidate()
+
+    run = IngestionOrchestrator(session, DummyRegistry(DummyAdapter([candidate]))).run_source(source, get_default_job_filter_preferences())
+
+    assert run.jobs_fetched_count == 1
+    assert run.jobs_created_count == 0
+    assert session.scalar(select(JobPosting).where(JobPosting.job_url == candidate.job_url)) is None
+    assert list(session.scalars(select(JobSourceLink))) == []
+    assert list(session.scalars(select(JobDecision))) == []
+    transient_items = transient_ingestion_registry.list(source.id)
+    assert len(transient_items) == 1
+    assert transient_items[0].title == candidate.title
+    assert transient_items[0].classification.bucket == "matched"
+
+
+def test_transient_tracking_persists_job_link_decision_and_consumes_entry(session):
+    source = make_source(session)
+    candidate = make_candidate()
+    IngestionOrchestrator(session, DummyRegistry(DummyAdapter([candidate]))).run_source(source, get_default_job_filter_preferences())
+    transient_id = transient_ingestion_registry.list(source.id)[0].transient_job_id
+
+    from app.domain.tracking import TrackingService
+
+    job, created = TrackingService(session).track_transient_job(transient_id, "saved", "keep")
+
+    assert created is True
+    assert job.tracking_status == "saved"
+    assert session.scalar(select(JobSourceLink).where(JobSourceLink.job_posting_id == job.id)) is not None
+    assert session.scalar(select(JobDecision).where(JobDecision.job_posting_id == job.id)) is not None
+    assert transient_ingestion_registry.get(transient_id) is None


### PR DESCRIPTION
# Pull Request

## 1. Feature Name

Transient untracked ingestion jobs

## 2. Summary

Untracked ingestion jobs are now transient until a user explicitly tracks them, while tracked jobs continue to persist and update normally. Tracking a transient job persists the job, source linkage, classification, decision/tracking metadata, and source-run attribution; a cleanup migration removes existing persisted untracked jobs and dependent records.

## 3. Related Documents
- Product Spec: docs/product/transient_untracked_ingestion_jobs_product_spec.md
- Technical Design: docs/architecture/transient_untracked_ingestion_jobs_technical_design.md
- UI/UX Spec: docs/uiux/transient_untracked_ingestion_jobs_design_spec.md
- QA Report: docs/qa/transient_untracked_ingestion_jobs_test_report.md
- QA Test Plan: docs/qa/transient_untracked_ingestion_jobs_test_plan.md
- Planning Issue: docs/release/transient_untracked_ingestion_jobs_issue.md
- Bug Report: docs/bugs/transient_untracked_ingestion_jobs_full_suite_failures_bug_report.md
- Backend Report: docs/backend/transient_untracked_ingestion_jobs_implementation_report.md
- Frontend Report: docs/frontend/transient_untracked_ingestion_jobs_implementation_report.md

## 4. Changes Included
- Added runtime-only transient ingestion storage for newly discovered untracked jobs.
- Updated ingestion persistence so new untracked jobs do not create durable job/source/classification records.
- Preserved existing tracked-job ingestion update behavior.
- Added transient job list/detail API and UI affordances, including temporary labeling and tracking actions.
- Added transient tracking flow that persists job, source link, classification/decision metadata, tracking event, and source-run linkage.
- Added cleanup migration for existing persisted untracked jobs and dependent records while preserving tracked jobs.
- Added and remediated unit, API, integration, UI, and migration regression coverage.

## 5. QA Status
- Approved: YES
- QA sign-off: [QA SIGN-OFF APPROVED]
- HITL validation: HITL validation successful

## 6. Test Coverage
- Full regression suite: 130 passed, 0 failed, 4 non-blocking warnings.
- Targeted transient feature suite: 15 passed, 0 failed.
- Prior remediation regression scope: 38 passed, 0 failed.
- Compile validation: PASS for `app` and `tests`.

## 7. Risks / Notes
- Runtime-only transient jobs are intentionally lost on refresh/restart until tracked.
- UI copy labels temporary jobs to reduce user confusion.
- Cleanup migration is destructive only for persisted jobs with `tracking_status IS NULL` and owned dependents; tracked jobs are preserved.
- Full suite warnings are Alembic deprecation warnings with no observed feature impact.

## 8. Linked Issue
- Closes #20
